### PR TITLE
fix: harden tth_2 processing and normalize Tehilim book divisions

### DIFF
--- a/data/tth_2/json/bamidbar.json
+++ b/data/tth_2/json/bamidbar.json
@@ -6993,7 +6993,7 @@
         },
         {
           "verse": 52,
-          "tth": "Y habló __יהוה__ a Moshéh, diciendo:",
+          "tth": "Y habló יהוה a Moshéh, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7067,7 +7067,7 @@
         },
         {
           "verse": 61,
-          "tth": "Y murieron Nadab y Avihu cuando acercaron fuego extraño delante de __יהוה__.",
+          "tth": "Y murieron Nadab y Avihu cuando acercaron fuego extraño delante de יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7091,7 +7091,7 @@
         },
         {
           "verse": 65,
-          "tth": "Pues había dicho __יהוה__ a ellos: Muriendo, morirán en el desierto. Y no quedó de ellos hombre, pero si Caleb, hijo de Iefunéh, y Yehoshúa, hijo de Nun.",
+          "tth": "Pues había dicho יהוה a ellos: Muriendo, morirán en el desierto. Y no quedó de ellos hombre, pero si Caleb, hijo de Iefunéh, y Yehoshúa, hijo de Nun.",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -7114,7 +7114,7 @@
         },
         {
           "verse": 3,
-          "tth": "Nuestro padre murió en el desierto, y él no estuvo en medio de la asamblea que confabuló contra __יהוה__, en la asamblea de Koraj, pero en su pecado murió, e hijos no tuvo para él.",
+          "tth": "Nuestro padre murió en el desierto, y él no estuvo en medio de la asamblea que confabuló contra יהוה, en la asamblea de Koraj, pero en su pecado murió, e hijos no tuvo para él.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7126,13 +7126,13 @@
         },
         {
           "verse": 5,
-          "tth": "Y se acercó Moshéh al proceso legal delante de __יהוה__.",
+          "tth": "Y se acercó Moshéh al proceso legal delante de יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 6,
-          "tth": "Y dijo __יהוה__ a Moshéh, diciendo:",
+          "tth": "Y dijo יהוה a Moshéh, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7175,14 +7175,14 @@
         },
         {
           "verse": 11,
-          "tth": "Y si no hay hermanos para su padre, darán su herencia a su familiar <em>más</em> cercano a él, de su familia, y él la heredará. Y será para los hijos de Israel por estatuto de proceso legal, como ordenó __יהוה__ a Moshéh”.",
+          "tth": "Y si no hay hermanos para su padre, darán su herencia a su familiar <em>más</em> cercano a él, de su familia, y él la heredará. Y será para los hijos de Israel por estatuto de proceso legal, como ordenó יהוה a Moshéh”.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Yehoshúa ungido sucesor de Moshéh"
         },
         {
           "verse": 12,
-          "tth": "Y dijo __יהוה__ a Moshéh: Sube a este monte Haabarim, y mira la tierra que he dado a los hijos de Israel.",
+          "tth": "Y dijo יהוה a Moshéh: Sube a este monte Haabarim, y mira la tierra que he dado a los hijos de Israel.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7200,13 +7200,13 @@
         },
         {
           "verse": 15,
-          "tth": "Y habló __יהוה__ a Moshéh, diciendo:",
+          "tth": "Y habló יהוה a Moshéh, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 16,
-          "tth": "Comande __יהוה__, Elohim de las mentes¹⁸⁴ de toda carne, un hombre sobre la congregación;",
+          "tth": "Comande יהוה, Elohim de las mentes¹⁸⁴ de toda carne, un hombre sobre la congregación;",
           "footnotes": [
             {
               "marker": "¹⁸⁴",
@@ -7219,13 +7219,13 @@
         },
         {
           "verse": 17,
-          "tth": "quien saldrá delante de ellos, y quien entrará delante de ellos, quien los sacará y quien los entrará, y no sea la congregación de __יהוה__ como ovejas que no tienen para sí pastor.",
+          "tth": "quien saldrá delante de ellos, y quien entrará delante de ellos, quien los sacará y quien los entrará, y no sea la congregación de יהוה como ovejas que no tienen para sí pastor.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 18,
-          "tth": "Y dijo __יהוה__ a Moshéh: Toma para ti a Yehoshúa, hijo de Nun, hombre que el Rúaj¹⁸⁵ <em>está</em> en él, y apoya tu mano sobre él;",
+          "tth": "Y dijo יהוה a Moshéh: Toma para ti a Yehoshúa, hijo de Nun, hombre que el Rúaj¹⁸⁵ <em>está</em> en él, y apoya tu mano sobre él;",
           "footnotes": [
             {
               "marker": "¹⁸⁵",
@@ -7257,7 +7257,7 @@
         },
         {
           "verse": 21,
-          "tth": "Y delante de Eleazar el sacerdote se parará, y preguntará para él por el juicio de los Urim¹⁸⁷ delante de __יהוה__. A su boca saldrán y a su boca entrarán, él y todos los hijos de Israel con él, y toda la congregación.",
+          "tth": "Y delante de Eleazar el sacerdote se parará, y preguntará para él por el juicio de los Urim¹⁸⁷ delante de יהוה. A su boca saldrán y a su boca entrarán, él y todos los hijos de Israel con él, y toda la congregación.",
           "footnotes": [
             {
               "marker": "¹⁸⁷",
@@ -7270,13 +7270,13 @@
         },
         {
           "verse": 22,
-          "tth": "E hizo Moshéh como <em>le</em> ordenó __יהוה__ a él; y tomó a Yehoshúa y lo paró delante de Eleazar el sacerdote, y delante de toda la congregación.",
+          "tth": "E hizo Moshéh como <em>le</em> ordenó יהוה a él; y tomó a Yehoshúa y lo paró delante de Eleazar el sacerdote, y delante de toda la congregación.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 23,
-          "tth": "Y apoyó sus manos sobre él y le ordenó, conforme había hablado __יהוה__ por mano de Moshéh.",
+          "tth": "Y apoyó sus manos sobre él y le ordenó, conforme había hablado יהוה por mano de Moshéh.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Korbanot de los tiempos señalados"
@@ -7288,7 +7288,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y habló __יהוה__ a Moshéh, diciendo:",
+          "tth": "Y habló יהוה a Moshéh, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7313,7 +7313,7 @@
         },
         {
           "verse": 3,
-          "tth": "Y dirás a ellos: “Esta es la ofrenda de fuego¹⁹⁰ que acercarán a __יהוה__: corderos hijos de un año, dos por día; <em>es</em> ofrenda ascendida¹⁹¹ constante.",
+          "tth": "Y dirás a ellos: “Esta es la ofrenda de fuego¹⁹⁰ que acercarán a יהוה: corderos hijos de un año, dos por día; <em>es</em> ofrenda ascendida¹⁹¹ constante.",
           "footnotes": [
             {
               "marker": "¹⁹⁰",
@@ -7351,19 +7351,19 @@
         },
         {
           "verse": 6,
-          "tth": "Es ofrenda ascendida constante que fue hecha en el monte Sinay, para olor calmante, ofrenda de fuego para __יהוה__.",
+          "tth": "Es ofrenda ascendida constante que fue hecha en el monte Sinay, para olor calmante, ofrenda de fuego para יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 7,
-          "tth": "Y su ofrenda derramada <em>será</em> un cuarto del hin para el cordero uno; en la Santidad derramarás una ofrenda derramada embriagante a __יהוה__.",
+          "tth": "Y su ofrenda derramada <em>será</em> un cuarto del hin para el cordero uno; en la Santidad derramarás una ofrenda derramada embriagante a יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 8,
-          "tth": "Y el cordero segundo harás entre las tardes; como ofrenda de grano de la mañana y como su ofrenda derramada harás, es ofrenda de fuego, olor calmante a __יהוה__.",
+          "tth": "Y el cordero segundo harás entre las tardes; como ofrenda de grano de la mañana y como su ofrenda derramada harás, es ofrenda de fuego, olor calmante a יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7381,7 +7381,7 @@
         },
         {
           "verse": 11,
-          "tth": "Y en los principios de sus meses, acercarán una ofrenda ascendida a __יהוה__: dos toros hijos de ganado y un carnero, y corderos hijos de un año, siete, completos;",
+          "tth": "Y en los principios de sus meses, acercarán una ofrenda ascendida a יהוה: dos toros hijos de ganado y un carnero, y corderos hijos de un año, siete, completos;",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7393,7 +7393,7 @@
         },
         {
           "verse": 13,
-          "tth": "y una décima, una décima de harina fina <em>como</em> ofrenda de grano mezclada con aceite, para el cordero uno, <em>es</em> ofrenda ascendida, olor calmante, una ofrenda de fuego a __יהוה__.",
+          "tth": "y una décima, una décima de harina fina <em>como</em> ofrenda de grano mezclada con aceite, para el cordero uno, <em>es</em> ofrenda ascendida, olor calmante, una ofrenda de fuego a יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7405,13 +7405,13 @@
         },
         {
           "verse": 15,
-          "tth": "Y un peludo de las cabras para ofrenda por el pecado a __יהוה__, junto a la ofrenda ascendida de la continuidad se hará, y su ofrenda derramada.",
+          "tth": "Y un peludo de las cabras para ofrenda por el pecado a יהוה, junto a la ofrenda ascendida de la continuidad se hará, y su ofrenda derramada.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 16,
-          "tth": "Y en el mes primero, el décimo cuarto día del mes, <em>es</em> Pésaj para __יהוה__.",
+          "tth": "Y en el mes primero, el décimo cuarto día del mes, <em>es</em> Pésaj para יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7429,7 +7429,7 @@
         },
         {
           "verse": 19,
-          "tth": "Y acercarán una ofrenda de fuego, ofrenda ascendida a __יהוה__: dos toros hijos de ganado, un carnero, y siete corderos hijos de un año, completos serán para ustedes.",
+          "tth": "Y acercarán una ofrenda de fuego, ofrenda ascendida a יהוה: dos toros hijos de ganado, un carnero, y siete corderos hijos de un año, completos serán para ustedes.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7466,7 +7466,7 @@
         },
         {
           "verse": 24,
-          "tth": "Como estas harán por día, siete días, el pan de la ofrenda de fuego <em>como</em> olor calmante para __יהוה__, junto a la ofrenda ascendida de la continuidad se hará, y su ofrenda derramada.",
+          "tth": "Como estas harán por día, siete días, el pan de la ofrenda de fuego <em>como</em> olor calmante para יהוה, junto a la ofrenda ascendida de la continuidad se hará, y su ofrenda derramada.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7478,7 +7478,7 @@
         },
         {
           "verse": 26,
-          "tth": "Y en el día de los primeros frutos¹⁹⁴, cuando acerquen una ofrenda de grano nueva a __יהוה__, en su <em>fiesta de las</em> semanas¹⁹⁵, convocación de santidad¹⁹⁶ habrá para ustedes; cualquier trabajo de servicio no harán.",
+          "tth": "Y en el día de los primeros frutos¹⁹⁴, cuando acerquen una ofrenda de grano nueva a יהוה, en su <em>fiesta de las</em> semanas¹⁹⁵, convocación de santidad¹⁹⁶ habrá para ustedes; cualquier trabajo de servicio no harán.",
           "footnotes": [
             {
               "marker": "¹⁹⁴",
@@ -7503,7 +7503,7 @@
         },
         {
           "verse": 27,
-          "tth": "Y acercarán una ofrenda ascendida para olor calmante a __יהוה__: dos toros hijos de ganado, un carnero, siete corderos hijos de un año,",
+          "tth": "Y acercarán una ofrenda ascendida para olor calmante a יהוה: dos toros hijos de ganado, un carnero, siete corderos hijos de un año,",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7551,7 +7551,7 @@
         },
         {
           "verse": 2,
-          "tth": "Y harán una ofrenda ascendida¹⁹⁸ para olor calmante a __יהוה__: un toro hijo de ganado, un carnero, corderos hijos de un año, siete, completos;",
+          "tth": "Y harán una ofrenda ascendida¹⁹⁸ para olor calmante a יהוה: un toro hijo de ganado, un carnero, corderos hijos de un año, siete, completos;",
           "footnotes": [
             {
               "marker": "¹⁹⁸",
@@ -7589,7 +7589,7 @@
         },
         {
           "verse": 6,
-          "tth": "además de la ofrenda ascendida del mes y su ofrenda de grano, la ofrenda ascendida de la continuidad y su ofrenda de grano, y sus ofrendas derramadas, conforme a su proceso legal²⁰⁰, para olor calmante, ofrenda de fuego a __יהוה__.",
+          "tth": "además de la ofrenda ascendida del mes y su ofrenda de grano, la ofrenda ascendida de la continuidad y su ofrenda de grano, y sus ofrendas derramadas, conforme a su proceso legal²⁰⁰, para olor calmante, ofrenda de fuego a יהוה.",
           "footnotes": [
             {
               "marker": "²⁰⁰",
@@ -7615,7 +7615,7 @@
         },
         {
           "verse": 8,
-          "tth": "Y acercarán una ofrenda ascendida a __יהוה__, olor calmante: un toro hijo de ganado, un carnero, corderos hijos de un año, siete, completos serán para ustedes;",
+          "tth": "Y acercarán una ofrenda ascendida a יהוה, olor calmante: un toro hijo de ganado, un carnero, corderos hijos de un año, siete, completos serán para ustedes;",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7652,13 +7652,13 @@
         },
         {
           "verse": 12,
-          "tth": "Y en el décimo quinto día del mes séptimo, convocación de santidad habrá para ustedes; cualquier trabajo de servicio no harán, y celebrarán fiesta a __יהוה__ siete días.",
+          "tth": "Y en el décimo quinto día del mes séptimo, convocación de santidad habrá para ustedes; cualquier trabajo de servicio no harán, y celebrarán fiesta a יהוה siete días.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 13,
-          "tth": "Y acercarán una ofrenda ascendida, ofrenda de fuego, olor calmante a __יהוה__: trece toros hijos de ganado, dos carneros, catorce corderos hijos de un año, completos serán;",
+          "tth": "Y acercarán una ofrenda ascendida, ofrenda de fuego, olor calmante a יהוה: trece toros hijos de ganado, dos carneros, catorce corderos hijos de un año, completos serán;",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7803,7 +7803,7 @@
         },
         {
           "verse": 36,
-          "tth": "Y acercarán una ofrenda ascendida, ofrenda de fuego, olor calmante a __יהוה__: un toro, un carnero, corderos hijos de un año, siete, completos;",
+          "tth": "Y acercarán una ofrenda ascendida, ofrenda de fuego, olor calmante a יהוה: un toro, un carnero, corderos hijos de un año, siete, completos;",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7821,7 +7821,7 @@
         },
         {
           "verse": 39,
-          "tth": "Estos harán para __יהוה__ en sus tiempos señalados²⁰⁴, aparte de sus votos y sus donaciones, para sus ofrendas ascendidas, para sus ofrendas de grano, para sus ofrendas derramadas y para sus retribuciones²⁰⁵”.",
+          "tth": "Estos harán para יהוה en sus tiempos señalados²⁰⁴, aparte de sus votos y sus donaciones, para sus ofrendas ascendidas, para sus ofrendas de grano, para sus ofrendas derramadas y para sus retribuciones²⁰⁵”.",
           "footnotes": [
             {
               "marker": "²⁰⁴",
@@ -7840,7 +7840,7 @@
         },
         {
           "verse": 40,
-          "tth": "Y dijo Moshéh a los hijos de Israel conforme a todo lo que ordenó __יהוה__ a Moshéh.",
+          "tth": "Y dijo Moshéh a los hijos de Israel conforme a todo lo que ordenó יהוה a Moshéh.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Procesos legales sobre los votos"
@@ -7852,19 +7852,19 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y habló Moshéh a las cabezas de las tribus de los hijos de Israel, diciendo: Esta es la palabra que ha ordenado __יהוה__.",
+          "tth": "Y habló Moshéh a las cabezas de las tribus de los hijos de Israel, diciendo: Esta es la palabra que ha ordenado יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 2,
-          "tth": "Cuando un hombre promete un voto a __יהוה__, o jura un juramento para amarrar una obligación sobre su ser, no perforará su palabra; conforme a todo lo que salga de su boca, hará.",
+          "tth": "Cuando un hombre promete un voto a יהוה, o jura un juramento para amarrar una obligación sobre su ser, no perforará su palabra; conforme a todo lo que salga de su boca, hará.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 3,
-          "tth": "Y una mujer, cuando promete un voto a __יהוה__, y se amarra una obligación, en casa de su padre, en su juventud,",
+          "tth": "Y una mujer, cuando promete un voto a יהוה, y se amarra una obligación, en casa de su padre, en su juventud,",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7876,7 +7876,7 @@
         },
         {
           "verse": 5,
-          "tth": "Pero si le impide su padre en el día que escucha, todos sus votos y sus obligaciones las cuales se ha amarrado sobre su ser, no permanecerán; y __יהוה__<em>la</em> perdonará a ella, pues se <em>lo</em> ha impedido su padre.",
+          "tth": "Pero si le impide su padre en el día que escucha, todos sus votos y sus obligaciones las cuales se ha amarrado sobre su ser, no permanecerán; y יהוה <em>la</em> perdonará a ella, pues se <em>lo</em> ha impedido su padre.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7894,7 +7894,7 @@
         },
         {
           "verse": 8,
-          "tth": "Pero si en el día <em>que</em> escucha su esposo, se <em>lo</em> impide, impedirá el voto de ella, el cual <em>está</em> sobre ella, y la pronunciación de sus labios que se ha amarrado sobre su ser; y __יהוה__<em>la</em> perdonará a ella.",
+          "tth": "Pero si en el día <em>que</em> escucha su esposo, se <em>lo</em> impide, impedirá el voto de ella, el cual <em>está</em> sobre ella, y la pronunciación de sus labios que se ha amarrado sobre su ser; y יהוה <em>la</em> perdonará a ella.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7925,7 +7925,7 @@
         },
         {
           "verse": 12,
-          "tth": "Pero si, impidiendo, los impide su esposo en el día <em>que</em> escucha, toda pronunciación de sus labios, por sus votos, y por la obligación de su ser, no permanecerá; su esposo los ha roto, y __יהוה__<em>la</em> perdonará a ella.",
+          "tth": "Pero si, impidiendo, los impide su esposo en el día <em>que</em> escucha, toda pronunciación de sus labios, por sus votos, y por la obligación de su ser, no permanecerá; su esposo los ha roto, y יהוה <em>la</em> perdonará a ella.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7949,7 +7949,7 @@
         },
         {
           "verse": 16,
-          "tth": "Estos son los decretos que ha ordenado __יהוה__ a Moshéh, entre un hombre para su mujer, y entre un padre para su hija en su juventud, <em>en</em> casa de su padre.",
+          "tth": "Estos son los decretos que ha ordenado יהוה a Moshéh, entre un hombre para su mujer, y entre un padre para su hija en su juventud, <em>en</em> casa de su padre.",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -7960,7 +7960,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y habló __יהוה__ a Moshéh, diciendo:",
+          "tth": "Y habló יהוה a Moshéh, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7985,7 +7985,7 @@
         },
         {
           "verse": 3,
-          "tth": "Y habló Moshéh al pueblo, diciendo: Saquen de ustedes hombres para el ejército, y sean sobre Midián para dar la venganza de __יהוה__ en Midián.",
+          "tth": "Y habló Moshéh al pueblo, diciendo: Saquen de ustedes hombres para el ejército, y sean sobre Midián para dar la venganza de יהוה en Midián.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8016,7 +8016,7 @@
         },
         {
           "verse": 7,
-          "tth": "Y salieron sobre Midián, conforme ordenó __יהוה__ a Moshéh, y mataron <em>a</em> todo varón.",
+          "tth": "Y salieron sobre Midián, conforme ordenó יהוה a Moshéh, y mataron <em>a</em> todo varón.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8070,7 +8070,7 @@
         },
         {
           "verse": 16,
-          "tth": "He aquí, ellas convirtieron a los hijos de Israel, por palabra de Bilam, para desviarse <em>con</em> traición contra __יהוה__, en el asunto de Peor, y hubo plaga en la congregación de __יהוה__.",
+          "tth": "He aquí, ellas convirtieron a los hijos de Israel, por palabra de Bilam, para desviarse <em>con</em> traición contra יהוה, en el asunto de Peor, y hubo plaga en la congregación de יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8101,7 +8101,7 @@
         },
         {
           "verse": 21,
-          "tth": "Y dijo Eleazar el sacerdote a los hombres del ejército que habían ido a la guerra: Este es el decreto²¹⁰ de la Torah que ha ordenado __יהוה__ a Moshéh:",
+          "tth": "Y dijo Eleazar el sacerdote a los hombres del ejército que habían ido a la guerra: Este es el decreto²¹⁰ de la Torah que ha ordenado יהוה a Moshéh:",
           "footnotes": [
             {
               "marker": "²¹⁰",
@@ -8132,7 +8132,7 @@
         },
         {
           "verse": 25,
-          "tth": "Y dijo __יהוה__ a Moshéh, diciendo:",
+          "tth": "Y dijo יהוה a Moshéh, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8150,13 +8150,13 @@
         },
         {
           "verse": 28,
-          "tth": "Y eleva un tributo para __יהוה__ de los hombres de la guerra que salieron al ejército, una vida de <em>cada</em> quinientos, de hombre y de ganado, de asnos y de rebaño;",
+          "tth": "Y eleva un tributo para יהוה de los hombres de la guerra que salieron al ejército, una vida de <em>cada</em> quinientos, de hombre y de ganado, de asnos y de rebaño;",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 29,
-          "tth": "de la mitad de ellos tómalo, dalo a Eleazar el sacerdote <em>como</em> terumáh²¹¹ de __יהוה__.",
+          "tth": "de la mitad de ellos tómalo, dalo a Eleazar el sacerdote <em>como</em> terumáh²¹¹ de יהוה.",
           "footnotes": [
             {
               "marker": "²¹¹",
@@ -8169,7 +8169,7 @@
         },
         {
           "verse": 30,
-          "tth": "Y de la mitad de los hijos de Israel tomarás un agarre de cincuenta, de hombre y de ganado, de asnos y de ganado, de toda bestia; y los darás a los leviím, guardadores de la guardia del Mishkán²¹² de __יהוה__.",
+          "tth": "Y de la mitad de los hijos de Israel tomarás un agarre de cincuenta, de hombre y de ganado, de asnos y de ganado, de toda bestia; y los darás a los leviím, guardadores de la guardia del Mishkán²¹² de יהוה.",
           "footnotes": [
             {
               "marker": "²¹²",
@@ -8182,7 +8182,7 @@
         },
         {
           "verse": 31,
-          "tth": "E hizo Moshéh, y Eleazar el sacerdote, como ordenó __יהוה__ a Moshéh.",
+          "tth": "E hizo Moshéh, y Eleazar el sacerdote, como ordenó יהוה a Moshéh.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8225,31 +8225,31 @@
         },
         {
           "verse": 37,
-          "tth": "y fue, el tributo para __יהוה__, de ovejas: seiscientas setenta y cinco;",
+          "tth": "y fue, el tributo para יהוה, de ovejas: seiscientas setenta y cinco;",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 38,
-          "tth": "y el ganado: treinta y seis mil, y el tributo a __יהוה__<em>fue de</em> setenta y dos;",
+          "tth": "y el ganado: treinta y seis mil, y el tributo a יהוה <em>fue de</em> setenta y dos;",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 39,
-          "tth": "y los asnos: treinta mil quinientos, y el tributo a __יהוה__<em>fue de</em> sesenta y uno.",
+          "tth": "y los asnos: treinta mil quinientos, y el tributo a יהוה <em>fue de</em> sesenta y uno.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 40,
-          "tth": "Y ser de hombre: dieciséis mil, y el tributo a __יהוה__<em>fue de</em> treinta y dos personas.",
+          "tth": "Y ser de hombre: dieciséis mil, y el tributo a יהוה <em>fue de</em> treinta y dos personas.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 41,
-          "tth": "Y dio Moshéh el tributo <em>como</em> terumáh de __יהוה__ a Eleazar el sacerdote, como ordenó __יהוה__ a Moshéh.",
+          "tth": "Y dio Moshéh el tributo <em>como</em> terumáh de יהוה a Eleazar el sacerdote, como ordenó יהוה a Moshéh.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8285,7 +8285,7 @@
         },
         {
           "verse": 47,
-          "tth": "Y tomó Moshéh de la mitad de los hijos de Israel, un agarre de <em>cada</em> cincuenta, de hombre y de bestia; y los dio a los leviím, guardadores de la guardia del Mishkán de __יהוה__, como ordenó __יהוה__ a Moshéh.",
+          "tth": "Y tomó Moshéh de la mitad de los hijos de Israel, un agarre de <em>cada</em> cincuenta, de hombre y de bestia; y los dio a los leviím, guardadores de la guardia del Mishkán de יהוה, como ordenó יהוה a Moshéh.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8303,7 +8303,7 @@
         },
         {
           "verse": 50,
-          "tth": "Y hemos acercado un korbán²¹⁴ <em>a</em> __יהוה__, <em>cada</em> hombre lo que encontró: utensilios de oro, brazaletes y pulseras, sellos, aretes y adornos, para hacer expiación por nuestras vidas delante de __יהוה__.",
+          "tth": "Y hemos acercado un korbán²¹⁴ <em>a</em> יהוה, <em>cada</em> hombre lo que encontró: utensilios de oro, brazaletes y pulseras, sellos, aretes y adornos, para hacer expiación por nuestras vidas delante de יהוה.",
           "footnotes": [
             {
               "marker": "²¹⁴",
@@ -8322,7 +8322,7 @@
         },
         {
           "verse": 52,
-          "tth": "Y era todo el oro de la terumáh que elevaron a __יהוה__: dieciséis mil setecientos cincuenta shekel, de los jefes de miles y de los jefes de cientos.",
+          "tth": "Y era todo el oro de la terumáh que elevaron a יהוה: dieciséis mil setecientos cincuenta shekel, de los jefes de miles y de los jefes de cientos.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8334,7 +8334,7 @@
         },
         {
           "verse": 54,
-          "tth": "Y tomaron Moshéh y Eleazar el sacerdote, el oro de los jefes de miles y de cientos, y lo llevaron a la Tienda del Mo’ed²¹⁵ <em>como</em> memorial para los hijos de Israel delante de __יהוה__.",
+          "tth": "Y tomaron Moshéh y Eleazar el sacerdote, el oro de los jefes de miles y de cientos, y lo llevaron a la Tienda del Mo’ed²¹⁵ <em>como</em> memorial para los hijos de Israel delante de יהוה.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Reubén y Gad piden habitar en Guilad"
@@ -8364,7 +8364,7 @@
         },
         {
           "verse": 4,
-          "tth": "la tierra que ha golpeado __יהוה__ delante de la congregación de Israel, tierra de ganado es; y para tus siervos <em>hay</em> ganado.",
+          "tth": "la tierra que ha golpeado יהוה delante de la congregación de Israel, tierra de ganado es; y para tus siervos <em>hay</em> ganado.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -9012,7 +9012,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y habló __יהוה__ a Moshéh, diciendo:",
+          "tth": "Y habló יהוה a Moshéh, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -9084,7 +9084,7 @@
         },
         {
           "verse": 13,
-          "tth": "Y ordenó Moshéh a los hijos de Israel, diciendo: Esta es la tierra la cual heredarán por goral, que ha ordenado __יהוה__ dar a las nueve tribus y media tribu.",
+          "tth": "Y ordenó Moshéh a los hijos de Israel, diciendo: Esta es la tierra la cual heredarán por goral, que ha ordenado יהוה dar a las nueve tribus y media tribu.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -9122,7 +9122,7 @@
         },
         {
           "verse": 16,
-          "tth": "Y habló __יהוה__ a Moshéh, diciendo:",
+          "tth": "Y habló יהוה a Moshéh, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -9206,7 +9206,7 @@
         },
         {
           "verse": 29,
-          "tth": "Estos son los que comandó²²⁶ __יהוה__ para heredar a los hijos de Israel en la tierra de Kenáan.",
+          "tth": "Estos son los que comandó²²⁶ יהוה para heredar a los hijos de Israel en la tierra de Kenáan.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Ciudades de los leviím y ciudades de refugio"
@@ -9218,7 +9218,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y habló __יהוה__ a Moshéh en las llanuras de Moab, junto al Iardén²²⁷, <em>por</em> Ierijó, diciendo:",
+          "tth": "Y habló יהוה a Moshéh en las llanuras de Moab, junto al Iardén²²⁷, <em>por</em> Ierijó, diciendo:",
           "footnotes": [
             {
               "marker": "²²⁷",
@@ -9280,7 +9280,7 @@
         },
         {
           "verse": 9,
-          "tth": "Y habló __יהוה__ a Moshéh, diciendo:",
+          "tth": "Y habló יהוה a Moshéh, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -9451,7 +9451,7 @@
         },
         {
           "verse": 34,
-          "tth": "Y no impurificarán la tierra en la cual ustedes habitan, que Yo habito en medio de ella, pues Yo, __יהוה__, habito en medio de los hijos de Israel”.",
+          "tth": "Y no impurificarán la tierra en la cual ustedes habitan, que Yo habito en medio de ella, pues Yo, יהוה, habito en medio de los hijos de Israel”.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Las hijas de Tzelofjad"
@@ -9469,7 +9469,7 @@
         },
         {
           "verse": 2,
-          "tth": "Y dijeron: A mi amo ordenó __יהוה__ dar la tierra por herencia, por goral²³², a los hijos de Israel; y mi amo ordenó por __יהוה__ para dar la herencia de Tzelofjad, nuestro hermano, a sus hijas.",
+          "tth": "Y dijeron: A mi amo ordenó יהוה dar la tierra por herencia, por goral²³², a los hijos de Israel; y mi amo ordenó por יהוה para dar la herencia de Tzelofjad, nuestro hermano, a sus hijas.",
           "footnotes": [
             {
               "marker": "²³²",
@@ -9501,13 +9501,13 @@
         },
         {
           "verse": 5,
-          "tth": "Y ordenó Moshéh a los hijos de Israel por boca de __יהוה__, diciendo: Son correctas las palabras de la tribu de los hijos de Iosef.",
+          "tth": "Y ordenó Moshéh a los hijos de Israel por boca de יהוה, diciendo: Son correctas las palabras de la tribu de los hijos de Iosef.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 6,
-          "tth": "Esta es la palabra que ha ordenado __יהוה__ a las hijas de Tzelofejad, diciendo: “Del que sea bueno a sus ojos serán por mujeres; pero por las familias de las tribus de sus padres serán por mujeres”.",
+          "tth": "Esta es la palabra que ha ordenado יהוה a las hijas de Tzelofejad, diciendo: “Del que sea bueno a sus ojos serán por mujeres; pero por las familias de las tribus de sus padres serán por mujeres”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -9531,7 +9531,7 @@
         },
         {
           "verse": 10,
-          "tth": "Conforme ordenó __יהוה__ a Moshéh, así hicieron las hijas de Tzelofjad.",
+          "tth": "Conforme ordenó יהוה a Moshéh, así hicieron las hijas de Tzelofjad.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -9555,7 +9555,7 @@
         },
         {
           "verse": 13,
-          "tth": "Estos son los mandamientos y los procesos legales que ordenó __יהוה__ por mano de Moshéh a los hijos de Israel, en las llanuras de Moab, por el Iardén²³⁴, Ierijó.",
+          "tth": "Estos son los mandamientos y los procesos legales que ordenó יהוה por mano de Moshéh a los hijos de Israel, en las llanuras de Moab, por el Iardén²³⁴, Ierijó.",
           "footnotes": [
             {
               "marker": "²³⁴",

--- a/data/tth_2/json/bereshit.json
+++ b/data/tth_2/json/bereshit.json
@@ -4890,13 +4890,7 @@
         },
         {
           "verse": 12,
-          "tth": "Y",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "estas son las generaciones de Ishmael, hijo de Abraham, quien dio a luz Hagar la mitzrit, sierva de Sarah, a Abraham.",
+          "tth": "Y estas son las generaciones de Ishmael, hijo de Abraham, quien dio a luz Hagar la mitzrit, sierva de Sarah, a Abraham.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4957,13 +4951,13 @@
         },
         {
           "verse": 21,
-          "tth": "Y suplicó Itzjak a __יהוה__ a la vista de su mujer, porque era estéril ella, y <em>como</em> le suplicó a יהוה, concibió Ribkah su mujer.",
+          "tth": "Y suplicó Itzjak a יהוה a la vista de su mujer, porque era estéril ella, y <em>como</em> le suplicó a יהוה, concibió Ribkah su mujer.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 22,
-          "tth": "Y se oprimían¹¹¹ los hijos dentro de ella, y ella dijo: Si es así, ¿por qué esto a mí? Y fue a consultar a __יהוה__.",
+          "tth": "Y se oprimían¹¹¹ los hijos dentro de ella, y ella dijo: Si es así, ¿por qué esto a mí? Y fue a consultar a יהוה.",
           "footnotes": [
             {
               "marker": "¹¹¹",
@@ -4976,7 +4970,7 @@
         },
         {
           "verse": 23,
-          "tth": "Y dijo __יהוה__ a ella: Dos naciones <em>hay</em> en tu vientre, y dos pueblos de tus entrañas se separarán; y un pueblo <em>más</em> que el <em>otro</em> pueblo se fortalecerá, y el Grande servirá pequeño.",
+          "tth": "Y dijo יהוה a ella: Dos naciones <em>hay</em> en tu vientre, y dos pueblos de tus entrañas se separarán; y un pueblo <em>más</em> que el <em>otro</em> pueblo se fortalecerá, y el Grande servirá pequeño.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5080,7 +5074,7 @@
         },
         {
           "verse": 2,
-          "tth": "Y apareció a él __יהוה__, y dijo: No desciendas a Mitzráim, habita en la tierra la cual te diré a ti.",
+          "tth": "Y apareció a él יהוה, y dijo: No desciendas a Mitzráim, habita en la tierra la cual te diré a ti.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5221,7 +5215,7 @@
         },
         {
           "verse": 22,
-          "tth": "Y se movieron de allí y cavaron otro pozo, y no pelearon por ese, y llamó su nombre Rejovot¹¹⁸, y dijo: Porque ahora nos ha ampliado __יהוה__, y fructificaremos en la tierra.",
+          "tth": "Y se movieron de allí y cavaron otro pozo, y no pelearon por ese, y llamó su nombre Rejovot¹¹⁸, y dijo: Porque ahora nos ha ampliado יהוה, y fructificaremos en la tierra.",
           "footnotes": [
             {
               "marker": "¹¹⁸",
@@ -5240,13 +5234,13 @@
         },
         {
           "verse": 24,
-          "tth": "Y apareció a él __יהוה__ en esa noche, y dijo: Yo soy el Elohim de Abraham tu padre, no temas, porque contigo Yo estoy. Y te bendeciré y aumentaré tu simiente, a causa de Abraham mi siervo.",
+          "tth": "Y apareció a él יהוה en esa noche, y dijo: Yo soy el Elohim de Abraham tu padre, no temas, porque contigo Yo estoy. Y te bendeciré y aumentaré tu simiente, a causa de Abraham mi siervo.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 25,
-          "tth": "Y construyó allí un altar, y llamó en el Nombre de __יהוה__, y tendió allí su tienda; y cavaron allí los siervos de Itzjak un pozo.",
+          "tth": "Y construyó allí un altar, y llamó en el Nombre de יהוה, y tendió allí su tienda; y cavaron allí los siervos de Itzjak un pozo.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5264,7 +5258,7 @@
         },
         {
           "verse": 28,
-          "tth": "Y ellos dijeron: Vemos claramente¹¹⁹ que ha estado __יהוה__ contigo, y dijimos: “Haya ahora un juramento entre nosotros, entre nosotros y tú, y hagamos¹²⁰ un pacto contigo,",
+          "tth": "Y ellos dijeron: Vemos claramente¹¹⁹ que ha estado יהוה contigo, y dijimos: “Haya ahora un juramento entre nosotros, entre nosotros y tú, y hagamos¹²⁰ un pacto contigo,",
           "footnotes": [
             {
               "marker": "¹¹⁹",
@@ -5283,7 +5277,7 @@
         },
         {
           "verse": 29,
-          "tth": "¡si harías con nosotros maldad!, como no te hemos tocado, y como hemos hecho contigo sólo el bien, y te hemos enviado <em>lejos</em> en shalom¹²¹; tú ahora <em>eres</em> bendito de __יהוה__.",
+          "tth": "¡si harías con nosotros maldad!, como no te hemos tocado, y como hemos hecho contigo sólo el bien, y te hemos enviado <em>lejos</em> en shalom¹²¹; tú ahora <em>eres</em> bendito de יהוה.",
           "footnotes": [
             {
               "marker": "¹²¹",
@@ -5380,7 +5374,7 @@
         },
         {
           "verse": 7,
-          "tth": "“Trae para mí caza y haz para mí delicias y coma yo, y te bendiga delante de __יהוה__ antes de mi muerte”.",
+          "tth": "“Trae para mí caza y haz para mí delicias y coma yo, y te bendiga delante de יהוה antes de mi muerte”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8188,7 +8182,7 @@
         },
         {
           "verse": 7,
-          "tth": "Pero fue Er, primogénito de Iehudáh, malvado en los ojos de __יהוה__, y lo mató __יהוה__.",
+          "tth": "Pero fue Er, primogénito de Iehudáh, malvado en los ojos de יהוה, y lo mató יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8213,7 +8207,7 @@
         },
         {
           "verse": 10,
-          "tth": "Pero fue malo en los ojos de __יהוה__ lo que hizo. Y lo mató también a él.",
+          "tth": "Pero fue malo en los ojos de יהוה lo que hizo. Y lo mató también a él.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8410,13 +8404,13 @@
         },
         {
           "verse": 2,
-          "tth": "Y era __יהוה__ con Iosef, y él fue un hombre próspero, y estaba en casa de su amo el mitzrí.",
+          "tth": "Y era יהוה con Iosef, y él fue un hombre próspero, y estaba en casa de su amo el mitzrí.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 3,
-          "tth": "Y vio su amo que __יהוה__ <em>estaba</em> con él, y todo lo que él hacía __יהוה__ lo hizo próspero en su mano.",
+          "tth": "Y vio su amo que יהוה <em>estaba</em> con él, y todo lo que él hacía יהוה lo hizo próspero en su mano.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8428,7 +8422,7 @@
         },
         {
           "verse": 5,
-          "tth": "Y sucedió <em>que</em> desde el tiempo <em>en</em> que lo hizo supervisor de su casa y sobre todo lo que le pertenecía, bendijo __יהוה__ la casa del mitzrí debido a Iosef, y era la bendición de __יהוה__ en todo lo que tenía para él en la casa y en el campo.",
+          "tth": "Y sucedió <em>que</em> desde el tiempo <em>en</em> que lo hizo supervisor de su casa y sobre todo lo que le pertenecía, bendijo יהוה la casa del mitzrí debido a Iosef, y era la bendición de יהוה en todo lo que tenía para él en la casa y en el campo.",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/devarim.json
+++ b/data/tth_2/json/devarim.json
@@ -40,7 +40,7 @@
         },
         {
           "verse": 3,
-          "tth": "Y sucedió en el año cuarenta, en el undécimo mes, en el <em>día</em> uno del mes, habló Moshéh a los hijos de Israel conforme a todo lo que les había ordenado __יהוה__,",
+          "tth": "Y sucedió en el año cuarenta, en el undécimo mes, en el <em>día</em> uno del mes, habló Moshéh a los hijos de Israel conforme a todo lo que les había ordenado יהוה,",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -58,7 +58,7 @@
         },
         {
           "verse": 6,
-          "tth": "__יהוה__ Elohim nuestro habló a nosotros en Joreb, diciendo: “Por mucho ustedes han habitado en esta montaña.",
+          "tth": "יהוה Elohim nuestro habló a nosotros en Joreb, diciendo: “Por mucho ustedes han habitado en esta montaña.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -89,14 +89,14 @@
         },
         {
           "verse": 8,
-          "tth": "Miren, he dado delante de ustedes la tierra; entren y hereden la tierra que juró __יהוה__ a sus padres, a Abraham, a Itzjak y a Yaakov, para dar <em>la</em> a ellos y a su simiente después de ellos”.",
+          "tth": "Miren, he dado delante de ustedes la tierra; entren y hereden la tierra que juró יהוה a sus padres, a Abraham, a Itzjak y a Yaakov, para dar <em>la</em> a ellos y a su simiente después de ellos”.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Nombramiento de jueces"
         },
         {
           "verse": 9,
-          "tth": "Y hablé a ustedes en ese tiempo, diciendo: “No puedo yo solo cargar <em>los</em> a ustedes.__10 יהוה__ su Elohim los ha multiplicado, y he aquí ustedes, hoy <em>son</em> como las estrellas del cielo, por multitud.__11 יהוה__, Elohim de sus padres, <em>los</em> aumente a ustedes, conforme son, mil veces, y los bendiga como <em>les</em> ha hablado a ustedes.",
+          "tth": "Y hablé a ustedes en ese tiempo, diciendo: “No puedo yo solo cargar <em>los</em> a ustedes.10 יהוה su Elohim los ha multiplicado, y he aquí ustedes, hoy <em>son</em> como las estrellas del cielo, por multitud.11 יהוה, Elohim de sus padres, <em>los</em> aumente a ustedes, conforme son, mil veces, y los bendiga como <em>les</em> ha hablado a ustedes.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -151,19 +151,19 @@
         },
         {
           "verse": 19,
-          "tth": "Y viajamos de Joreb y caminamos por todo el desierto grande y terrible que vieron, camino del monte del emorí, conforme había ordenado __יהוה__ nuestro Elohim a nosotros; y entramos a Kádesh Barnea.",
+          "tth": "Y viajamos de Joreb y caminamos por todo el desierto grande y terrible que vieron, camino del monte del emorí, conforme había ordenado יהוה nuestro Elohim a nosotros; y entramos a Kádesh Barnea.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 20,
-          "tth": "Y les dije: “Han llegado al monte del emorí, el cual __יהוה__ nuestro Elohim da a nosotros.",
+          "tth": "Y les dije: “Han llegado al monte del emorí, el cual יהוה nuestro Elohim da a nosotros.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 21,
-          "tth": "Mira,<em>Israel</em>, ha puesto __יהוה__ tu Elohim delante de ti la tierra; sube, heréda <em>la</em>, como ha hablado __יהוה__, Elohim de tus padres, a ti. No temas y no te consternes”.",
+          "tth": "Mira,<em>Israel</em>, ha puesto יהוה tu Elohim delante de ti la tierra; sube, heréda <em>la</em>, como ha hablado יהוה, Elohim de tus padres, a ti. No temas y no te consternes”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -194,19 +194,19 @@
         },
         {
           "verse": 25,
-          "tth": "Y tomaron en sus manos del fruto de la tierra y lo hicieron bajar hacia nosotros; y nos regresaron palabra, y dijeron: “Buena es la tierra que __יהוה__ nuestro Elohim da a nosotros”.",
+          "tth": "Y tomaron en sus manos del fruto de la tierra y lo hicieron bajar hacia nosotros; y nos regresaron palabra, y dijeron: “Buena es la tierra que יהוה nuestro Elohim da a nosotros”.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 26,
-          "tth": "Pero no quisieron subir, y se amargaron con la boca de __יהוה__ su Elohim.",
+          "tth": "Pero no quisieron subir, y se amargaron con la boca de יהוה su Elohim.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 27,
-          "tth": "Y murmuraron en sus tiendas, y dijeron: “En el odio de __יהוה__ hacia nosotros, nos ha sacado de la tierra de Mitzráim para darnos en mano de emorí, para destruirnos.",
+          "tth": "Y murmuraron en sus tiendas, y dijeron: “En el odio de יהוה hacia nosotros, nos ha sacado de la tierra de Mitzráim para darnos en mano de emorí, para destruirnos.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -231,19 +231,19 @@
         },
         {
           "verse": 30,
-          "tth": "__יהוה__, Elohim de ustedes, va delante de ustedes, Él luchará por ustedes, como todo lo que hizo con ustedes en Mitzráim a ojos de ustedes,",
+          "tth": "יהוה, Elohim de ustedes, va delante de ustedes, Él luchará por ustedes, como todo lo que hizo con ustedes en Mitzráim a ojos de ustedes,",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 31,
-          "tth": "y en el desierto, donde has visto que te llevó __יהוה__ tu Elohim, como lleva un hombre a su hijo, por todo el camino el cual han andado hasta llegar a este lugar”.",
+          "tth": "y en el desierto, donde has visto que te llevó יהוה tu Elohim, como lleva un hombre a su hijo, por todo el camino el cual han andado hasta llegar a este lugar”.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 32,
-          "tth": "Pero en este asunto, ustedes no creyeron en __יהוה__ su Elohim,",
+          "tth": "Pero en este asunto, ustedes no creyeron en יהוה su Elohim,",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -256,7 +256,7 @@
         },
         {
           "verse": 34,
-          "tth": "Y escuchó __יהוה__ la voz de sus palabras, y se enojó, y juró, diciendo:",
+          "tth": "Y escuchó יהוה la voz de sus palabras, y se enojó, y juró, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -268,13 +268,13 @@
         },
         {
           "verse": 36,
-          "tth": "<em>no la verán</em>, excepto Caleb, hijo de Iefunéh; él la verá, y a él daré la tierra en la cual ha andado, y a sus hijos, porque <em>estuvo</em> plenamente tras de Mí, __יהוה__”.",
+          "tth": "<em>no la verán</em>, excepto Caleb, hijo de Iefunéh; él la verá, y a él daré la tierra en la cual ha andado, y a sus hijos, porque <em>estuvo</em> plenamente tras de Mí, יהוה”.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 37,
-          "tth": "También conmigo se enojó __יהוה__ debido a ustedes, diciendo: “Tampoco tú entrarás allí.",
+          "tth": "También conmigo se enojó יהוה debido a ustedes, diciendo: “Tampoco tú entrarás allí.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -299,19 +299,19 @@
         },
         {
           "verse": 41,
-          "tth": "Y respondieron, y dijeron a mí: “Pecamos ante __יהוה__; nosotros subiremos y lucharemos como todo lo que nos ordenó __יהוה__ nuestro Elohim”. Y ciñó <em>cada</em> hombre los utensilios de su guerra, y se prepararon para subir a la montaña.",
+          "tth": "Y respondieron, y dijeron a mí: “Pecamos ante יהוה; nosotros subiremos y lucharemos como todo lo que nos ordenó יהוה nuestro Elohim”. Y ciñó <em>cada</em> hombre los utensilios de su guerra, y se prepararon para subir a la montaña.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 42,
-          "tth": "Y dijo __יהוה__ a mí: “Di a ellos: ‘No suban, y no luchen, porque no estoy entre ustedes, y no sean derrotados delante de sus enemigos’”.",
+          "tth": "Y dijo יהוה a mí: “Di a ellos: ‘No suban, y no luchen, porque no estoy entre ustedes, y no sean derrotados delante de sus enemigos’”.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 43,
-          "tth": "Y hablé a ustedes, pero no escucharon, y se amargaron con la boca de __יהוה__, y actuaron presuntuosamente⁹, y subieron a la montaña.",
+          "tth": "Y hablé a ustedes, pero no escucharon, y se amargaron con la boca de יהוה, y actuaron presuntuosamente⁹, y subieron a la montaña.",
           "footnotes": [
             {
               "marker": "⁹",
@@ -330,7 +330,7 @@
         },
         {
           "verse": 45,
-          "tth": "Y volvieron y lloraron delante de __יהוה__, y no escuchó __יהוה__ a su voz, y no dio oídos a ustedes.",
+          "tth": "Y volvieron y lloraron delante de יהוה, y no escuchó יהוה a su voz, y no dio oídos a ustedes.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -348,13 +348,13 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y giramos, y viajamos hacia el desierto <em>por</em> el camino del mar de Cañas, como me había ordenado __יהוה__, y rodeamos al monte Seir muchos días.",
+          "tth": "Y giramos, y viajamos hacia el desierto <em>por</em> el camino del mar de Cañas, como me había ordenado יהוה, y rodeamos al monte Seir muchos días.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 2,
-          "tth": "Y dijo __יהוה__ a mí, diciendo:",
+          "tth": "Y dijo יהוה a mí, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -384,7 +384,7 @@
         },
         {
           "verse": 7,
-          "tth": "Pues __יהוה__ tu Elohim te bendijo en toda obra de tus manos; Él conoce tu caminar hacia este gran desierto. Estos cuarenta años __יהוה__ tu Elohim <em>ha estado</em> contigo, no te ha faltado una cosa’ ”.",
+          "tth": "Pues יהוה tu Elohim te bendijo en toda obra de tus manos; Él conoce tu caminar hacia este gran desierto. Estos cuarenta años יהוה tu Elohim <em>ha estado</em> contigo, no te ha faltado una cosa’ ”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -396,7 +396,7 @@
         },
         {
           "verse": 9,
-          "tth": "Y dijo __יהוה__ a mí: “No asedies a Moab, y no los provoquen a la guerra, porque no te daré de su tierra <em>por</em> herencia, porque a los hijos de Lot he dado Ar <em>por</em> herencia”.",
+          "tth": "Y dijo יהוה a mí: “No asedies a Moab, y no los provoquen a la guerra, porque no te daré de su tierra <em>por</em> herencia, porque a los hijos de Lot he dado Ar <em>por</em> herencia”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -440,7 +440,7 @@
         },
         {
           "verse": 12,
-          "tth": "Y en Seir habitaron los jorim¹⁴ antes, pero los hijos de Esav los desposeyeron y los destruyeron de delante de ellos, y habitaron en su lugar, como hizo Israel a la tierra de su herencia, que dio __יהוה__ a ellos.",
+          "tth": "Y en Seir habitaron los jorim¹⁴ antes, pero los hijos de Esav los desposeyeron y los destruyeron de delante de ellos, y habitaron en su lugar, como hizo Israel a la tierra de su herencia, que dio יהוה a ellos.",
           "footnotes": [
             {
               "marker": "¹⁴",
@@ -459,13 +459,13 @@
         },
         {
           "verse": 14,
-          "tth": "Y los días que fuimos desde Kádesh Barnea, hasta que cruzamos el arroyo de Zared, <em>fueron</em> treinta y ocho años; hasta <em>que</em> se completó toda la generación de los hombres de la guerra de entre el campamento, como había jurado __יהוה__ a ellos.",
+          "tth": "Y los días que fuimos desde Kádesh Barnea, hasta que cruzamos el arroyo de Zared, <em>fueron</em> treinta y ocho años; hasta <em>que</em> se completó toda la generación de los hombres de la guerra de entre el campamento, como había jurado יהוה a ellos.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 15,
-          "tth": "Y también, la mano de __יהוה__ estaba contra ellos para aturdirlos de entre el campamento, hasta <em>que</em> fueron completados.",
+          "tth": "Y también, la mano de יהוה estaba contra ellos para aturdirlos de entre el campamento, hasta <em>que</em> fueron completados.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -477,7 +477,7 @@
         },
         {
           "verse": 17,
-          "tth": "habló __יהוה__ a mí, diciendo:",
+          "tth": "habló יהוה a mí, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -514,7 +514,7 @@
         },
         {
           "verse": 21,
-          "tth": "pueblo grande y numeroso, y elevado como los anakim, pero los destruyó __יהוה__ de delante de ellos. Y los desposeyeron, y habitaron en su lugar,",
+          "tth": "pueblo grande y numeroso, y elevado como los anakim, pero los destruyó יהוה de delante de ellos. Y los desposeyeron, y habitaron en su lugar,",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -597,7 +597,7 @@
         },
         {
           "verse": 29,
-          "tth": "como hicieron por mí los hijos de Esav que habitan en Seir, y los moabim²⁴ que habitan en Ar, hasta que cruce el Iardén²⁵ hacia la tierra que __יהוה__ nuestro Elohim da a nosotros”.",
+          "tth": "como hicieron por mí los hijos de Esav que habitan en Seir, y los moabim²⁴ que habitan en Ar, hasta que cruce el Iardén²⁵ hacia la tierra que יהוה nuestro Elohim da a nosotros”.",
           "footnotes": [
             {
               "marker": "²⁴",
@@ -616,13 +616,13 @@
         },
         {
           "verse": 30,
-          "tth": "Pero no quiso Sijón, rey de Jeshbón, dejarnos pasar por él, porque dejó duro __יהוה__ tu Elohim su espíritu y fortaleció su corazón, a fin de darlo en tu mano, como <em>lo está</em> este día.",
+          "tth": "Pero no quiso Sijón, rey de Jeshbón, dejarnos pasar por él, porque dejó duro יהוה tu Elohim su espíritu y fortaleció su corazón, a fin de darlo en tu mano, como <em>lo está</em> este día.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 31,
-          "tth": "Y dijo __יהוה__ a mí: “Mira, he comenzado <em>a</em> dar delante de ti a Sijón y a su tierra. Comienza <em>a</em> heredar, para heredar su tierra”.",
+          "tth": "Y dijo יהוה a mí: “Mira, he comenzado <em>a</em> dar delante de ti a Sijón y a su tierra. Comienza <em>a</em> heredar, para heredar su tierra”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -634,7 +634,7 @@
         },
         {
           "verse": 33,
-          "tth": "Y lo dio __יהוה__ Elohim nuestro delante de nosotros; y lo golpeamos, y a sus hijos y a todo su pueblo.",
+          "tth": "Y lo dio יהוה Elohim nuestro delante de nosotros; y lo golpeamos, y a sus hijos y a todo su pueblo.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -652,13 +652,13 @@
         },
         {
           "verse": 36,
-          "tth": "Desde Aroer, que <em>está</em> sobre la ribera del arroyo de Arnón, y la ciudad que <em>está</em> en el arroyo, hasta Guilad, no hubo ciudad que <em>sea</em> inaccesible para nosotros; todo dio __יהוה__ Elohim nuestro delante de nosotros.",
+          "tth": "Desde Aroer, que <em>está</em> sobre la ribera del arroyo de Arnón, y la ciudad que <em>está</em> en el arroyo, hasta Guilad, no hubo ciudad que <em>sea</em> inaccesible para nosotros; todo dio יהוה Elohim nuestro delante de nosotros.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 37,
-          "tth": "Solamente a la tierra de los hijos de Amón no te acercaste, toda la mano del arroyo Iabok, y las ciudades de la montaña, y todo lo que había ordenado __יהוה__ nuestro Elohim.",
+          "tth": "Solamente a la tierra de los hijos de Amón no te acercaste, toda la mano del arroyo Iabok, y las ciudades de la montaña, y todo lo que había ordenado יהוה nuestro Elohim.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Derrota del rey del Bashán"
@@ -676,7 +676,7 @@
         },
         {
           "verse": 2,
-          "tth": "Y dijo __יהוה__ a mí: “No le temas, porque en tu mano lo he dado, a él y a todo su pueblo y a su tierra, y harás a él como hiciste a Sijón, rey del emorí²⁶, que habitaba en Jeshbón”.",
+          "tth": "Y dijo יהוה a mí: “No le temas, porque en tu mano lo he dado, a él y a todo su pueblo y a su tierra, y harás a él como hiciste a Sijón, rey del emorí²⁶, que habitaba en Jeshbón”.",
           "footnotes": [
             {
               "marker": "²⁶",
@@ -689,7 +689,7 @@
         },
         {
           "verse": 3,
-          "tth": "Y dio __יהוה__ nuestro Elohim en nuestras manos también a Og, rey del Bashán, y a todo su pueblo; y lo golpeamos, hasta que no quedó a él sobreviviente.",
+          "tth": "Y dio יהוה nuestro Elohim en nuestras manos también a Og, rey del Bashán, y a todo su pueblo; y lo golpeamos, hasta que no quedó a él sobreviviente.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -834,7 +834,7 @@
         },
         {
           "verse": 18,
-          "tth": "Y les ordené en ese tiempo, diciendo: “__יהוה__ su Elohim ha dado a ustedes esta tierra para heredarla; armados cruzarán delante de sus hermanos los hijos de Israel, todos los hijos de valor.",
+          "tth": "Y les ordené en ese tiempo, diciendo: “יהוה su Elohim ha dado a ustedes esta tierra para heredarla; armados cruzarán delante de sus hermanos los hijos de Israel, todos los hijos de valor.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -846,32 +846,32 @@
         },
         {
           "verse": 20,
-          "tth": "hasta que dé reposo __יהוה__ a sus hermanos como <em>a</em> ustedes, y hereden también ellos la tierra que __יהוה__ su Elohim les da en el <em>otro</em> lado del Iardén. Y volverán, <em>cada</em> hombre, a sus posesiones que he dado a ustedes”.",
+          "tth": "hasta que dé reposo יהוה a sus hermanos como <em>a</em> ustedes, y hereden también ellos la tierra que יהוה su Elohim les da en el <em>otro</em> lado del Iardén. Y volverán, <em>cada</em> hombre, a sus posesiones que he dado a ustedes”.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 21,
-          "tth": "Y a Yehoshúa ordené en ese tiempo, diciendo: “Tus ojos han visto todo lo que ha hecho __יהוה__ su Elohim a estos dos reyes; así hará __יהוה__ a todos los reinos los cuales tú pasarás por allí.",
+          "tth": "Y a Yehoshúa ordené en ese tiempo, diciendo: “Tus ojos han visto todo lo que ha hecho יהוה su Elohim a estos dos reyes; así hará יהוה a todos los reinos los cuales tú pasarás por allí.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 22,
-          "tth": "No les temas, porque __יהוה__ su Elohim, Él luchará por ustedes”.",
+          "tth": "No les temas, porque יהוה su Elohim, Él luchará por ustedes”.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Elohim no permite a Moshéh cruzar el Iardén"
         },
         {
           "verse": 23,
-          "tth": "E imploré favor a __יהוה__ en ese tiempo, diciendo:",
+          "tth": "E imploré favor a יהוה en ese tiempo, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 24,
-          "tth": "“Adonai __יהוה__, Tú has comenzado a mostrar a tu siervo tu grandeza y tu mano fuerte, que, ¿quién es El³⁸ en los cielos y en la tierra que haga conforme a tus obras y conforme a tus potencias?",
+          "tth": "“Adonai יהוה, Tú has comenzado a mostrar a tu siervo tu grandeza y tu mano fuerte, que, ¿quién es El³⁸ en los cielos y en la tierra que haga conforme a tus obras y conforme a tus potencias?",
           "footnotes": [
             {
               "marker": "³⁸",
@@ -890,7 +890,7 @@
         },
         {
           "verse": 26,
-          "tth": "Pero desbordó <em>la paciencia</em>³⁹ __יהוה__ conmigo a causa de ustedes, y no me escuchó, y dijo __יהוה__: “¡Suficiente para ti! No añadas más palabra a Mí de este asunto.",
+          "tth": "Pero desbordó <em>la paciencia</em>³⁹ יהוה conmigo a causa de ustedes, y no me escuchó, y dijo יהוה: “¡Suficiente para ti! No añadas más palabra a Mí de este asunto.",
           "footnotes": [
             {
               "marker": "³⁹",
@@ -927,31 +927,31 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y ahora, Israel, escucha los estatutos y los procesos legales que yo les enseño para hacer, a fin de que vivan y entren y hereden la tierra que __יהוה__, Elohim de sus padres, da a ustedes.",
+          "tth": "Y ahora, Israel, escucha los estatutos y los procesos legales que yo les enseño para hacer, a fin de que vivan y entren y hereden la tierra que יהוה, Elohim de sus padres, da a ustedes.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 2,
-          "tth": "No añadirán a la palabra que yo les mando, y no quitarán de ella, para guardar los mandamientos de __יהוה__ su Elohim que yo les mando.",
+          "tth": "No añadirán a la palabra que yo les mando, y no quitarán de ella, para guardar los mandamientos de יהוה su Elohim que yo les mando.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 3,
-          "tth": "Sus ojos han visto lo que ha hecho __יהוה__ en Baal Peor, pues todo hombre que fue tras Baal Peor, destruyó __יהוה__ tu Elohim de en medio de ti.",
+          "tth": "Sus ojos han visto lo que ha hecho יהוה en Baal Peor, pues todo hombre que fue tras Baal Peor, destruyó יהוה tu Elohim de en medio de ti.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 4,
-          "tth": "Mas ustedes, los aferrados a __יהוה__ su Elohim, <em>están</em> vivos todos ustedes hoy.",
+          "tth": "Mas ustedes, los aferrados a יהוה su Elohim, <em>están</em> vivos todos ustedes hoy.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 5,
-          "tth": "Miren, les he enseñado decretos⁴⁰ y procesos legales⁴¹ conforme me ordenó __יהוה__ mi Elohim, para hacer así en medio de la tierra que ustedes irán allí para heredarla.",
+          "tth": "Miren, les he enseñado decretos⁴⁰ y procesos legales⁴¹ conforme me ordenó יהוה mi Elohim, para hacer así en medio de la tierra que ustedes irán allí para heredarla.",
           "footnotes": [
             {
               "marker": "⁴⁰",
@@ -976,7 +976,7 @@
         },
         {
           "verse": 7,
-          "tth": "Pues, ¿qué nación grande <em>hay</em> que <em>tenga</em> para sí un Elohim cercano a ella como <em>está</em> __יהוה__ nuestro Elohim en todo nuestro llamar a Él?",
+          "tth": "Pues, ¿qué nación grande <em>hay</em> que <em>tenga</em> para sí un Elohim cercano a ella como <em>está</em> יהוה nuestro Elohim en todo nuestro llamar a Él?",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -994,7 +994,7 @@
         },
         {
           "verse": 10,
-          "tth": "El día que te paraste delante de __יהוה__ tu Elohim en Joreb, cuando dijo __יהוה__ a mí: “Reúne para Mí al pueblo, y les haré oír mis palabras, las cuales aprenderán para temerme todos los días que ellos vivan sobre la tierra, y a sus hijos enseñen”.",
+          "tth": "El día que te paraste delante de יהוה tu Elohim en Joreb, cuando dijo יהוה a mí: “Reúne para Mí al pueblo, y les haré oír mis palabras, las cuales aprenderán para temerme todos los días que ellos vivan sobre la tierra, y a sus hijos enseñen”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1006,7 +1006,7 @@
         },
         {
           "verse": 12,
-          "tth": "Y habló __יהוה__ a ustedes de en medio del fuego; la voz de las palabras ustedes escucharon, pero imagen no vieron, excepto una voz.",
+          "tth": "Y habló יהוה a ustedes de en medio del fuego; la voz de las palabras ustedes escucharon, pero imagen no vieron, excepto una voz.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1018,13 +1018,13 @@
         },
         {
           "verse": 14,
-          "tth": "Y a mí ordenó __יהוה__ en ese tiempo a enseñarles los estatutos y los procesos legales, para hacerlos en la tierra a la cual ustedes cruzarán allí para heredarla.",
+          "tth": "Y a mí ordenó יהוה en ese tiempo a enseñarles los estatutos y los procesos legales, para hacerlos en la tierra a la cual ustedes cruzarán allí para heredarla.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 15,
-          "tth": "Y guarden mucho sus vidas, porque no vieron ninguna apariencia en el día <em>que</em> habló __יהוה__ a ustedes en Joreb de en medio del fuego;",
+          "tth": "Y guarden mucho sus vidas, porque no vieron ninguna apariencia en el día <em>que</em> habló יהוה a ustedes en Joreb de en medio del fuego;",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1048,19 +1048,19 @@
         },
         {
           "verse": 19,
-          "tth": "Y no sea que levantes tus ojos a los cielos y veas al sol y a la luna y a las estrellas, todo el ejército de los cielos, y seas impulsado y te inclines a ellos y les sirvas, los cuales repartió __יהוה__ tu Elohim por todos los pueblos debajo de todo el cielo.",
+          "tth": "Y no sea que levantes tus ojos a los cielos y veas al sol y a la luna y a las estrellas, todo el ejército de los cielos, y seas impulsado y te inclines a ellos y les sirvas, los cuales repartió יהוה tu Elohim por todos los pueblos debajo de todo el cielo.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 20,
-          "tth": "Pero a ustedes ha tomado __יהוה__ y los ha sacado del horno de hierro, de Mitzráim, para ser a ustedes por pueblo de heredad, como este día.",
+          "tth": "Pero a ustedes ha tomado יהוה y los ha sacado del horno de hierro, de Mitzráim, para ser a ustedes por pueblo de heredad, como este día.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 21,
-          "tth": "Y __יהוה__ se enojó conmigo por sus palabras, y juró que no cruzaría yo el Iardén⁴² y que no entraría a la tierra buena que __יהוה__ tu Elohim da a ti <em>como</em> herencia.",
+          "tth": "Y יהוה se enojó conmigo por sus palabras, y juró que no cruzaría yo el Iardén⁴² y que no entraría a la tierra buena que יהוה tu Elohim da a ti <em>como</em> herencia.",
           "footnotes": [
             {
               "marker": "⁴²",
@@ -1079,7 +1079,7 @@
         },
         {
           "verse": 23,
-          "tth": "Guárdense, no sea que olviden el pacto de __יהוה__ su Elohim, que hizo⁴³ con ustedes, y hagan para ustedes una estatuilla de apariencia de cualquier <em>cosa</em> que te ha ordenado <em>no hacer</em> __יהוה__ tu Elohim.",
+          "tth": "Guárdense, no sea que olviden el pacto de יהוה su Elohim, que hizo⁴³ con ustedes, y hagan para ustedes una estatuilla de apariencia de cualquier <em>cosa</em> que te ha ordenado <em>no hacer</em> יהוה tu Elohim.",
           "footnotes": [
             {
               "marker": "⁴³",
@@ -1092,7 +1092,7 @@
         },
         {
           "verse": 24,
-          "tth": "Porque __יהוה__ tu Elohim, fuego consumidor es Él, un Elohim celoso⁴⁴.",
+          "tth": "Porque יהוה tu Elohim, fuego consumidor es Él, un Elohim celoso⁴⁴.",
           "footnotes": [
             {
               "marker": "⁴⁴",
@@ -1105,7 +1105,7 @@
         },
         {
           "verse": 25,
-          "tth": "Cuando hayan engendrado hijos e hijos de hijos, y hayan envejecido ustedes en la tierra, y se corrompen y hacen una estatuilla de apariencia de cualquier <em>cosa</em>, y hacen el mal en los ojos de __יהוה__ tu Elohim, para hacerlo enfurecer,",
+          "tth": "Cuando hayan engendrado hijos e hijos de hijos, y hayan envejecido ustedes en la tierra, y se corrompen y hacen una estatuilla de apariencia de cualquier <em>cosa</em>, y hacen el mal en los ojos de יהוה tu Elohim, para hacerlo enfurecer,",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1124,7 +1124,7 @@
         },
         {
           "verse": 27,
-          "tth": "Y los dispersará __יהוה__ entre los pueblos, y quedarán <em>pocos</em> hombres de número en las naciones las cuales los conducirá __יהוה__ allí.",
+          "tth": "Y los dispersará יהוה entre los pueblos, y quedarán <em>pocos</em> hombres de número en las naciones las cuales los conducirá יהוה allí.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1136,13 +1136,13 @@
         },
         {
           "verse": 29,
-          "tth": "Mas buscarán desde allí a __יהוה__ tu Elohim, y lo encontrarás, porque lo buscarás con todo tu corazón y con todo tu ser.",
+          "tth": "Mas buscarán desde allí a יהוה tu Elohim, y lo encontrarás, porque lo buscarás con todo tu corazón y con todo tu ser.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 30,
-          "tth": "Cuando estés angustiado⁴⁶, y te encuentren todas estas cosas, en la posteridad de los días⁴⁷, regresarás a __יהוה__ tu Elohim y escucharás a su voz.",
+          "tth": "Cuando estés angustiado⁴⁶, y te encuentren todas estas cosas, en la posteridad de los días⁴⁷, regresarás a יהוה tu Elohim y escucharás a su voz.",
           "footnotes": [
             {
               "marker": "⁴⁶",
@@ -1161,7 +1161,7 @@
         },
         {
           "verse": 31,
-          "tth": "Pues El⁴⁸ amoroso entrañablemente⁴⁹ es __יהוה__ tu Elohim, no te debilitará y no te destruirá, y no olvidará el pacto de tus padres, que juró a ellos.",
+          "tth": "Pues El⁴⁸ amoroso entrañablemente⁴⁹ es יהוה tu Elohim, no te debilitará y no te destruirá, y no olvidará el pacto de tus padres, que juró a ellos.",
           "footnotes": [
             {
               "marker": "⁴⁸",
@@ -1192,13 +1192,13 @@
         },
         {
           "verse": 34,
-          "tth": "¿O ha intentado un dios ir a tomar para sí una nación de entre <em>otra</em> nación, con pruebas, con señales y con maravillas, y con mano fuerte y con brazo extendido, y con grandes terrores, como todo lo que hizo por ustedes __יהוה__ su Elohim en Mitzráim a tus ojos?",
+          "tth": "¿O ha intentado un dios ir a tomar para sí una nación de entre <em>otra</em> nación, con pruebas, con señales y con maravillas, y con mano fuerte y con brazo extendido, y con grandes terrores, como todo lo que hizo por ustedes יהוה su Elohim en Mitzráim a tus ojos?",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 35,
-          "tth": "Tú has visto, para conocer que __יהוה__, Él es el Elohim, no hay otro además de Él.",
+          "tth": "Tú has visto, para conocer que יהוה, Él es el Elohim, no hay otro además de Él.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1222,13 +1222,13 @@
         },
         {
           "verse": 39,
-          "tth": "Y conoce hoy y regresa en tu corazón, que __יהוה__, Él es el Elohim arriba en los cielos y abajo sobre la tierra; no hay otro.",
+          "tth": "Y conoce hoy y regresa en tu corazón, que יהוה, Él es el Elohim arriba en los cielos y abajo sobre la tierra; no hay otro.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 40,
-          "tth": "Y guardarás sus decretos y sus mandamientos que yo te ordeno hoy, por lo que será bueno para ti y para tus hijos después de ti, a fin de que hagas largos <em>tus</em> días sobre la tierra que __יהוה__ tu Elohim te da todos los días.",
+          "tth": "Y guardarás sus decretos y sus mandamientos que yo te ordeno hoy, por lo que será bueno para ti y para tus hijos después de ti, a fin de que hagas largos <em>tus</em> días sobre la tierra que יהוה tu Elohim te da todos los días.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Ciudades de refugio"
@@ -1321,7 +1321,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y llamó Moshéh a todo Israel, y dijo a ellos: Escucha Israel los decretos⁵⁴ y los procesos legales⁵⁵ que yo hablo en sus oídos hoy, para que los aprendan y guarden para hacerlos.__2 יהוה__ Elohim nuestro ha hecho⁵⁶ con nosotros un pacto en Joreb.",
+          "tth": "Y llamó Moshéh a todo Israel, y dijo a ellos: Escucha Israel los decretos⁵⁴ y los procesos legales⁵⁵ que yo hablo en sus oídos hoy, para que los aprendan y guarden para hacerlos.2 יהוה Elohim nuestro ha hecho⁵⁶ con nosotros un pacto en Joreb.",
           "footnotes": [
             {
               "marker": "⁵⁴",
@@ -1346,25 +1346,25 @@
         },
         {
           "verse": 3,
-          "tth": "No con nuestros padres ha hecho __יהוה__ este pacto, pues con nosotros, estos nosotros <em>que estamos</em> aquí hoy, todos nosotros <em>que estamos</em> vivos.",
+          "tth": "No con nuestros padres ha hecho יהוה este pacto, pues con nosotros, estos nosotros <em>que estamos</em> aquí hoy, todos nosotros <em>que estamos</em> vivos.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 4,
-          "tth": "Cara a cara habló __יהוה__ con nosotros en el monte de en medio del fuego,",
+          "tth": "Cara a cara habló יהוה con nosotros en el monte de en medio del fuego,",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 5,
-          "tth": "yo estaba parado entre __יהוה__ y ustedes en esa ocasión, para declarar a ustedes la palabra de __יהוה__, pues temieron a causa del fuego, y no subieron al monte. Diciendo:",
+          "tth": "yo estaba parado entre יהוה y ustedes en esa ocasión, para declarar a ustedes la palabra de יהוה, pues temieron a causa del fuego, y no subieron al monte. Diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 6,
-          "tth": "“Yo soy __יהוה__ tu Elohim, que te hice salir de la tierra de Mitzráim, de la casa de esclavos.",
+          "tth": "“Yo soy יהוה tu Elohim, que te hice salir de la tierra de Mitzráim, de la casa de esclavos.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1389,7 +1389,7 @@
         },
         {
           "verse": 9,
-          "tth": "No te inclinarás a ellos y no los servirás, porque Yo, __יהוה__ tu Elohim, <em>soy</em> El celoso⁵⁸, visitando la iniquidad⁵⁹ de los padres sobre los hijos, y sobre las terceras y sobre las cuartas <em>generaciones</em> de los que me odian,",
+          "tth": "No te inclinarás a ellos y no los servirás, porque Yo, יהוה tu Elohim, <em>soy</em> El celoso⁵⁸, visitando la iniquidad⁵⁹ de los padres sobre los hijos, y sobre las terceras y sobre las cuartas <em>generaciones</em> de los que me odian,",
           "footnotes": [
             {
               "marker": "⁵⁸",
@@ -1427,13 +1427,13 @@
         },
         {
           "verse": 11,
-          "tth": "No levantarás el Nombre de __יהוה__ tu Elohim para mentira, porque no dejará limpio יהוה a quien levante su Nombre para mentira.",
+          "tth": "No levantarás el Nombre de יהוה tu Elohim para mentira, porque no dejará limpio יהוה a quien levante su Nombre para mentira.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 12,
-          "tth": "Guarda el día del Shabat para apartarlo⁶², como te ordenó __יהוה__ tu Elohim.",
+          "tth": "Guarda el día del Shabat para apartarlo⁶², como te ordenó יהוה tu Elohim.",
           "footnotes": [
             {
               "marker": "⁶²",
@@ -1452,19 +1452,19 @@
         },
         {
           "verse": 14,
-          "tth": "pero el día séptimo es Shabat para __יהוה__ tu Elohim, no harás ningún trabajo, tú, y tu hijo, y tu hija, y tu siervo, y tu sierva, y tu buey, y tu asno, y cualquier bestia tuya, y tu extranjero que <em>está</em> en tus puertas, a fin de que descanse tu siervo y tu sierva como tú.",
+          "tth": "pero el día séptimo es Shabat para יהוה tu Elohim, no harás ningún trabajo, tú, y tu hijo, y tu hija, y tu siervo, y tu sierva, y tu buey, y tu asno, y cualquier bestia tuya, y tu extranjero que <em>está</em> en tus puertas, a fin de que descanse tu siervo y tu sierva como tú.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 15,
-          "tth": "Y recordarás que esclavo fuiste en la tierra de Mitzráim, y te dejó salir __יהוה__ tu Elohim de allí con mano fuerte y con brazo extendido, por eso te mandó __יהוה__ tu Elohim a hacer el día del Shabat.",
+          "tth": "Y recordarás que esclavo fuiste en la tierra de Mitzráim, y te dejó salir יהוה tu Elohim de allí con mano fuerte y con brazo extendido, por eso te mandó יהוה tu Elohim a hacer el día del Shabat.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 16,
-          "tth": "Honra a tu padre y a tu madre, como te ordenó __יהוה__ tu Elohim, a fin de que se hagan largos tus días, y a fin de que sea bueno para ti sobre la tierra que __יהוה__ tu Elohim te da.",
+          "tth": "Honra a tu padre y a tu madre, como te ordenó יהוה tu Elohim, a fin de que se hagan largos tus días, y a fin de que sea bueno para ti sobre la tierra que יהוה tu Elohim te da.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1508,7 +1508,7 @@
         },
         {
           "verse": 22,
-          "tth": "Estas palabras habló __יהוה__ a toda la asamblea de ustedes en el monte, de en medio del fuego, la nube y la niebla, <em>con</em> gran voz, y no añadió. Y las escribió sobre dos tablas de piedra, y las dio a mí.",
+          "tth": "Estas palabras habló יהוה a toda la asamblea de ustedes en el monte, de en medio del fuego, la nube y la niebla, <em>con</em> gran voz, y no añadió. Y las escribió sobre dos tablas de piedra, y las dio a mí.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1520,13 +1520,13 @@
         },
         {
           "verse": 24,
-          "tth": "y dijeron ustedes: “He aquí, nos ha hecho ver __יהוה__ nuestro Elohim su gloria y su grandeza, y su voz hemos escuchado de en medio del fuego; este día vimos que habla Elohim con el hombre, y <em>este</em> vive.",
+          "tth": "y dijeron ustedes: “He aquí, nos ha hecho ver יהוה nuestro Elohim su gloria y su grandeza, y su voz hemos escuchado de en medio del fuego; este día vimos que habla Elohim con el hombre, y <em>este</em> vive.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 25,
-          "tth": "Y ahora, ¿por qué moriremos? Porque nos consumirá este gran fuego; si volvemos nosotros a escuchar la voz de __יהוה__ nuestro Elohim, aún moriremos.",
+          "tth": "Y ahora, ¿por qué moriremos? Porque nos consumirá este gran fuego; si volvemos nosotros a escuchar la voz de יהוה nuestro Elohim, aún moriremos.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1538,13 +1538,13 @@
         },
         {
           "verse": 27,
-          "tth": "Acérca <em>te</em> tú y escucha todo lo que dirá __יהוה__ nuestro Elohim; y tú hablarás a nosotros todo lo que dirá __יהוה__ nuestro Elohim a ti, y escucharemos y <em>lo</em> haremos”.",
+          "tth": "Acérca <em>te</em> tú y escucha todo lo que dirá יהוה nuestro Elohim; y tú hablarás a nosotros todo lo que dirá יהוה nuestro Elohim a ti, y escucharemos y <em>lo</em> haremos”.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 28,
-          "tth": "Y escuchó __יהוה__ la voz de sus palabras cuando hablaron a mí, y me dijo __יהוה__: “Escuché la voz de las palabras de este pueblo que hablaron a ti. Fue bueno todo lo que hablaron.",
+          "tth": "Y escuchó יהוה la voz de sus palabras cuando hablaron a mí, y me dijo יהוה: “Escuché la voz de las palabras de este pueblo que hablaron a ti. Fue bueno todo lo que hablaron.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1568,13 +1568,13 @@
         },
         {
           "verse": 32,
-          "tth": "Y guardarán para hacer conforme ordenó __יהוה__ su Elohim a ustedes; no se desvíen <em>a</em> derecha e izquierda.",
+          "tth": "Y guardarán para hacer conforme ordenó יהוה su Elohim a ustedes; no se desvíen <em>a</em> derecha e izquierda.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 33,
-          "tth": "En todo el camino que les ordenó __יהוה__ su Elohim andarán, a fin de que vivan y <em>sea</em> bueno a ustedes, y puedan hacer largos <em>sus</em> días en la tierra que heredarán. <em>El Shemá</em>",
+          "tth": "En todo el camino que les ordenó יהוה su Elohim andarán, a fin de que vivan y <em>sea</em> bueno a ustedes, y puedan hacer largos <em>sus</em> días en la tierra que heredarán. <em>El Shemá</em>",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -1585,7 +1585,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y estos son los mandamientos⁶⁴, los decretos⁶⁵ y los procesos legales⁶⁶ que ordenó __יהוה__ su Elohim para enseñarles, para hacer <em>los</em> en la tierra que ustedes cruzarán hacia ahí para heredarla,",
+          "tth": "Y estos son los mandamientos⁶⁴, los decretos⁶⁵ y los procesos legales⁶⁶ que ordenó יהוה su Elohim para enseñarles, para hacer <em>los</em> en la tierra que ustedes cruzarán hacia ahí para heredarla,",
           "footnotes": [
             {
               "marker": "⁶⁴",
@@ -1610,19 +1610,19 @@
         },
         {
           "verse": 2,
-          "tth": "a fin de que temas a __יהוה__ tu Elohim, para guardar todos sus decretos y sus mandamientos que yo te ordeno, tú y tu hijo y el hijo de tu hijo, todos los días de tu vida, para que sean largos tus días.",
+          "tth": "a fin de que temas a יהוה tu Elohim, para guardar todos sus decretos y sus mandamientos que yo te ordeno, tú y tu hijo y el hijo de tu hijo, todos los días de tu vida, para que sean largos tus días.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 3,
-          "tth": "Y escucha, Israel, y guarda para hacer lo que sea bueno para ti, y que te multipliques mucho, como te habló __יהוה__, Elohim de tus padres, una tierra <em>que</em> fluye leche y miel.",
+          "tth": "Y escucha, Israel, y guarda para hacer lo que sea bueno para ti, y que te multipliques mucho, como te habló יהוה, Elohim de tus padres, una tierra <em>que</em> fluye leche y miel.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 4,
-          "tth": "Escucha⁶⁷ Israel, __יהוה__ nuestro Elohim, __יהוה es uno⁶⁸.",
+          "tth": "Escucha⁶⁷ Israel, יהוה nuestro Elohim, __יהוה es uno⁶⁸.",
           "footnotes": [
             {
               "marker": "⁶⁷",
@@ -1634,14 +1634,14 @@
               "marker": "⁶⁸",
               "number": "68",
               "word": "uno",
-              "explanation": "Heb.: Shemá Israel __יהוה__ Eloheinu __יהוה__ ejad."
+              "explanation": "Heb.: Shemá Israel יהוה Eloheinu יהוה ejad."
             }
           ],
           "hebrew_terms": []
         },
         {
           "verse": 5,
-          "tth": "Y amarás a __יהוה__ tu Elohim con todo tu corazón⁶⁹, con todo tu ser⁷⁰ y con toda tu abundancia⁷¹.",
+          "tth": "Y amarás a יהוה tu Elohim con todo tu corazón⁶⁹, con todo tu ser⁷⁰ y con toda tu abundancia⁷¹.",
           "footnotes": [
             {
               "marker": "⁶⁹",
@@ -1698,7 +1698,7 @@
         },
         {
           "verse": 10,
-          "tth": "Y sucederá cuando te lleve __יהוה__ tu Elohim a la tierra que juró a tus padres, a Abraham, a Itzjak y a Yaakov, para darte ciudades grandes y buenas que no construiste,",
+          "tth": "Y sucederá cuando te lleve יהוה tu Elohim a la tierra que juró a tus padres, a Abraham, a Itzjak y a Yaakov, para darte ciudades grandes y buenas que no construiste,",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1710,13 +1710,13 @@
         },
         {
           "verse": 12,
-          "tth": "guárdate, no sea que olvides a __יהוה__ que te hizo salir de la tierra de Mitzráim, de la casa de esclavos.",
+          "tth": "guárdate, no sea que olvides a יהוה que te hizo salir de la tierra de Mitzráim, de la casa de esclavos.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 13,
-          "tth": "A __יהוה__ tu Elohim temerás, y a Él servirás, y en su Nombre jurarás.",
+          "tth": "A יהוה tu Elohim temerás, y a Él servirás, y en su Nombre jurarás.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1728,7 +1728,7 @@
         },
         {
           "verse": 15,
-          "tth": "porque El celoso⁷³, __יהוה__ tu Elohim, <em>está</em> en medio de ti, no sea que se caliente la nariz de __יהוה__ tu Elohim contra ti, y te destruya de sobre la faz de la tierra.",
+          "tth": "porque El celoso⁷³, יהוה tu Elohim, <em>está</em> en medio de ti, no sea que se caliente la nariz de יהוה tu Elohim contra ti, y te destruya de sobre la faz de la tierra.",
           "footnotes": [
             {
               "marker": "⁷³",
@@ -1741,7 +1741,7 @@
         },
         {
           "verse": 16,
-          "tth": "No probarán a __יהוה__ su Elohim, como <em>lo</em> examinaron en Masah⁷⁴.",
+          "tth": "No probarán a יהוה su Elohim, como <em>lo</em> examinaron en Masah⁷⁴.",
           "footnotes": [
             {
               "marker": "⁷⁴",
@@ -1754,37 +1754,37 @@
         },
         {
           "verse": 17,
-          "tth": "Guardando, guardarán los mandamientos de __יהוה__ su Elohim, y sus testimonios, y sus decretos que te ha ordenado.",
+          "tth": "Guardando, guardarán los mandamientos de יהוה su Elohim, y sus testimonios, y sus decretos que te ha ordenado.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 18,
-          "tth": "Y harás lo recto y lo bueno en los ojos de __יהוה__, a fin de que vaya bien a ti, y puedas entrar y heredar la tierra buena que juró __יהוה__ a tus padres,",
+          "tth": "Y harás lo recto y lo bueno en los ojos de יהוה, a fin de que vaya bien a ti, y puedas entrar y heredar la tierra buena que juró יהוה a tus padres,",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 19,
-          "tth": "empujando a todos tus enemigos de delante de ti, como habló __יהוה__.",
+          "tth": "empujando a todos tus enemigos de delante de ti, como habló יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 20,
-          "tth": "Cuando te pregunte tu hijo mañana, diciendo: “¿Qué <em>son</em> los testimonios, los decretos y los procesos legales que les ordenó __יהוה__ nuestro Elohim? ”,",
+          "tth": "Cuando te pregunte tu hijo mañana, diciendo: “¿Qué <em>son</em> los testimonios, los decretos y los procesos legales que les ordenó יהוה nuestro Elohim? ”,",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 21,
-          "tth": "y dirás a tu hijo: “Esclavos éramos de Faraón en Mitzráim, y nos hizo salir __יהוה__ de Mitzráim con mano fuerte.",
+          "tth": "y dirás a tu hijo: “Esclavos éramos de Faraón en Mitzráim, y nos hizo salir יהוה de Mitzráim con mano fuerte.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 22,
-          "tth": "Y puso __יהוה__ señales y maravillas grandes y malas en Mitzráim, en Faraón y en toda su casa, a nuestros ojos;",
+          "tth": "Y puso יהוה señales y maravillas grandes y malas en Mitzráim, en Faraón y en toda su casa, a nuestros ojos;",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1796,13 +1796,13 @@
         },
         {
           "verse": 24,
-          "tth": "Y nos mandó __יהוה__ a hacer todos estos decretos, para temer a __יהוה__ nuestro Elohim para el bien nuestro todos los días, para vivir, como este día.",
+          "tth": "Y nos mandó יהוה a hacer todos estos decretos, para temer a יהוה nuestro Elohim para el bien nuestro todos los días, para vivir, como este día.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 25,
-          "tth": "Y justicia habrá para nosotros cuando guardemos para hacer todos los mandamientos estos delante de __יהוה__ nuestro Elohim, como nos ha mandado.",
+          "tth": "Y justicia habrá para nosotros cuando guardemos para hacer todos los mandamientos estos delante de יהוה nuestro Elohim, como nos ha mandado.",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -1813,7 +1813,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Cuando te haya hecho entrar __יהוה__ tu Elohim",
+          "tth": "Cuando te haya hecho entrar יהוה tu Elohim",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1825,7 +1825,7 @@
         },
         {
           "verse": 2,
-          "tth": "y los haya dado __יהוה__ tu Elohim delante de ti, y los hayas golpeado, habiendo destruido, los destruirás. No harás⁷⁵ para ellos pacto, y no los favorecerás.",
+          "tth": "y los haya dado יהוה tu Elohim delante de ti, y los hayas golpeado, habiendo destruido, los destruirás. No harás⁷⁵ para ellos pacto, y no los favorecerás.",
           "footnotes": [
             {
               "marker": "⁷⁵",
@@ -1844,7 +1844,7 @@
         },
         {
           "verse": 4,
-          "tth": "Porque desviará a tu hijo de detrás de Mí <em>para que</em> sirva <em>a</em> otros dioses; y se calentará la nariz de __יהוה__ contra ustedes, y Él te destruirá pronto.",
+          "tth": "Porque desviará a tu hijo de detrás de Mí <em>para que</em> sirva <em>a</em> otros dioses; y se calentará la nariz de יהוה contra ustedes, y Él te destruirá pronto.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1857,7 +1857,7 @@
         },
         {
           "verse": 6,
-          "tth": "Porque pueblo kadosh⁷⁶ <em>eres</em> tú para __יהוה__ tu Elohim; a ti <em>te</em> escogió __יהוה__ tu Elohim para ser a Él por pueblo, una adquisición⁷⁷ de <em>entre</em> todos los pueblos que <em>están</em> sobre la faz de la tierra.",
+          "tth": "Porque pueblo kadosh⁷⁶ <em>eres</em> tú para יהוה tu Elohim; a ti <em>te</em> escogió יהוה tu Elohim para ser a Él por pueblo, una adquisición⁷⁷ de <em>entre</em> todos los pueblos que <em>están</em> sobre la faz de la tierra.",
           "footnotes": [
             {
               "marker": "⁷⁶",
@@ -1876,19 +1876,19 @@
         },
         {
           "verse": 7,
-          "tth": "No por ser ustedes <em>más</em> numerosos que cualquier <em>otro</em> pueblo los amó __יהוה__ y <em>los</em> escogió a ustedes, pues eran el menor de <em>entre</em> todos los pueblos;",
+          "tth": "No por ser ustedes <em>más</em> numerosos que cualquier <em>otro</em> pueblo los amó יהוה y <em>los</em> escogió a ustedes, pues eran el menor de <em>entre</em> todos los pueblos;",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 8,
-          "tth": "pues por el amor de __יהוה__ hacia ustedes y debido a que guardó el juramento que juró a sus padres,<em>los</em> hizo salir __יהוה__ a ustedes con mano fuerte, y te rescató de la casa de esclavos, de la mano de Faraón, rey de Mitzráim.",
+          "tth": "pues por el amor de יהוה hacia ustedes y debido a que guardó el juramento que juró a sus padres,<em>los</em> hizo salir יהוה a ustedes con mano fuerte, y te rescató de la casa de esclavos, de la mano de Faraón, rey de Mitzráim.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 9,
-          "tth": "Y sabrás que __יהוה__ tu Elohim, Él es Elohim, Elohim fiel⁷⁸, <em>que</em> guarda el pacto y la bondad⁷⁹ para los que lo aman y⁸⁰ para los que guardan sus mandamientos, por mil generaciones.",
+          "tth": "Y sabrás que יהוה tu Elohim, Él es Elohim, Elohim fiel⁷⁸, <em>que</em> guarda el pacto y la bondad⁷⁹ para los que lo aman y⁸⁰ para los que guardan sus mandamientos, por mil generaciones.",
           "footnotes": [
             {
               "marker": "⁷⁸",
@@ -1932,7 +1932,7 @@
         },
         {
           "verse": 12,
-          "tth": "Y sucederá en consecuencia de que escuchen estos procesos legales y los guarden y los hagan, guardará __יהוה__ tu Elohim para ti el pacto y la bondad que juró a tus padres.",
+          "tth": "Y sucederá en consecuencia de que escuchen estos procesos legales y los guarden y los hagan, guardará יהוה tu Elohim para ti el pacto y la bondad que juró a tus padres.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1950,13 +1950,13 @@
         },
         {
           "verse": 15,
-          "tth": "Y hará desviar __יהוה__ de ti toda enfermedad; y todas las aflicciones malas de Mitzráim que conociste no pondrá en ti, pero las pondrá en todos tus aborrecedores.",
+          "tth": "Y hará desviar יהוה de ti toda enfermedad; y todas las aflicciones malas de Mitzráim que conociste no pondrá en ti, pero las pondrá en todos tus aborrecedores.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 16,
-          "tth": "Y consumirás a todos los pueblos que __יהוה__ tu Elohim te da, no tendrá favor tu ojo sobre ellos, y no servirás a sus dioses, porque trampa <em>sería</em> esto para ti.",
+          "tth": "Y consumirás a todos los pueblos que יהוה tu Elohim te da, no tendrá favor tu ojo sobre ellos, y no servirás a sus dioses, porque trampa <em>sería</em> esto para ti.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1968,25 +1968,25 @@
         },
         {
           "verse": 18,
-          "tth": "no tengas temor de ellos, recordando, recuerda lo que hizo __יהוה__ tu Elohim a Faraón y a todo Mitzráim;",
+          "tth": "no tengas temor de ellos, recordando, recuerda lo que hizo יהוה tu Elohim a Faraón y a todo Mitzráim;",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 19,
-          "tth": "las grandes pruebas que vieron tus ojos, las señales y las maravillas, y la mano fuerte y el brazo extendido <em>con</em> el cual te sacó __יהוה__ tu Elohim. Así hará __יהוה__ tu Elohim a todos los pueblos que tú tienes temor de sus rostros.",
+          "tth": "las grandes pruebas que vieron tus ojos, las señales y las maravillas, y la mano fuerte y el brazo extendido <em>con</em> el cual te sacó יהוה tu Elohim. Así hará יהוה tu Elohim a todos los pueblos que tú tienes temor de sus rostros.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 20,
-          "tth": "Y además, a la avispa enviará __יהוה__ tu Elohim entre ellos, hasta perecer los que restan y los que se esconden de tu rostro.",
+          "tth": "Y además, a la avispa enviará יהוה tu Elohim entre ellos, hasta perecer los que restan y los que se esconden de tu rostro.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 21,
-          "tth": "No te asustes de sus rostros, porque __יהוה__ tu Elohim <em>está</em> en medio de ti, El⁸¹ grande y temible.",
+          "tth": "No te asustes de sus rostros, porque יהוה tu Elohim <em>está</em> en medio de ti, El⁸¹ grande y temible.",
           "footnotes": [
             {
               "marker": "⁸¹",
@@ -1999,13 +1999,13 @@
         },
         {
           "verse": 22,
-          "tth": "Y expulsará __יהוה__ tu Elohim a las naciones estas de delante de ti poco <em>a</em> poco; no podrás acabarlas rápido, no sea que se hagan numerosos sobre ti los animales del campo.",
+          "tth": "Y expulsará יהוה tu Elohim a las naciones estas de delante de ti poco <em>a</em> poco; no podrás acabarlas rápido, no sea que se hagan numerosos sobre ti los animales del campo.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 23,
-          "tth": "Pero las dará __יהוה__ tu Elohim delante de ti y las confundirá <em>con</em> confusión grande, hasta <em>que estén</em> destruidas.",
+          "tth": "Pero las dará יהוה tu Elohim delante de ti y las confundirá <em>con</em> confusión grande, hasta <em>que estén</em> destruidas.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2017,7 +2017,7 @@
         },
         {
           "verse": 25,
-          "tth": "Las estatuas de sus dioses quemarán en el fuego; no codiciarás la plata y el oro <em>que están</em> sobre ellas y las tomarás para ti, no sea que seas atrapado por esto, porque abominación de __יהוה__ tu Elohim es esto.",
+          "tth": "Las estatuas de sus dioses quemarán en el fuego; no codiciarás la plata y el oro <em>que están</em> sobre ellas y las tomarás para ti, no sea que seas atrapado por esto, porque abominación de יהוה tu Elohim es esto.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2035,19 +2035,19 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Todo mandamiento que yo te ordeno hoy guardarán para hacer, a fin que de vivan y se multipliquen, y entren y hereden la tierra que juró __יהוה__ a sus padres.",
+          "tth": "Todo mandamiento que yo te ordeno hoy guardarán para hacer, a fin que de vivan y se multipliquen, y entren y hereden la tierra que juró יהוה a sus padres.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 2,
-          "tth": "Y recordarás todo el camino que te hizo caminar __יהוה__ tu Elohim estos cuarenta años en el desierto, a fin de que te humilles para examinarte, para saber que <em>hay</em> en tu corazón, ¿guardarías sus mandamientos o no?",
+          "tth": "Y recordarás todo el camino que te hizo caminar יהוה tu Elohim estos cuarenta años en el desierto, a fin de que te humilles para examinarte, para saber que <em>hay</em> en tu corazón, ¿guardarías sus mandamientos o no?",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 3,
-          "tth": "Y te afligió, y te hizo tener hambre, y te hizo comer el man⁸² que no conocías y no habían conocido tus padres, a fin de hacerte saber que no sólo por el pan vivirá el hombre, pues por todo lo que sale de la boca de __יהוה__ vivirá el hombre.",
+          "tth": "Y te afligió, y te hizo tener hambre, y te hizo comer el man⁸² que no conocías y no habían conocido tus padres, a fin de hacerte saber que no sólo por el pan vivirá el hombre, pues por todo lo que sale de la boca de יהוה vivirá el hombre.",
           "footnotes": [
             {
               "marker": "⁸²",
@@ -2066,19 +2066,19 @@
         },
         {
           "verse": 5,
-          "tth": "Y sabrás con tu corazón que como castiga un hombre a su hijo, __יהוה__ tu Elohim te castiga.",
+          "tth": "Y sabrás con tu corazón que como castiga un hombre a su hijo, יהוה tu Elohim te castiga.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 6,
-          "tth": "Y guardarás los mandamientos de __יהוה__ tu Elohim, para andar en sus caminos y para temerle.",
+          "tth": "Y guardarás los mandamientos de יהוה tu Elohim, para andar en sus caminos y para temerle.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 7,
-          "tth": "Porque __יהוה__ tu Elohim te hace entrar a una tierra buena, una tierra de arroyos de aguas, de fuentes⁸³ y profundidades que salen por los valles y por las montañas;",
+          "tth": "Porque יהוה tu Elohim te hace entrar a una tierra buena, una tierra de arroyos de aguas, de fuentes⁸³ y profundidades que salen por los valles y por las montañas;",
           "footnotes": [
             {
               "marker": "⁸³",
@@ -2103,14 +2103,14 @@
         },
         {
           "verse": 10,
-          "tth": "Y comerás y te saciarás, y bendecirás a __יהוה__ tu Elohim por la tierra buena que dio a ti.",
+          "tth": "Y comerás y te saciarás, y bendecirás a יהוה tu Elohim por la tierra buena que dio a ti.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "El peligro de olvidar a Elohim"
         },
         {
           "verse": 11,
-          "tth": "Guárdate, no sea que olvides a __יהוה__ tu Elohim para no guardar sus mandamientos, sus procesos legales y sus decretos, los cuales yo te ordeno hoy;",
+          "tth": "Guárdate, no sea que olvides a יהוה tu Elohim para no guardar sus mandamientos, sus procesos legales y sus decretos, los cuales yo te ordeno hoy;",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2128,7 +2128,7 @@
         },
         {
           "verse": 14,
-          "tth": "y se eleve tu corazón, y olvides a __יהוה__ tu Elohim que te hizo salir de la tierra de Mitzráim, de la casa de esclavos.",
+          "tth": "y se eleve tu corazón, y olvides a יהוה tu Elohim que te hizo salir de la tierra de Mitzráim, de la casa de esclavos.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2159,19 +2159,19 @@
         },
         {
           "verse": 18,
-          "tth": "Y recordarás a __יהוה__ tu Elohim, porque Él es el que te da fuerza para hacer virtud, a fin de establecer su pacto, el cual juró a tus padres, como este día.",
+          "tth": "Y recordarás a יהוה tu Elohim, porque Él es el que te da fuerza para hacer virtud, a fin de establecer su pacto, el cual juró a tus padres, como este día.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 19,
-          "tth": "Y sucederá <em>que</em> si, olvidando, olvidas a __יהוה__ tu Elohim, y andas tras de otros dioses y les sirves y te inclinas a ellos, testifico contra ustedes hoy que, pereciendo, perecerán.",
+          "tth": "Y sucederá <em>que</em> si, olvidando, olvidas a יהוה tu Elohim, y andas tras de otros dioses y les sirves y te inclinas a ellos, testifico contra ustedes hoy que, pereciendo, perecerán.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 20,
-          "tth": "Como las naciones que __יהוה__ hace perecer de delante de ustedes, así perecerán, en consecuencia de <em>que</em> no escucharon a la voz de __יהוה__ su Elohim.",
+          "tth": "Como las naciones que יהוה hace perecer de delante de ustedes, así perecerán, en consecuencia de <em>que</em> no escucharon a la voz de יהוה su Elohim.",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -2208,44 +2208,44 @@
         },
         {
           "verse": 3,
-          "tth": "Y conocerás hoy que __יהוה__ tu Elohim, es Él el que pasa delante de ti <em>como</em> fuego consumidor, Él los destruirá y Él los humillará delante de ti, y hará que los desposees y que los hagas perecer pronto, como habló __יהוה__ a ti.",
+          "tth": "Y conocerás hoy que יהוה tu Elohim, es Él el que pasa delante de ti <em>como</em> fuego consumidor, Él los destruirá y Él los humillará delante de ti, y hará que los desposees y que los hagas perecer pronto, como habló יהוה a ti.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 4,
-          "tth": "No digas en tu corazón cuando los empuje __יהוה__ tu Elohim de delante de ti, diciendo: “Por mi justicia me ha hecho entrar __יהוה__ para heredar esta tierra”, pero por la maldad de estas naciones __יהוה__ las desposee de delante de ti.",
+          "tth": "No digas en tu corazón cuando los empuje יהוה tu Elohim de delante de ti, diciendo: “Por mi justicia me ha hecho entrar יהוה para heredar esta tierra”, pero por la maldad de estas naciones יהוה las desposee de delante de ti.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 5,
-          "tth": "No por tu justicia y por la rectitud de tu corazón tú entrarás para heredar su tierra, porque por la maldad de estas naciones __יהוה__ tu Elohim los desposee de delante de ti, a fin de establecer la palabra que juró __יהוה__ a tus padres, a Abraham, a Itzjak y a Yaakov.",
+          "tth": "No por tu justicia y por la rectitud de tu corazón tú entrarás para heredar su tierra, porque por la maldad de estas naciones יהוה tu Elohim los desposee de delante de ti, a fin de establecer la palabra que juró יהוה a tus padres, a Abraham, a Itzjak y a Yaakov.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 6,
-          "tth": "Y sabrás que no por tu justicia __יהוה__ tu Elohim te da esta tierra buena para heredarla, pues un pueblo de duro cuello eres tú.",
+          "tth": "Y sabrás que no por tu justicia יהוה tu Elohim te da esta tierra buena para heredarla, pues un pueblo de duro cuello eres tú.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "La rebelión de Israel en Joreb"
         },
         {
           "verse": 7,
-          "tth": "Recuerda; no olvides que hiciste enojar a __יהוה__ tu Elohim en el desierto; desde el día que saliste de la tierra de Mitzráim hasta que llegaron hasta este lugar, amargos fueron con __יהוה__.",
+          "tth": "Recuerda; no olvides que hiciste enojar a יהוה tu Elohim en el desierto; desde el día que saliste de la tierra de Mitzráim hasta que llegaron hasta este lugar, amargos fueron con יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 8,
-          "tth": "Y en Joreb hicieron enfurecer a __יהוה__, y se enojó mucho __יהוה__ con ustedes para destruirlos.",
+          "tth": "Y en Joreb hicieron enfurecer a יהוה, y se enojó mucho יהוה con ustedes para destruirlos.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 9,
-          "tth": "Cuando subí al monte para tomar las tablas de piedra del pacto que hizo⁸⁷ __יהוה__ con ustedes, y permanecí en el monte cuarenta días y cuarenta noches; pan no comí y agua no bebí.",
+          "tth": "Cuando subí al monte para tomar las tablas de piedra del pacto que hizo⁸⁷ יהוה con ustedes, y permanecí en el monte cuarenta días y cuarenta noches; pan no comí y agua no bebí.",
           "footnotes": [
             {
               "marker": "⁸⁷",
@@ -2258,25 +2258,25 @@
         },
         {
           "verse": 10,
-          "tth": "Y me dio __יהוה__ las dos tablas de piedra escritas con el dedo de Elohim; y sobre ellas <em>estaban</em> conforme a todas las palabras que habló __יהוה__ con ustedes en el monte de en medio del fuego, en el día de la asamblea.",
+          "tth": "Y me dio יהוה las dos tablas de piedra escritas con el dedo de Elohim; y sobre ellas <em>estaban</em> conforme a todas las palabras que habló יהוה con ustedes en el monte de en medio del fuego, en el día de la asamblea.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 11,
-          "tth": "Y sucedió por el final de los cuarenta días y las cuarenta noches, me dio __יהוה__ las dos tablas de piedra, tablas del pacto.",
+          "tth": "Y sucedió por el final de los cuarenta días y las cuarenta noches, me dio יהוה las dos tablas de piedra, tablas del pacto.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 12,
-          "tth": "Y dijo __יהוה__ a mí: “Levántate; baja pronto de este <em>lugar</em>, porque se ha corrompido tu pueblo el cual hiciste salir de Mitzráim. Se desviaron rápido del camino que les ordené; se han hecho una imagen fundida”.",
+          "tth": "Y dijo יהוה a mí: “Levántate; baja pronto de este <em>lugar</em>, porque se ha corrompido tu pueblo el cual hiciste salir de Mitzráim. Se desviaron rápido del camino que les ordené; se han hecho una imagen fundida”.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 13,
-          "tth": "Y dijo __יהוה__ a mí, diciendo: “He visto a este pueblo, y he aquí, pueblo de duro cuello es este.",
+          "tth": "Y dijo יהוה a mí, diciendo: “He visto a este pueblo, y he aquí, pueblo de duro cuello es este.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2294,7 +2294,7 @@
         },
         {
           "verse": 16,
-          "tth": "Y miré, y he aquí, habían pecado ante __יהוה __su Elohim, habían hecho para ustedes un becerro de imagen fundida. Se desviaron rápido del camino que les había ordenado __יהוה__.",
+          "tth": "Y miré, y he aquí, habían pecado ante יהוהsu Elohim, habían hecho para ustedes un becerro de imagen fundida. Se desviaron rápido del camino que les había ordenado יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2306,13 +2306,13 @@
         },
         {
           "verse": 18,
-          "tth": "Y caí delante de __יהוה__ como <em>en</em> los primeros cuarenta días y cuarenta noches; pan no comí y agua no bebí, por todo su pecado que pecaron para hacer el mal en los ojos de __יהוה__, para generarle rechazo.",
+          "tth": "Y caí delante de יהוה como <em>en</em> los primeros cuarenta días y cuarenta noches; pan no comí y agua no bebí, por todo su pecado que pecaron para hacer el mal en los ojos de יהוה, para generarle rechazo.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 19,
-          "tth": "Porque temí a causa de la ira⁸⁸ y el calor <em>con</em> que estaba enojado __יהוה__ por ustedes para destruirlos; pero me escuchó __יהוה__ también en esta vez.",
+          "tth": "Porque temí a causa de la ira⁸⁸ y el calor <em>con</em> que estaba enojado יהוה por ustedes para destruirlos; pero me escuchó יהוה también en esta vez.",
           "footnotes": [
             {
               "marker": "⁸⁸",
@@ -2325,7 +2325,7 @@
         },
         {
           "verse": 20,
-          "tth": "Y con Aharón se enojó mucho __יהוה__ para destruirlo; y entré en juicio también a favor de Aharón en ese tiempo.",
+          "tth": "Y con Aharón se enojó mucho יהוה para destruirlo; y entré en juicio también a favor de Aharón en ese tiempo.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2343,25 +2343,25 @@
         },
         {
           "verse": 23,
-          "tth": "Y cuando los envió __יהוה__ desde Kádesh Barnea, diciendo: “Suban y vean la tierra que he dado a ustedes”, se amargaron con la boca de __יהוה__ su Elohim, y no fueron afirmados por Él, y no escucharon a su voz.",
+          "tth": "Y cuando los envió יהוה desde Kádesh Barnea, diciendo: “Suban y vean la tierra que he dado a ustedes”, se amargaron con la boca de יהוה su Elohim, y no fueron afirmados por Él, y no escucharon a su voz.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 24,
-          "tth": "Amargos fueron con __יהוה__ desde el día que los conocí.",
+          "tth": "Amargos fueron con יהוה desde el día que los conocí.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 25,
-          "tth": "Y caí delante de __יהוה__ los cuarenta días y cuarenta noches, que caí porque dijo __יהוה__: <em>Estoy</em> por destruirlos.",
+          "tth": "Y caí delante de יהוה los cuarenta días y cuarenta noches, que caí porque dijo יהוה: <em>Estoy</em> por destruirlos.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 26,
-          "tth": "Y entré en juicio hacia __יהוה__, y dije: “Adonai __יהוה__, no destruyas tu pueblo y tu herencia, que has redimido con tu grandeza, que has hecho salir de Mitzráim con mano fuerte.",
+          "tth": "Y entré en juicio hacia יהוה, y dije: “Adonai יהוה, no destruyas tu pueblo y tu herencia, que has redimido con tu grandeza, que has hecho salir de Mitzráim con mano fuerte.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2373,7 +2373,7 @@
         },
         {
           "verse": 28,
-          "tth": "No sea que digan <em>los de</em> la tierra que nos sacaste de allí: ‘Debido a que no fue capaz __יהוה__ de hacerlos entrar a la tierra que habló a ellos, y debido a que los odió, los ha sacado para hacerlos morir en el desierto’.",
+          "tth": "No sea que digan <em>los de</em> la tierra que nos sacaste de allí: ‘Debido a que no fue capaz יהוה de hacerlos entrar a la tierra que habló a ellos, y debido a que los odió, los ha sacado para hacerlos morir en el desierto’.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2391,7 +2391,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "En aquel tiempo dijo __יהוה__ a mí: “Esculpe para ti dos tablas de piedra como las primeras, y sube a Mí al monte, y haz para ti un arca de madera.",
+          "tth": "En aquel tiempo dijo יהוה a mí: “Esculpe para ti dos tablas de piedra como las primeras, y sube a Mí al monte, y haz para ti un arca de madera.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2409,13 +2409,13 @@
         },
         {
           "verse": 4,
-          "tth": "Y Él escribió sobre las tablas, como la escritura primera, las diez palabras que había hablado __יהוה__ a ustedes en el monte, de en medio del fuego, en el día de la asamblea; y las dio __יהוה__ a mí.",
+          "tth": "Y Él escribió sobre las tablas, como la escritura primera, las diez palabras que había hablado יהוה a ustedes en el monte, de en medio del fuego, en el día de la asamblea; y las dio יהוה a mí.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 5,
-          "tth": "Y me giré y descendí del monte, y puse las tablas en el arca que yo había hecho; y están allí, como me ordenó __יהוה__.",
+          "tth": "Y me giré y descendí del monte, y puse las tablas en el arca que yo había hecho; y están allí, como me ordenó יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2440,50 +2440,50 @@
         },
         {
           "verse": 8,
-          "tth": "En ese tiempo separó __יהוה__ a la tribu de Levi para llevar el arca del Pacto de __יהוה__, para pararse delante de __יהוה__, para ministrarle y para bendecir su Nombre hasta este día.",
+          "tth": "En ese tiempo separó יהוה a la tribu de Levi para llevar el arca del Pacto de יהוה, para pararse delante de יהוה, para ministrarle y para bendecir su Nombre hasta este día.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 9,
-          "tth": "Por eso, no hay para Levi porción y herencia con sus hermanos; __יהוה__, Él es su herencia, como le habló __יהוה__ tu Elohim.",
+          "tth": "Por eso, no hay para Levi porción y herencia con sus hermanos; יהוה, Él es su herencia, como le habló יהוה tu Elohim.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 10,
-          "tth": "Y yo me quedé en el monte como los primeros días, cuarenta días y cuarenta noches, y me escuchó __יהוה__ también en esta vez; no quiso __יהוה__ destruirte.",
+          "tth": "Y yo me quedé en el monte como los primeros días, cuarenta días y cuarenta noches, y me escuchó יהוה también en esta vez; no quiso יהוה destruirte.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 11,
-          "tth": "Y dijo __יהוה__ a mí: “Levántate, ve por el viaje delante del pueblo, y entrarán y heredarán la tierra que juré a sus padres para dar a ellos”.",
+          "tth": "Y dijo יהוה a mí: “Levántate, ve por el viaje delante del pueblo, y entrarán y heredarán la tierra que juré a sus padres para dar a ellos”.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Lo que pide Elohim de Israel"
         },
         {
           "verse": 12,
-          "tth": "Y ahora, Israel, ¿qué pide __יהוה__ tu Elohim de ti, sino que temas a __יהוה__ tu Elohim, para andar en todos sus caminos, para amarlo y para servir a __יהוה__ tu Elohim con todo tu corazón y con todo tu ser,",
+          "tth": "Y ahora, Israel, ¿qué pide יהוה tu Elohim de ti, sino que temas a יהוה tu Elohim, para andar en todos sus caminos, para amarlo y para servir a יהוה tu Elohim con todo tu corazón y con todo tu ser,",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 13,
-          "tth": "para guardar los mandamientos de __יהוה__ y sus decretos que yo te ordeno hoy para el bien tuyo?",
+          "tth": "para guardar los mandamientos de יהוה y sus decretos que yo te ordeno hoy para el bien tuyo?",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 14,
-          "tth": "He aquí, para __יהוה__ tu Elohim <em>son</em> los cielos y los cielos de los cielos, la tierra y todo lo que <em>hay</em> en ella.",
+          "tth": "He aquí, para יהוה tu Elohim <em>son</em> los cielos y los cielos de los cielos, la tierra y todo lo que <em>hay</em> en ella.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 15,
-          "tth": "Solamente a tus padres deseó __יהוה__ para amarlos, y escogió a su simiente después de ellos, a ustedes, de <em>entre</em> todos los pueblos, como este día.",
+          "tth": "Solamente a tus padres deseó יהוה para amarlos, y escogió a su simiente después de ellos, a ustedes, de <em>entre</em> todos los pueblos, como este día.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2495,7 +2495,7 @@
         },
         {
           "verse": 17,
-          "tth": "Porque __יהוה__ su Elohim, Él es Elohim de dioses y Amo de amos, El⁹⁰ grande, fuerte y temible, que no levanta rostros⁹¹ y no toma soborno.",
+          "tth": "Porque יהוה su Elohim, Él es Elohim de dioses y Amo de amos, El⁹⁰ grande, fuerte y temible, que no levanta rostros⁹¹ y no toma soborno.",
           "footnotes": [
             {
               "marker": "⁹⁰",
@@ -2526,7 +2526,7 @@
         },
         {
           "verse": 20,
-          "tth": "A __יהוה__ tu Elohim temerás; a Él servirás, en Él te unirás y en su Nombre jurarás.",
+          "tth": "A יהוה tu Elohim temerás; a Él servirás, en Él te unirás y en su Nombre jurarás.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2538,7 +2538,7 @@
         },
         {
           "verse": 22,
-          "tth": "Con setenta personas descendieron tus padres a Mitzráim, y ahora te ha puesto __יהוה__ tu Elohim como las estrellas de los cielos, por multitud.",
+          "tth": "Con setenta personas descendieron tus padres a Mitzráim, y ahora te ha puesto יהוה tu Elohim como las estrellas de los cielos, por multitud.",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -2549,7 +2549,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y amarás a __יהוה__ tu Elohim, y guardarás su guardia, sus decretos⁹², sus procesos legales⁹³ y sus mandamientos⁹⁴ todos los días.",
+          "tth": "Y amarás a יהוה tu Elohim, y guardarás su guardia, sus decretos⁹², sus procesos legales⁹³ y sus mandamientos⁹⁴ todos los días.",
           "footnotes": [
             {
               "marker": "⁹²",
@@ -2574,7 +2574,7 @@
         },
         {
           "verse": 2,
-          "tth": "Y conocerás hoy que no <em>es</em> con sus hijos, quienes no han conocido y quienes no han visto la disciplina⁹⁵ de __יהוה__ su Elohim, su grandeza, y su mano fuerte y su brazo extendido,",
+          "tth": "Y conocerás hoy que no <em>es</em> con sus hijos, quienes no han conocido y quienes no han visto la disciplina⁹⁵ de יהוה su Elohim, su grandeza, y su mano fuerte y su brazo extendido,",
           "footnotes": [
             {
               "marker": "⁹⁵",
@@ -2593,7 +2593,7 @@
         },
         {
           "verse": 4,
-          "tth": "y lo que hizo a la fuerza de Mitzráim, a sus caballos y a sus carros, quien hizo flotar las aguas del mar de Cañas⁹⁶ sobre sus rostros cuando perseguían tras ustedes, y los destruyó __יהוה__ hasta este día;",
+          "tth": "y lo que hizo a la fuerza de Mitzráim, a sus caballos y a sus carros, quien hizo flotar las aguas del mar de Cañas⁹⁶ sobre sus rostros cuando perseguían tras ustedes, y los destruyó יהוה hasta este día;",
           "footnotes": [
             {
               "marker": "⁹⁶",
@@ -2618,7 +2618,7 @@
         },
         {
           "verse": 7,
-          "tth": "Pero sus ojos han visto toda la gran obra de __יהוה__, la cual hizo.",
+          "tth": "Pero sus ojos han visto toda la gran obra de יהוה, la cual hizo.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Obediencia y recompensa"
@@ -2631,7 +2631,7 @@
         },
         {
           "verse": 9,
-          "tth": "a fin de que se hagan largos <em>sus</em> días sobre la tierra que juró __יהוה__ a sus padres para dar a ellos y a su simiente, una tierra <em>que</em> fluye leche y miel.",
+          "tth": "a fin de que se hagan largos <em>sus</em> días sobre la tierra que juró יהוה a sus padres para dar a ellos y a su simiente, una tierra <em>que</em> fluye leche y miel.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2649,13 +2649,13 @@
         },
         {
           "verse": 12,
-          "tth": "una tierra la cual __יהוה__ tu Elohim busca; siempre los ojos de __יהוה__ tu Elohim <em>están</em> en ella, desde el principio del año y hasta el final del año.",
+          "tth": "una tierra la cual יהוה tu Elohim busca; siempre los ojos de יהוה tu Elohim <em>están</em> en ella, desde el principio del año y hasta el final del año.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 13,
-          "tth": "Y sucederá <em>que</em> si escuchando, escuchan a mis mandamientos que yo les ordeno hoy, para amar a __יהוה__ su Elohim y para servirle con todo su corazón y con todo su ser,",
+          "tth": "Y sucederá <em>que</em> si escuchando, escuchan a mis mandamientos que yo les ordeno hoy, para amar a יהוה su Elohim y para servirle con todo su corazón y con todo su ser,",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2699,7 +2699,7 @@
         },
         {
           "verse": 17,
-          "tth": "Y se encienda la ira de __יהוה__ contra ustedes y retenga los cielos y no haya lluvia y la tierra no dé su producto, y perecerán rápido de sobre la tierra buena que __יהוה__ da a ustedes.",
+          "tth": "Y se encienda la ira de יהוה contra ustedes y retenga los cielos y no haya lluvia y la tierra no dé su producto, y perecerán rápido de sobre la tierra buena que יהוה da a ustedes.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2723,19 +2723,19 @@
         },
         {
           "verse": 21,
-          "tth": "a fin de que se multipliquen sus días y los días de sus hijos sobre la tierra que juró __יהוה__ a sus padres para dar a ellos, como los días de los cielos sobre la tierra.",
+          "tth": "a fin de que se multipliquen sus días y los días de sus hijos sobre la tierra que juró יהוה a sus padres para dar a ellos, como los días de los cielos sobre la tierra.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 22,
-          "tth": "Porque, si guardando, guardan este mandamiento que yo les ordeno para hacerlo, para amar a __יהוה__ su Elohim, para andar en todos sus caminos, y para unirse a Él,",
+          "tth": "Porque, si guardando, guardan este mandamiento que yo les ordeno para hacerlo, para amar a יהוה su Elohim, para andar en todos sus caminos, y para unirse a Él,",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 23,
-          "tth": "desposeerá __יהוה__ a todas las naciones estas de delante de ustedes, y desposeerán <em>a</em> las naciones <em>más</em> grandes y numerosas que ustedes.",
+          "tth": "desposeerá יהוה a todas las naciones estas de delante de ustedes, y desposeerán <em>a</em> las naciones <em>más</em> grandes y numerosas que ustedes.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2747,7 +2747,7 @@
         },
         {
           "verse": 25,
-          "tth": "No se afirmará hombre contra los rostros de ustedes; su temor y su terror pondrá __יהוה__ su Elohim sobre la faz de toda la tierra que pisarán en ella, conforme ha hablado a ustedes.",
+          "tth": "No se afirmará hombre contra los rostros de ustedes; su temor y su terror pondrá יהוה su Elohim sobre la faz de toda la tierra que pisarán en ella, conforme ha hablado a ustedes.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2759,19 +2759,19 @@
         },
         {
           "verse": 27,
-          "tth": "la bendición, que escuchen los mandamientos de __יהוה__ su Elohim, los cuales yo les ordeno hoy,",
+          "tth": "la bendición, que escuchen los mandamientos de יהוה su Elohim, los cuales yo les ordeno hoy,",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 28,
-          "tth": "y la maldición, si no escuchan a los mandamientos de __יהוה__ su Elohim, y se desvían del camino que yo les ordeno hoy, para andar tras de otros dioses que no conocieron.",
+          "tth": "y la maldición, si no escuchan a los mandamientos de יהוה su Elohim, y se desvían del camino que yo les ordeno hoy, para andar tras de otros dioses que no conocieron.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 29,
-          "tth": "Y sucederá, cuando te haya traído __יהוה__ tu Elohim a la tierra que tú entrarás allí para heredarla, pondrás la bendición¹⁰⁰ sobre el monte Gerizim, y el desprecio¹⁰¹ sobre el monte Ebal.",
+          "tth": "Y sucederá, cuando te haya traído יהוה tu Elohim a la tierra que tú entrarás allí para heredarla, pondrás la bendición¹⁰⁰ sobre el monte Gerizim, y el desprecio¹⁰¹ sobre el monte Ebal.",
           "footnotes": [
             {
               "marker": "¹⁰⁰",
@@ -2803,7 +2803,7 @@
         },
         {
           "verse": 31,
-          "tth": "Porque ustedes cruzarán el Iardén para entrar a heredar la tierra que __יהוה__ su Elohim da a ustedes, y la heredarán y habitarán en ella.",
+          "tth": "Porque ustedes cruzarán el Iardén para entrar a heredar la tierra que יהוה su Elohim da a ustedes, y la heredarán y habitarán en ella.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2821,7 +2821,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Estos son los decretos¹⁰³ y los procesos legales¹⁰⁴ que guardarán para hacer en la tierra que <em>te</em> da __יהוה__, Elohim de tus padres, a ti para poseerla todos los días que ustedes vivirán sobre la tierra.",
+          "tth": "Estos son los decretos¹⁰³ y los procesos legales¹⁰⁴ que guardarán para hacer en la tierra que <em>te</em> da יהוה, Elohim de tus padres, a ti para poseerla todos los días que ustedes vivirán sobre la tierra.",
           "footnotes": [
             {
               "marker": "¹⁰³",
@@ -2859,7 +2859,7 @@
         },
         {
           "verse": 4,
-          "tth": "No harán así a __יהוה__ su Elohim,",
+          "tth": "No harán así a יהוה su Elohim,",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3518,7 +3518,7 @@
         },
         {
           "verse": 21,
-          "tth": "No comerán cualquier cadáver. Al extranjero que <em>está</em> en tus puertas podrás darlo, y lo coma, o puedes venderlo a un extraño, porque pueblo kadosh eres tú para __יהוה__ tu Elohim. No cocinarás un cabrito en la leche de su <em>propia</em> madre.",
+          "tth": "No comerán cualquier cadáver. Al extranjero que <em>está</em> en tus puertas podrás darlo, y lo coma, o puedes venderlo a un extraño, porque pueblo kadosh eres tú para יהוה tu Elohim. No cocinarás un cabrito en la leche de su <em>propia</em> madre.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Sobre el décimo"
@@ -3531,7 +3531,7 @@
         },
         {
           "verse": 23,
-          "tth": "Y comerás delante de __יהוה__ tu Elohim, en el lugar que escogerá para morar su Nombre allí, del décimo de tu grano, <em>de</em> tu mosto, <em>de</em> tu aceite fresco, y <em>de</em> las primogenituras de tu ganado y tu rebaño, a fin de que aprendas a temer a __יהוה__ tu Elohim todos los días.",
+          "tth": "Y comerás delante de יהוה tu Elohim, en el lugar que escogerá para morar su Nombre allí, del décimo de tu grano, <em>de</em> tu mosto, <em>de</em> tu aceite fresco, y <em>de</em> las primogenituras de tu ganado y tu rebaño, a fin de que aprendas a temer a יהוה tu Elohim todos los días.",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/hoshea.json
+++ b/data/tth_2/json/hoshea.json
@@ -2637,7 +2637,7 @@
         },
         {
           "verse": 1,
-          "tth": "fue su herencia, conforme había ordenado __יהוה__, por mano de Moshéh, a las nueve tribus y a la media tribu.",
+          "tth": "fue su herencia, conforme había ordenado יהוה, por mano de Moshéh, a las nueve tribus y a la media tribu.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2662,38 +2662,38 @@
         },
         {
           "verse": 5,
-          "tth": "Como había ordenado __יהוה__ a Moshéh, así hicieron los hijos de Israel, y repartieron la tierra.",
+          "tth": "Como había ordenado יהוה a Moshéh, así hicieron los hijos de Israel, y repartieron la tierra.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "La herencia de Caleb"
         },
         {
           "verse": 6,
-          "tth": "Y se acercaron los hijos de Iehudáh a Yehoshúa en Gilgal, y le dijo Caleb, hijo de Iefunéh el kenizí: Tú conoces la palabra que habló __יהוה__ a Moshéh, hombre del Elohim, sobre mi causa y sobre tu causa en Kádesh Barnea.",
+          "tth": "Y se acercaron los hijos de Iehudáh a Yehoshúa en Gilgal, y le dijo Caleb, hijo de Iefunéh el kenizí: Tú conoces la palabra que habló יהוה a Moshéh, hombre del Elohim, sobre mi causa y sobre tu causa en Kádesh Barnea.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 7,
-          "tth": "Edad de cuarenta años <em>tenía</em> yo cuando me envió Moshéh, siervo de __יהוה,__ desde Kádesh Barnea a explorar la tierra, y regresé a él palabra conforme con mi corazón.",
+          "tth": "Edad de cuarenta años <em>tenía</em> yo cuando me envió Moshéh, siervo de יהוה, desde Kádesh Barnea a explorar la tierra, y regresé a él palabra conforme con mi corazón.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 8,
-          "tth": "Pero mis hermanos que subieron conmigo, hicieron derretir el corazón del pueblo, pero yo fui completo tras de __יהוה__ mi Elohim.",
+          "tth": "Pero mis hermanos que subieron conmigo, hicieron derretir el corazón del pueblo, pero yo fui completo tras de יהוה mi Elohim.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 9,
-          "tth": "Y juró Moshéh en aquel día, diciendo: “¡Si no <em>fuera</em> la tierra, que ha pisado tu pie en ella, para ti por herencia y para tus hijos hasta siempre! Porque fuiste completo tras de __יהוה__ mi Elohim”.",
+          "tth": "Y juró Moshéh en aquel día, diciendo: “¡Si no <em>fuera</em> la tierra, que ha pisado tu pie en ella, para ti por herencia y para tus hijos hasta siempre! Porque fuiste completo tras de יהוה mi Elohim”.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 10,
-          "tth": "Y ahora, he aquí, me hizo vivir __יהוה__, como habló, estos cuarenta y cinco años, desde entonces <em>que</em> habló __יהוה__ esta palabra a Moshéh, cuando caminaba Israel por el desierto; y ahora, he aquí, yo <em>tengo</em> hoy edad de ochenta y cinco años.",
+          "tth": "Y ahora, he aquí, me hizo vivir יהוה, como habló, estos cuarenta y cinco años, desde entonces <em>que</em> habló יהוה esta palabra a Moshéh, cuando caminaba Israel por el desierto; y ahora, he aquí, yo <em>tengo</em> hoy edad de ochenta y cinco años.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2705,7 +2705,7 @@
         },
         {
           "verse": 12,
-          "tth": "Y ahora, da a mí este monte que habló __יהוה__ en ese día, porque tú escuchaste en ese día que <em>había</em> anakim allí, y ciudades grandes fortificadas; quizá __יהוה__ <em>esté</em> conmigo y los desposeeré como ha hablado __יהוה__.",
+          "tth": "Y ahora, da a mí este monte que habló יהוה en ese día, porque tú escuchaste en ese día que <em>había</em> anakim allí, y ciudades grandes fortificadas; quizá יהוה <em>esté</em> conmigo y los desposeeré como ha hablado יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2717,7 +2717,7 @@
         },
         {
           "verse": 14,
-          "tth": "Por eso, fue Jebrón para Caleb, hijo de Iefunéh el kenizí, por herencia hasta este día, porque fue completo tras de __יהוה__, Elohim de Israel.",
+          "tth": "Por eso, fue Jebrón para Caleb, hijo de Iefunéh el kenizí, por herencia hasta este día, porque fue completo tras de יהוה, Elohim de Israel.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2854,7 +2854,7 @@
         },
         {
           "verse": 13,
-          "tth": "Y a Caleb, hijo de Iefunéh, dio una porción entre los hijos de Iehudáh, por boca de __יהוה__ a Yehoshúa, <em>dio</em> Kiriat Arba, <em>Arba era</em> padre de Anak, esta es Jebrón.",
+          "tth": "Y a Caleb, hijo de Iefunéh, dio una porción entre los hijos de Iehudáh, por boca de יהוה a Yehoshúa, <em>dio</em> Kiriat Arba, <em>Arba era</em> padre de Anak, esta es Jebrón.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3292,7 +3292,7 @@
         },
         {
           "verse": 4,
-          "tth": "Y ellas se acercaron delante de Eleazar el sacerdote y delante de Yehoshúa, hijo de Nun, y delante de los jefes, diciendo: __יהוה__ ha ordenado a Moshéh para dar a nosotras una herencia entre nuestros hermanos. Y les dio por boca de __יהוה__ una herencia entre los hermanos de su padre.",
+          "tth": "Y ellas se acercaron delante de Eleazar el sacerdote y delante de Yehoshúa, hijo de Nun, y delante de los jefes, diciendo: יהוה ha ordenado a Moshéh para dar a nosotras una herencia entre nuestros hermanos. Y les dio por boca de יהוה una herencia entre los hermanos de su padre.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3359,7 +3359,7 @@
         },
         {
           "verse": 14,
-          "tth": "Y hablaron los hijos de Iosef a Yehoshúa, diciendo: ¿Por qué has dado a mí <em>por</em> herencia un <em>solo</em> goral⁹⁸ y una <em>sola</em> porción, y yo <em>soy</em> un pueblo numeroso, incluso que hasta aquí me ha bendecido __יהוה__?",
+          "tth": "Y hablaron los hijos de Iosef a Yehoshúa, diciendo: ¿Por qué has dado a mí <em>por</em> herencia un <em>solo</em> goral⁹⁸ y una <em>sola</em> porción, y yo <em>soy</em> un pueblo numeroso, incluso que hasta aquí me ha bendecido יהוה?",
           "footnotes": [
             {
               "marker": "⁹⁸",
@@ -3428,7 +3428,7 @@
         },
         {
           "verse": 3,
-          "tth": "Y dijo Yehoshúa a los hijos de Israel: ¿Hasta cuándo¹⁰¹ ustedes se mostrarán flojos para entrar a poseer la tierra que dio a ustedes __יהוה__, Elohim de sus padres?",
+          "tth": "Y dijo Yehoshúa a los hijos de Israel: ¿Hasta cuándo¹⁰¹ ustedes se mostrarán flojos para entrar a poseer la tierra que dio a ustedes יהוה, Elohim de sus padres?",
           "footnotes": [
             {
               "marker": "¹⁰¹",
@@ -3453,7 +3453,7 @@
         },
         {
           "verse": 6,
-          "tth": "Y ustedes escribirán la tierra <em>en</em> siete partes, y traerán a mí <em>la escritura</em> aquí. Y lanzaré para ustedes un goral¹⁰² aquí delante de __יהוה__ nuestro Elohim.",
+          "tth": "Y ustedes escribirán la tierra <em>en</em> siete partes, y traerán a mí <em>la escritura</em> aquí. Y lanzaré para ustedes un goral¹⁰² aquí delante de יהוה nuestro Elohim.",
           "footnotes": [
             {
               "marker": "¹⁰²",
@@ -3466,7 +3466,7 @@
         },
         {
           "verse": 7,
-          "tth": "Pero no hay parte para los leviím¹⁰³ en medio de ustedes, porque el sacerdocio de __יהוה__ es su herencia. Y Gad y Reubén, y la media tribu de Menasheh, tomaron su herencia del <em>otro</em> lado del Iardén, hacia el amanecer, la cual dio a ellos Moshéh, siervo de __יהוה__.",
+          "tth": "Pero no hay parte para los leviím¹⁰³ en medio de ustedes, porque el sacerdocio de יהוה es su herencia. Y Gad y Reubén, y la media tribu de Menasheh, tomaron su herencia del <em>otro</em> lado del Iardén, hacia el amanecer, la cual dio a ellos Moshéh, siervo de יהוה.",
           "footnotes": [
             {
               "marker": "¹⁰³",
@@ -3479,7 +3479,7 @@
         },
         {
           "verse": 8,
-          "tth": "Y se levantaron los hombres y se fueron, y ordenó Yehoshúa a los que fueron a escribir la tierra, diciendo: Vayan y caminen por la tierra, y escríbanla y vuelvan a mí; y aquí lanzaré para ustedes un goral delante de __יהוה__ en Shiloh.",
+          "tth": "Y se levantaron los hombres y se fueron, y ordenó Yehoshúa a los que fueron a escribir la tierra, diciendo: Vayan y caminen por la tierra, y escríbanla y vuelvan a mí; y aquí lanzaré para ustedes un goral delante de יהוה en Shiloh.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3491,7 +3491,7 @@
         },
         {
           "verse": 10,
-          "tth": "Y lanzó para ellos Yehoshúa un goral en Shiloh delante de __יהוה__, y repartió allí Yehoshúa la tierra a los hijos de Israel, conforme a sus divisiones.",
+          "tth": "Y lanzó para ellos Yehoshúa un goral en Shiloh delante de יהוה, y repartió allí Yehoshúa la tierra a los hijos de Israel, conforme a sus divisiones.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3950,13 +3950,13 @@
         },
         {
           "verse": 50,
-          "tth": "Por boca de __יהוה__, le dieron la ciudad que él pidió, Timnat Seraj, en el monte de Efráim. Y el construyó la ciudad y habitó en ella.",
+          "tth": "Por boca de יהוה, le dieron la ciudad que él pidió, Timnat Seraj, en el monte de Efráim. Y el construyó la ciudad y habitó en ella.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 51,
-          "tth": "Estas son las herencias que dividieron en posesión Eleazar el sacerdote, Yehoshúa, hijo de Nun, y las cabezas de los padres de las tribus de los hijos de Israel, por goral, en Shiloh, delante de __יהוה__, en la entrada de la Tienda del Mo’ed¹¹⁰. Y terminaron de repartir la tierra.",
+          "tth": "Estas son las herencias que dividieron en posesión Eleazar el sacerdote, Yehoshúa, hijo de Nun, y las cabezas de los padres de las tribus de los hijos de Israel, por goral, en Shiloh, delante de יהוה, en la entrada de la Tienda del Mo’ed¹¹⁰. Y terminaron de repartir la tierra.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Las ciudades de refugio"
@@ -3968,7 +3968,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y habló __יהוה__ a Yehoshúa, diciendo:",
+          "tth": "Y habló יהוה a Yehoshúa, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4048,13 +4048,13 @@
         },
         {
           "verse": 2,
-          "tth": "y hablaron a ellos en Shiloh en la tierra de Kenáan, diciendo: __יהוה__ mandó por mano de Moshéh a dar a nosotros ciudades para habitar, y sus tierra exteriores para nuestras bestias.",
+          "tth": "y hablaron a ellos en Shiloh en la tierra de Kenáan, diciendo: יהוה mandó por mano de Moshéh a dar a nosotros ciudades para habitar, y sus tierra exteriores para nuestras bestias.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 3,
-          "tth": "Y dieron los hijos de Israel a los leviím de su herencia, por boca de __יהוה__, estas ciudades y sus tierras exteriores.",
+          "tth": "Y dieron los hijos de Israel a los leviím de su herencia, por boca de יהוה, estas ciudades y sus tierras exteriores.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4103,7 +4103,7 @@
         },
         {
           "verse": 8,
-          "tth": "Y dieron los hijos de Israel a los leviím estas ciudades y sus tierras exteriores, como ordenó __יהוה__ por mano de Moshéh, por goral.",
+          "tth": "Y dieron los hijos de Israel a los leviím estas ciudades y sus tierras exteriores, como ordenó יהוה por mano de Moshéh, por goral.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4327,19 +4327,19 @@
         },
         {
           "verse": 43,
-          "tth": "Y dio __יהוה__ a Israel toda la tierra que había jurado dar a sus padres, y la heredaron y habitaron en ella.",
+          "tth": "Y dio יהוה a Israel toda la tierra que había jurado dar a sus padres, y la heredaron y habitaron en ella.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 44,
-          "tth": "Y les hizo descansar __יהוה__ de alrededor, conforme a todo lo que juró a sus padres; y no se afirmó hombre contra sus rostros de <em>entre</em> todos sus enemigos; a todos sus enemigos dio __יהוה__ en su mano.",
+          "tth": "Y les hizo descansar יהוה de alrededor, conforme a todo lo que juró a sus padres; y no se afirmó hombre contra sus rostros de <em>entre</em> todos sus enemigos; a todos sus enemigos dio יהוה en su mano.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 45,
-          "tth": "No cayó una palabra de toda la cosa buena que había hablado __יהוה__ a la casa de Israel; todas vinieron <em>a pasar</em>.",
+          "tth": "No cayó una palabra de toda la cosa buena que había hablado יהוה a la casa de Israel; todas vinieron <em>a pasar</em>.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Retorno de las tribus del otro lado del Iardén"
@@ -4370,19 +4370,19 @@
         },
         {
           "verse": 2,
-          "tth": "y les dijo: Ustedes guardaron todo lo que les había ordenado Moshéh, siervo de __יהוה__, y escucharon a la voz de todo lo que les ordené.",
+          "tth": "y les dijo: Ustedes guardaron todo lo que les había ordenado Moshéh, siervo de יהוה, y escucharon a la voz de todo lo que les ordené.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 3,
-          "tth": "No abandonaron a sus hermanos <em>por</em> estos muchos días hasta este día, y han guardado la guardia del mandamiento de __יהוה__ su Elohim.",
+          "tth": "No abandonaron a sus hermanos <em>por</em> estos muchos días hasta este día, y han guardado la guardia del mandamiento de יהוה su Elohim.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 4,
-          "tth": "Y ahora, ha hecho descansar __יהוה__ su Elohim a sus hermanos, como había hablado a ellos; y ahora, giren y vayan para ustedes a sus tiendas, a la tierra de su propiedad, la cual dio a ustedes Moshéh, siervo de __יהוה__, en el <em>otro</em> lado del Iardén¹²⁰.",
+          "tth": "Y ahora, ha hecho descansar יהוה su Elohim a sus hermanos, como había hablado a ellos; y ahora, giren y vayan para ustedes a sus tiendas, a la tierra de su propiedad, la cual dio a ustedes Moshéh, siervo de יהוה, en el <em>otro</em> lado del Iardén¹²⁰.",
           "footnotes": [
             {
               "marker": "¹²⁰",
@@ -4395,7 +4395,7 @@
         },
         {
           "verse": 5,
-          "tth": "Sólo, guarden mucho para hacer el mandamiento y la Torah que les ordenó Moshéh, siervo de __יהוה__, para amar a __יהוה__ su Elohim, y para caminar en todos sus caminos, y para guardar sus mandamientos, y para aferrarse a Él, y para servirle con todo su corazón y con todo su ser.",
+          "tth": "Sólo, guarden mucho para hacer el mandamiento y la Torah que les ordenó Moshéh, siervo de יהוה, para amar a יהוה su Elohim, y para caminar en todos sus caminos, y para guardar sus mandamientos, y para aferrarse a Él, y para servirle con todo su corazón y con todo su ser.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4419,7 +4419,7 @@
         },
         {
           "verse": 9,
-          "tth": "Y regresaron y se fueron los hijos de Reubén, los hijos de Gad y la media tribu de Menasheh, de los hijos de Israel, de Shiloh, que <em>está</em> en la tierra de Kenáan, para ir a la tierra de Guilad, a la tierra de su propiedad que habían tomado posesión en ella por boca de __יהוה__, por mano de Moshéh.",
+          "tth": "Y regresaron y se fueron los hijos de Reubén, los hijos de Gad y la media tribu de Menasheh, de los hijos de Israel, de Shiloh, que <em>está</em> en la tierra de Kenáan, para ir a la tierra de Guilad, a la tierra de su propiedad que habían tomado posesión en ella por boca de יהוה, por mano de Moshéh.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "El altar junto al Iardén"
@@ -4469,13 +4469,13 @@
         },
         {
           "verse": 16,
-          "tth": "Así dice toda la congregación de __יהוה__: “¿Qué es esta infidelidad, que han sido infieles con el Elohim de Israel, para regresar hoy de detrás de __יהוה,__ en que construyeron para ustedes un altar para rebelarse hoy contra __יהוה__?",
+          "tth": "Así dice toda la congregación de יהוה: “¿Qué es esta infidelidad, que han sido infieles con el Elohim de Israel, para regresar hoy de detrás de יהוה, en que construyeron para ustedes un altar para rebelarse hoy contra יהוה?",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 17,
-          "tth": "¿Es poca para nosotros la iniquidad de Peor, la cual no estamos puros de ella hasta este día, y sucedió la plaga¹²² (Lit.: golpe) en la congregación de __יהוה__?,",
+          "tth": "¿Es poca para nosotros la iniquidad de Peor, la cual no estamos puros de ella hasta este día, y sucedió la plaga¹²² (Lit.: golpe) en la congregación de יהוה?,",
           "footnotes": [
             {
               "marker": "¹²²",
@@ -4488,13 +4488,13 @@
         },
         {
           "verse": 18,
-          "tth": "pero ustedes regresaron hoy de detrás de __יהוה__. ¡Y sucederá <em>que</em> ustedes son rebeldes hoy contra __יהוה__, y mañana con toda la congregación de Israel se enfurecerá!",
+          "tth": "pero ustedes regresaron hoy de detrás de יהוה. ¡Y sucederá <em>que</em> ustedes son rebeldes hoy contra יהוה, y mañana con toda la congregación de Israel se enfurecerá!",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 19,
-          "tth": "Pero si es impura la tierra de su propiedad, crucen para ustedes a la tierra de la propiedad de __יהוה__, que mora allí el Mishkán¹²³, y tomen posesión en medio de nosotros. Pero contra __יהוה__ no se rebelen, y con nosotros no se rebelen edificando para ustedes un altar aparte del altar de __יהוה__ nuestro Elohim.",
+          "tth": "Pero si es impura la tierra de su propiedad, crucen para ustedes a la tierra de la propiedad de יהוה, que mora allí el Mishkán¹²³, y tomen posesión en medio de nosotros. Pero contra יהוה no se rebelen, y con nosotros no se rebelen edificando para ustedes un altar aparte del altar de יהוה nuestro Elohim.",
           "footnotes": [
             {
               "marker": "¹²³",
@@ -4519,7 +4519,7 @@
         },
         {
           "verse": 22,
-          "tth": "¡El Elohim¹²⁴, __יהוה__, El Elohim, __יהוה__! Él sabe; e Israel, él sabrá. Si <em>fue</em> con rebelión y si <em>fue</em> con infidelidad contra __יהוה__, no nos salves este día.",
+          "tth": "¡El Elohim¹²⁴, יהוה, El Elohim, יהוה! Él sabe; e Israel, él sabrá. Si <em>fue</em> con rebelión y si <em>fue</em> con infidelidad contra יהוה, no nos salves este día.",
           "footnotes": [
             {
               "marker": "¹²⁴",
@@ -4532,7 +4532,7 @@
         },
         {
           "verse": 23,
-          "tth": "<em>Si</em> construimos para nosotros un altar para regresar de detrás de __יהוה__, y si para hacer subir sobre él ofrenda ascendida¹²⁵ y ofrenda de grano¹²⁶, y si para hacer sobre él sacrificios de retribución, __יהוה__, Él demandará.",
+          "tth": "<em>Si</em> construimos para nosotros un altar para regresar de detrás de יהוה, y si para hacer subir sobre él ofrenda ascendida¹²⁵ y ofrenda de grano¹²⁶, y si para hacer sobre él sacrificios de retribución, יהוה, Él demandará.",
           "footnotes": [
             {
               "marker": "¹²⁵",
@@ -4551,13 +4551,13 @@
         },
         {
           "verse": 24,
-          "tth": "Pero si no, por preocupación de un asunto hemos hecho esto, diciendo: “Mañana dirán sus hijos a nuestros hijos, diciendo: ‘¿Qué <em>hay</em> para ustedes y para __יהוה__, Elohim de Israel?",
+          "tth": "Pero si no, por preocupación de un asunto hemos hecho esto, diciendo: “Mañana dirán sus hijos a nuestros hijos, diciendo: ‘¿Qué <em>hay</em> para ustedes y para יהוה, Elohim de Israel?",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 25,
-          "tth": "La frontera puso __יהוה__ entre nosotros y ustedes, hijos de Reubén e hijos de Gad, al Iardén; no hay para ustedes parte con __יהוה’__. Y harían cesar sus hijos a nuestros hijos para no temer a __יהוה__.",
+          "tth": "La frontera puso יהוה entre nosotros y ustedes, hijos de Reubén e hijos de Gad, al Iardén; no hay para ustedes parte con יהוה’. Y harían cesar sus hijos a nuestros hijos para no temer a יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4569,13 +4569,13 @@
         },
         {
           "verse": 27,
-          "tth": "porque testigo este <em>será</em> entre nosotros y ustedes y nuestras generaciones después de nosotros, para servir con el servicio de __יהוה__ delante de Él con nuestras ofrendas ascendidas, con nuestros sacrificios y con nuestras retribuciones, y no dirán sus hijos mañana a nuestros hijos: ‘No hay para ustedes parte con __יהוה’__ ”.",
+          "tth": "porque testigo este <em>será</em> entre nosotros y ustedes y nuestras generaciones después de nosotros, para servir con el servicio de יהוה delante de Él con nuestras ofrendas ascendidas, con nuestros sacrificios y con nuestras retribuciones, y no dirán sus hijos mañana a nuestros hijos: ‘No hay para ustedes parte con יהוה’ ”.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 28,
-          "tth": "Y dijimos: “Y sucederá que dirán <em>esto</em> a nosotros y a nuestras generaciones mañana, pero diremos: ‘Vean la construcción¹²⁷ del altar de __יהוה__ que hicieron nuestros padres, no para ofrendas ascendidas y no para sacrificios, porque testigo es él entre nosotros y ustedes’ ”.",
+          "tth": "Y dijimos: “Y sucederá que dirán <em>esto</em> a nosotros y a nuestras generaciones mañana, pero diremos: ‘Vean la construcción¹²⁷ del altar de יהוה que hicieron nuestros padres, no para ofrendas ascendidas y no para sacrificios, porque testigo es él entre nosotros y ustedes’ ”.",
           "footnotes": [
             {
               "marker": "¹²⁷",
@@ -4588,7 +4588,7 @@
         },
         {
           "verse": 29,
-          "tth": "¡Lejos <em>esté</em> de nosotros¹²⁸ rebelarse contra __יהוה__ y regresar hoy de detrás de __יהוה__ para construir un altar para ofrenda ascendida, para ofrenda de grano y para sacrificio, aparte del altar de __יהוה__ nuestro Elohim que <em>está</em> delante de su Mishkán!",
+          "tth": "¡Lejos <em>esté</em> de nosotros¹²⁸ rebelarse contra יהוה y regresar hoy de detrás de יהוה para construir un altar para ofrenda ascendida, para ofrenda de grano y para sacrificio, aparte del altar de יהוה nuestro Elohim que <em>está</em> delante de su Mishkán!",
           "footnotes": [
             {
               "marker": "¹²⁸",
@@ -4607,7 +4607,7 @@
         },
         {
           "verse": 31,
-          "tth": "Y dijo Pinjas, hijo de Eleazar el sacerdote, a los hijos de Reubén, a los hijos de Gad y a los hijos de Menasheh: Hoy sabemos que en medio de nosotros <em>está</em> __יהוה__, que no cometieron contra __יהוה__ esta infidelidad; entonces, ustedes rescataron a los hijos de Israel de la mano de __יהוה__.",
+          "tth": "Y dijo Pinjas, hijo de Eleazar el sacerdote, a los hijos de Reubén, a los hijos de Gad y a los hijos de Menasheh: Hoy sabemos que en medio de nosotros <em>está</em> יהוה, que no cometieron contra יהוה esta infidelidad; entonces, ustedes rescataron a los hijos de Israel de la mano de יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4625,7 +4625,7 @@
         },
         {
           "verse": 34,
-          "tth": "Y llamaron los hijos de Reubén y los hijos de Gad al altar “Ed”, porque testigo¹²⁹ es él entre nosotros <em>de</em> que __יהוה__ es el Elohim.",
+          "tth": "Y llamaron los hijos de Reubén y los hijos de Gad al altar “Ed”, porque testigo¹²⁹ es él entre nosotros <em>de</em> que יהוה es el Elohim.",
           "footnotes": [
             {
               "marker": "¹²⁹",
@@ -4643,7 +4643,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y sucedió por muchos días después de que había dado descanso __יהוה__ a Israel de todos sus enemigos de alrededor, y Yehoshúa <em>era</em> viejo entrado en días,",
+          "tth": "Y sucedió por muchos días después de que había dado descanso יהוה a Israel de todos sus enemigos de alrededor, y Yehoshúa <em>era</em> viejo entrado en días,",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4655,7 +4655,7 @@
         },
         {
           "verse": 3,
-          "tth": "Y ustedes han visto todo lo que ha hecho __יהוה__ su Elohim a todas estas naciones debido a ustedes, porque __יהוה__ su Elohim, Él luchó por ustedes.",
+          "tth": "Y ustedes han visto todo lo que ha hecho יהוה su Elohim a todas estas naciones debido a ustedes, porque יהוה su Elohim, Él luchó por ustedes.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4667,7 +4667,7 @@
         },
         {
           "verse": 5,
-          "tth": "Y __יהוה__ su Elohim, Él las empujará debido a ustedes y las desposeerá delante de ustedes; y poseerán su tierra, como ha hablado __יהוה__ su Elohim a ustedes.",
+          "tth": "Y יהוה su Elohim, Él las empujará debido a ustedes y las desposeerá delante de ustedes; y poseerán su tierra, como ha hablado יהוה su Elohim a ustedes.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4692,25 +4692,25 @@
         },
         {
           "verse": 8,
-          "tth": "sino que en __יהוה__ su Elohim se aferrarán, como han hecho hasta este día.",
+          "tth": "sino que en יהוה su Elohim se aferrarán, como han hecho hasta este día.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 9,
-          "tth": "Y desposeyó __יהוה__ de delante de ustedes las naciones grandes y tremendas; y ustedes, no se afirmó hombre contra sus rostros hasta este día.",
+          "tth": "Y desposeyó יהוה de delante de ustedes las naciones grandes y tremendas; y ustedes, no se afirmó hombre contra sus rostros hasta este día.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 10,
-          "tth": "Un hombre de ustedes perseguirá <em>a</em> mil, porque __יהוה__ su Elohim, Él lucha por ustedes, como les ha hablado.",
+          "tth": "Un hombre de ustedes perseguirá <em>a</em> mil, porque יהוה su Elohim, Él lucha por ustedes, como les ha hablado.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 11,
-          "tth": "Y tengan mucho cuidado, por sus vidas, para amar a __יהוה__ su Elohim.",
+          "tth": "Y tengan mucho cuidado, por sus vidas, para amar a יהוה su Elohim.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4729,25 +4729,25 @@
         },
         {
           "verse": 13,
-          "tth": "sabiendo sabrán que no volverá __יהוה__ su Elohim a desposeer a estas naciones de delante de ustedes, y serán a ustedes por trampa y por obstáculo, y por azote en sus laterales y por espinas en sus ojos, hasta perecer ustedes de sobre esta tierra buena que dio a ustedes __יהוה__ su Elohim.",
+          "tth": "sabiendo sabrán que no volverá יהוה su Elohim a desposeer a estas naciones de delante de ustedes, y serán a ustedes por trampa y por obstáculo, y por azote en sus laterales y por espinas en sus ojos, hasta perecer ustedes de sobre esta tierra buena que dio a ustedes יהוה su Elohim.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 14,
-          "tth": "Y he aquí, yo me voy hoy por el camino de toda la tierra, y sabrán ustedes con todo su corazón y con todo su ser que no ha caído una palabra de todas las palabras buenas que habló __יהוה__ su Elohim sobre ustedes; todo ha venido <em>a pasar</em> a ustedes, no cayó de ella una palabra.",
+          "tth": "Y he aquí, yo me voy hoy por el camino de toda la tierra, y sabrán ustedes con todo su corazón y con todo su ser que no ha caído una palabra de todas las palabras buenas que habló יהוה su Elohim sobre ustedes; todo ha venido <em>a pasar</em> a ustedes, no cayó de ella una palabra.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 15,
-          "tth": "Y sucederá <em>que</em> conforme ha venido sobre ustedes toda la palabra buena que habló __יהוה__ su Elohim a ustedes, así hará venir __יהוה__ sobre ustedes toda la palabra mala, hasta destruirlos de sobre esta tierra buena que les dio a ustedes __יהוה__ su Elohim.",
+          "tth": "Y sucederá <em>que</em> conforme ha venido sobre ustedes toda la palabra buena que habló יהוה su Elohim a ustedes, así hará venir יהוה sobre ustedes toda la palabra mala, hasta destruirlos de sobre esta tierra buena que les dio a ustedes יהוה su Elohim.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 16,
-          "tth": "Cuando traspasen el Pacto de __יהוה__ su Elohim el cual les ordenó, y vayan y sirvan otros dioses, y se inclinen a ellos, se encenderá la ira de __יהוה__ contra ustedes, y perecerán rápidamente de sobre la tierra buena que dio a ustedes.",
+          "tth": "Cuando traspasen el Pacto de יהוה su Elohim el cual les ordenó, y vayan y sirvan otros dioses, y se inclinen a ellos, se encenderá la ira de יהוה contra ustedes, y perecerán rápidamente de sobre la tierra buena que dio a ustedes.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Discurso de Yehoshúa en Shejem"
@@ -4765,7 +4765,7 @@
         },
         {
           "verse": 2,
-          "tth": "Y dijo Yehoshúa a todo el pueblo: Así ha dicho __יהוה__, Elohim de Israel: “En el <em>otro</em> lado del río habitaron sus padres desde la antigüedad, Téraj, padre de Abraham y padre de Najor, y servían <em>a</em> otros dioses.",
+          "tth": "Y dijo Yehoshúa a todo el pueblo: Así ha dicho יהוה, Elohim de Israel: “En el <em>otro</em> lado del río habitaron sus padres desde la antigüedad, Téraj, padre de Abraham y padre de Najor, y servían <em>a</em> otros dioses.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4802,7 +4802,7 @@
         },
         {
           "verse": 7,
-          "tth": "Y gritaron a __יהוה__, y Él puso oscuridad entres ustedes y los mitzrim¹³³, e hizo venir sobre ellos el mar, y los cubrió; y vieron sus ojos lo que hice en Mitzráim. Y habitaron en el desierto muchos días.",
+          "tth": "Y gritaron a יהוה, y Él puso oscuridad entres ustedes y los mitzrim¹³³, e hizo venir sobre ellos el mar, y los cubrió; y vieron sus ojos lo que hice en Mitzráim. Y habitaron en el desierto muchos días.",
           "footnotes": [
             {
               "marker": "¹³³",
@@ -4864,19 +4864,19 @@
         },
         {
           "verse": 14,
-          "tth": "Y ahora, teman a __יהוה__ y sírvanle con integridad y con verdad; desvíen los dioses que sirvieron sus padres en el <em>otro</em> lado del río y en Mitzráim, ¡y sirvan a __יהוה__!",
+          "tth": "Y ahora, teman a יהוה y sírvanle con integridad y con verdad; desvíen los dioses que sirvieron sus padres en el <em>otro</em> lado del río y en Mitzráim, ¡y sirvan a יהוה!",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 15,
-          "tth": "Y si es malo en sus ojos servir a __יהוה__, elijan para ustedes hoy a quién servirán: si a los dioses que sirvieron sus padres que <em>estaban</em> del <em>otro</em> lado del río, y si a los dioses del emorí, que ustedes habitan en su tierra; pero yo y mi casa serviremos a __יהוה__.",
+          "tth": "Y si es malo en sus ojos servir a יהוה, elijan para ustedes hoy a quién servirán: si a los dioses que sirvieron sus padres que <em>estaban</em> del <em>otro</em> lado del río, y si a los dioses del emorí, que ustedes habitan en su tierra; pero yo y mi casa serviremos a יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 16,
-          "tth": "Y respondió el pueblo, y dijo: ¡Lejos <em>esté</em> de nosotros¹³⁶ de abandonar a __יהוה__ para servir otros dioses!",
+          "tth": "Y respondió el pueblo, y dijo: ¡Lejos <em>esté</em> de nosotros¹³⁶ de abandonar a יהוה para servir otros dioses!",
           "footnotes": [
             {
               "marker": "¹³⁶",
@@ -4889,20 +4889,20 @@
         },
         {
           "verse": 17,
-          "tth": "Porque __יהוה__ Elohim nuestro, Él <em>nos</em> hizo subir a nosotros y a nuestros padres de la tierra de Mitzráim, de la casa de esclavos, y el que hizo ante nuestros ojos estas grandes señales y nos guardó en todo el camino que caminamos en él y en todos los pueblos que pasamos en medio de ellos.",
+          "tth": "Porque יהוה Elohim nuestro, Él <em>nos</em> hizo subir a nosotros y a nuestros padres de la tierra de Mitzráim, de la casa de esclavos, y el que hizo ante nuestros ojos estas grandes señales y nos guardó en todo el camino que caminamos en él y en todos los pueblos que pasamos en medio de ellos.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 18,
-          "tth": "Y expulsó __יהוה__ a todos los pueblos, y al emorí, habitante de la tierra, de delante de nosotros. También nosotros serviremos a __יהוה__, porque Él <em>es</em> nuestro Elohim.",
+          "tth": "Y expulsó יהוה a todos los pueblos, y al emorí, habitante de la tierra, de delante de nosotros. También nosotros serviremos a יהוה, porque Él <em>es</em> nuestro Elohim.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Pacto del pueblo en Shejem"
         },
         {
           "verse": 19,
-          "tth": "Y dijo Yehoshúa al pueblo: No podrán servir a __יהוה__, porque Elohim Santo¹³⁷ es Él, El celoso¹³⁸ es Él, no soportará a sus transgresiones y a sus pecados.",
+          "tth": "Y dijo Yehoshúa al pueblo: No podrán servir a יהוה, porque Elohim Santo¹³⁷ es Él, El celoso¹³⁸ es Él, no soportará a sus transgresiones y a sus pecados.",
           "footnotes": [
             {
               "marker": "¹³⁷",
@@ -4921,31 +4921,31 @@
         },
         {
           "verse": 20,
-          "tth": "Cuando abandonen a __יהוה__ y sirvan dioses de extranjero, Él volverá y hará mal a ustedes, y los consumirá después de que hizo bien a ustedes.",
+          "tth": "Cuando abandonen a יהוה y sirvan dioses de extranjero, Él volverá y hará mal a ustedes, y los consumirá después de que hizo bien a ustedes.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 21,
-          "tth": "Y dijo el pueblo a Yehoshúa: No, porque a __יהוה__ serviremos.",
+          "tth": "Y dijo el pueblo a Yehoshúa: No, porque a יהוה serviremos.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 22,
-          "tth": "Y dijo Yehoshúa al pueblo: Testigos <em>son</em> ustedes contra ustedes <em>mismos</em>, porque eligieron para ustedes a __יהוה__, para servirle. Y dijeron: Testigos <em>somos</em>.",
+          "tth": "Y dijo Yehoshúa al pueblo: Testigos <em>son</em> ustedes contra ustedes <em>mismos</em>, porque eligieron para ustedes a יהוה, para servirle. Y dijeron: Testigos <em>somos</em>.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 23,
-          "tth": "Y ahora, desvíen a los dioses de extranjero que <em>están</em> en medio de ustedes, e inclinen su corazón a __יהוה__, Elohim de Israel.",
+          "tth": "Y ahora, desvíen a los dioses de extranjero que <em>están</em> en medio de ustedes, e inclinen su corazón a יהוה, Elohim de Israel.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 24,
-          "tth": "Y dijo el pueblo a Yehoshúa: A __יהוה__ Elohim nuestro serviremos, y a su voz escucharemos.",
+          "tth": "Y dijo el pueblo a Yehoshúa: A יהוה Elohim nuestro serviremos, y a su voz escucharemos.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4976,7 +4976,7 @@
         },
         {
           "verse": 26,
-          "tth": "Y escribió Yehoshúa estas palabras en el rollo de la Torah de Elohim; y tomó una piedra grande y la levantó allí debajo del roble que <em>está</em> en el Mikdash¹⁴² de __יהוה__.",
+          "tth": "Y escribió Yehoshúa estas palabras en el rollo de la Torah de Elohim; y tomó una piedra grande y la levantó allí debajo del roble que <em>está</em> en el Mikdash¹⁴² de יהוה.",
           "footnotes": [
             {
               "marker": "¹⁴²",
@@ -4989,7 +4989,7 @@
         },
         {
           "verse": 27,
-          "tth": "Y dijo Yehoshúa a todo el pueblo: He aquí, esta piedra será en nosotros por testigo, porque ella ha escuchado todas las palabras de __יהוה__ que habló con nosotros, y será contra ustedes por testigo, no sea que engañen a su Elohim.",
+          "tth": "Y dijo Yehoshúa a todo el pueblo: He aquí, esta piedra será en nosotros por testigo, porque ella ha escuchado todas las palabras de יהוה que habló con nosotros, y será contra ustedes por testigo, no sea que engañen a su Elohim.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5001,7 +5001,7 @@
         },
         {
           "verse": 29,
-          "tth": "Y sucedió después de estas cosas, murió Yehoshúa, hijo de Nun, siervo de __יהוה__, de edad de ciento diez años.",
+          "tth": "Y sucedió después de estas cosas, murió Yehoshúa, hijo de Nun, siervo de יהוה, de edad de ciento diez años.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5013,7 +5013,7 @@
         },
         {
           "verse": 31,
-          "tth": "Y sirvió Israel a __יהוה__ todos los días de Yehoshúa y todos los días de los ancianos que hicieron largos <em>sus</em> días después de Yehoshúa y que conocieron toda obra de __יהוה__ que hizo a Israel.",
+          "tth": "Y sirvió Israel a יהוה todos los días de Yehoshúa y todos los días de los ancianos que hicieron largos <em>sus</em> días después de Yehoshúa y que conocieron toda obra de יהוה que hizo a Israel.",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/iehoshua.json
+++ b/data/tth_2/json/iehoshua.json
@@ -2637,7 +2637,7 @@
         },
         {
           "verse": 1,
-          "tth": "fue su herencia, conforme había ordenado __יהוה__, por mano de Moshéh, a las nueve tribus y a la media tribu.",
+          "tth": "fue su herencia, conforme había ordenado יהוה, por mano de Moshéh, a las nueve tribus y a la media tribu.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2662,38 +2662,38 @@
         },
         {
           "verse": 5,
-          "tth": "Como había ordenado __יהוה__ a Moshéh, así hicieron los hijos de Israel, y repartieron la tierra.",
+          "tth": "Como había ordenado יהוה a Moshéh, así hicieron los hijos de Israel, y repartieron la tierra.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "La herencia de Caleb"
         },
         {
           "verse": 6,
-          "tth": "Y se acercaron los hijos de Iehudáh a Yehoshúa en Gilgal, y le dijo Caleb, hijo de Iefunéh el kenizí: Tú conoces la palabra que habló __יהוה__ a Moshéh, hombre del Elohim, sobre mi causa y sobre tu causa en Kádesh Barnea.",
+          "tth": "Y se acercaron los hijos de Iehudáh a Yehoshúa en Gilgal, y le dijo Caleb, hijo de Iefunéh el kenizí: Tú conoces la palabra que habló יהוה a Moshéh, hombre del Elohim, sobre mi causa y sobre tu causa en Kádesh Barnea.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 7,
-          "tth": "Edad de cuarenta años <em>tenía</em> yo cuando me envió Moshéh, siervo de __יהוה,__ desde Kádesh Barnea a explorar la tierra, y regresé a él palabra conforme con mi corazón.",
+          "tth": "Edad de cuarenta años <em>tenía</em> yo cuando me envió Moshéh, siervo de יהוה, desde Kádesh Barnea a explorar la tierra, y regresé a él palabra conforme con mi corazón.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 8,
-          "tth": "Pero mis hermanos que subieron conmigo, hicieron derretir el corazón del pueblo, pero yo fui completo tras de __יהוה__ mi Elohim.",
+          "tth": "Pero mis hermanos que subieron conmigo, hicieron derretir el corazón del pueblo, pero yo fui completo tras de יהוה mi Elohim.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 9,
-          "tth": "Y juró Moshéh en aquel día, diciendo: “¡Si no <em>fuera</em> la tierra, que ha pisado tu pie en ella, para ti por herencia y para tus hijos hasta siempre! Porque fuiste completo tras de __יהוה__ mi Elohim”.",
+          "tth": "Y juró Moshéh en aquel día, diciendo: “¡Si no <em>fuera</em> la tierra, que ha pisado tu pie en ella, para ti por herencia y para tus hijos hasta siempre! Porque fuiste completo tras de יהוה mi Elohim”.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 10,
-          "tth": "Y ahora, he aquí, me hizo vivir __יהוה__, como habló, estos cuarenta y cinco años, desde entonces <em>que</em> habló __יהוה__ esta palabra a Moshéh, cuando caminaba Israel por el desierto; y ahora, he aquí, yo <em>tengo</em> hoy edad de ochenta y cinco años.",
+          "tth": "Y ahora, he aquí, me hizo vivir יהוה, como habló, estos cuarenta y cinco años, desde entonces <em>que</em> habló יהוה esta palabra a Moshéh, cuando caminaba Israel por el desierto; y ahora, he aquí, yo <em>tengo</em> hoy edad de ochenta y cinco años.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2705,7 +2705,7 @@
         },
         {
           "verse": 12,
-          "tth": "Y ahora, da a mí este monte que habló __יהוה__ en ese día, porque tú escuchaste en ese día que <em>había</em> anakim allí, y ciudades grandes fortificadas; quizá __יהוה__ <em>esté</em> conmigo y los desposeeré como ha hablado __יהוה__.",
+          "tth": "Y ahora, da a mí este monte que habló יהוה en ese día, porque tú escuchaste en ese día que <em>había</em> anakim allí, y ciudades grandes fortificadas; quizá יהוה <em>esté</em> conmigo y los desposeeré como ha hablado יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2717,7 +2717,7 @@
         },
         {
           "verse": 14,
-          "tth": "Por eso, fue Jebrón para Caleb, hijo de Iefunéh el kenizí, por herencia hasta este día, porque fue completo tras de __יהוה__, Elohim de Israel.",
+          "tth": "Por eso, fue Jebrón para Caleb, hijo de Iefunéh el kenizí, por herencia hasta este día, porque fue completo tras de יהוה, Elohim de Israel.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2854,7 +2854,7 @@
         },
         {
           "verse": 13,
-          "tth": "Y a Caleb, hijo de Iefunéh, dio una porción entre los hijos de Iehudáh, por boca de __יהוה__ a Yehoshúa, <em>dio</em> Kiriat Arba, <em>Arba era</em> padre de Anak, esta es Jebrón.",
+          "tth": "Y a Caleb, hijo de Iefunéh, dio una porción entre los hijos de Iehudáh, por boca de יהוה a Yehoshúa, <em>dio</em> Kiriat Arba, <em>Arba era</em> padre de Anak, esta es Jebrón.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3292,7 +3292,7 @@
         },
         {
           "verse": 4,
-          "tth": "Y ellas se acercaron delante de Eleazar el sacerdote y delante de Yehoshúa, hijo de Nun, y delante de los jefes, diciendo: __יהוה__ ha ordenado a Moshéh para dar a nosotras una herencia entre nuestros hermanos. Y les dio por boca de __יהוה__ una herencia entre los hermanos de su padre.",
+          "tth": "Y ellas se acercaron delante de Eleazar el sacerdote y delante de Yehoshúa, hijo de Nun, y delante de los jefes, diciendo: יהוה ha ordenado a Moshéh para dar a nosotras una herencia entre nuestros hermanos. Y les dio por boca de יהוה una herencia entre los hermanos de su padre.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3359,7 +3359,7 @@
         },
         {
           "verse": 14,
-          "tth": "Y hablaron los hijos de Iosef a Yehoshúa, diciendo: ¿Por qué has dado a mí <em>por</em> herencia un <em>solo</em> goral⁹⁸ y una <em>sola</em> porción, y yo <em>soy</em> un pueblo numeroso, incluso que hasta aquí me ha bendecido __יהוה__?",
+          "tth": "Y hablaron los hijos de Iosef a Yehoshúa, diciendo: ¿Por qué has dado a mí <em>por</em> herencia un <em>solo</em> goral⁹⁸ y una <em>sola</em> porción, y yo <em>soy</em> un pueblo numeroso, incluso que hasta aquí me ha bendecido יהוה?",
           "footnotes": [
             {
               "marker": "⁹⁸",
@@ -3428,7 +3428,7 @@
         },
         {
           "verse": 3,
-          "tth": "Y dijo Yehoshúa a los hijos de Israel: ¿Hasta cuándo¹⁰¹ ustedes se mostrarán flojos para entrar a poseer la tierra que dio a ustedes __יהוה__, Elohim de sus padres?",
+          "tth": "Y dijo Yehoshúa a los hijos de Israel: ¿Hasta cuándo¹⁰¹ ustedes se mostrarán flojos para entrar a poseer la tierra que dio a ustedes יהוה, Elohim de sus padres?",
           "footnotes": [
             {
               "marker": "¹⁰¹",
@@ -3453,7 +3453,7 @@
         },
         {
           "verse": 6,
-          "tth": "Y ustedes escribirán la tierra <em>en</em> siete partes, y traerán a mí <em>la escritura</em> aquí. Y lanzaré para ustedes un goral¹⁰² aquí delante de __יהוה__ nuestro Elohim.",
+          "tth": "Y ustedes escribirán la tierra <em>en</em> siete partes, y traerán a mí <em>la escritura</em> aquí. Y lanzaré para ustedes un goral¹⁰² aquí delante de יהוה nuestro Elohim.",
           "footnotes": [
             {
               "marker": "¹⁰²",
@@ -3466,7 +3466,7 @@
         },
         {
           "verse": 7,
-          "tth": "Pero no hay parte para los leviím¹⁰³ en medio de ustedes, porque el sacerdocio de __יהוה__ es su herencia. Y Gad y Reubén, y la media tribu de Menasheh, tomaron su herencia del <em>otro</em> lado del Iardén, hacia el amanecer, la cual dio a ellos Moshéh, siervo de __יהוה__.",
+          "tth": "Pero no hay parte para los leviím¹⁰³ en medio de ustedes, porque el sacerdocio de יהוה es su herencia. Y Gad y Reubén, y la media tribu de Menasheh, tomaron su herencia del <em>otro</em> lado del Iardén, hacia el amanecer, la cual dio a ellos Moshéh, siervo de יהוה.",
           "footnotes": [
             {
               "marker": "¹⁰³",
@@ -3479,7 +3479,7 @@
         },
         {
           "verse": 8,
-          "tth": "Y se levantaron los hombres y se fueron, y ordenó Yehoshúa a los que fueron a escribir la tierra, diciendo: Vayan y caminen por la tierra, y escríbanla y vuelvan a mí; y aquí lanzaré para ustedes un goral delante de __יהוה__ en Shiloh.",
+          "tth": "Y se levantaron los hombres y se fueron, y ordenó Yehoshúa a los que fueron a escribir la tierra, diciendo: Vayan y caminen por la tierra, y escríbanla y vuelvan a mí; y aquí lanzaré para ustedes un goral delante de יהוה en Shiloh.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3491,7 +3491,7 @@
         },
         {
           "verse": 10,
-          "tth": "Y lanzó para ellos Yehoshúa un goral en Shiloh delante de __יהוה__, y repartió allí Yehoshúa la tierra a los hijos de Israel, conforme a sus divisiones.",
+          "tth": "Y lanzó para ellos Yehoshúa un goral en Shiloh delante de יהוה, y repartió allí Yehoshúa la tierra a los hijos de Israel, conforme a sus divisiones.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3950,13 +3950,13 @@
         },
         {
           "verse": 50,
-          "tth": "Por boca de __יהוה__, le dieron la ciudad que él pidió, Timnat Seraj, en el monte de Efráim. Y el construyó la ciudad y habitó en ella.",
+          "tth": "Por boca de יהוה, le dieron la ciudad que él pidió, Timnat Seraj, en el monte de Efráim. Y el construyó la ciudad y habitó en ella.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 51,
-          "tth": "Estas son las herencias que dividieron en posesión Eleazar el sacerdote, Yehoshúa, hijo de Nun, y las cabezas de los padres de las tribus de los hijos de Israel, por goral, en Shiloh, delante de __יהוה__, en la entrada de la Tienda del Mo’ed¹¹⁰. Y terminaron de repartir la tierra.",
+          "tth": "Estas son las herencias que dividieron en posesión Eleazar el sacerdote, Yehoshúa, hijo de Nun, y las cabezas de los padres de las tribus de los hijos de Israel, por goral, en Shiloh, delante de יהוה, en la entrada de la Tienda del Mo’ed¹¹⁰. Y terminaron de repartir la tierra.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Las ciudades de refugio"
@@ -3968,7 +3968,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y habló __יהוה__ a Yehoshúa, diciendo:",
+          "tth": "Y habló יהוה a Yehoshúa, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4048,13 +4048,13 @@
         },
         {
           "verse": 2,
-          "tth": "y hablaron a ellos en Shiloh en la tierra de Kenáan, diciendo: __יהוה__ mandó por mano de Moshéh a dar a nosotros ciudades para habitar, y sus tierra exteriores para nuestras bestias.",
+          "tth": "y hablaron a ellos en Shiloh en la tierra de Kenáan, diciendo: יהוה mandó por mano de Moshéh a dar a nosotros ciudades para habitar, y sus tierra exteriores para nuestras bestias.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 3,
-          "tth": "Y dieron los hijos de Israel a los leviím de su herencia, por boca de __יהוה__, estas ciudades y sus tierras exteriores.",
+          "tth": "Y dieron los hijos de Israel a los leviím de su herencia, por boca de יהוה, estas ciudades y sus tierras exteriores.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4103,7 +4103,7 @@
         },
         {
           "verse": 8,
-          "tth": "Y dieron los hijos de Israel a los leviím estas ciudades y sus tierras exteriores, como ordenó __יהוה__ por mano de Moshéh, por goral.",
+          "tth": "Y dieron los hijos de Israel a los leviím estas ciudades y sus tierras exteriores, como ordenó יהוה por mano de Moshéh, por goral.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4327,19 +4327,19 @@
         },
         {
           "verse": 43,
-          "tth": "Y dio __יהוה__ a Israel toda la tierra que había jurado dar a sus padres, y la heredaron y habitaron en ella.",
+          "tth": "Y dio יהוה a Israel toda la tierra que había jurado dar a sus padres, y la heredaron y habitaron en ella.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 44,
-          "tth": "Y les hizo descansar __יהוה__ de alrededor, conforme a todo lo que juró a sus padres; y no se afirmó hombre contra sus rostros de <em>entre</em> todos sus enemigos; a todos sus enemigos dio __יהוה__ en su mano.",
+          "tth": "Y les hizo descansar יהוה de alrededor, conforme a todo lo que juró a sus padres; y no se afirmó hombre contra sus rostros de <em>entre</em> todos sus enemigos; a todos sus enemigos dio יהוה en su mano.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 45,
-          "tth": "No cayó una palabra de toda la cosa buena que había hablado __יהוה__ a la casa de Israel; todas vinieron <em>a pasar</em>.",
+          "tth": "No cayó una palabra de toda la cosa buena que había hablado יהוה a la casa de Israel; todas vinieron <em>a pasar</em>.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Retorno de las tribus del otro lado del Iardén"
@@ -4370,19 +4370,19 @@
         },
         {
           "verse": 2,
-          "tth": "y les dijo: Ustedes guardaron todo lo que les había ordenado Moshéh, siervo de __יהוה__, y escucharon a la voz de todo lo que les ordené.",
+          "tth": "y les dijo: Ustedes guardaron todo lo que les había ordenado Moshéh, siervo de יהוה, y escucharon a la voz de todo lo que les ordené.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 3,
-          "tth": "No abandonaron a sus hermanos <em>por</em> estos muchos días hasta este día, y han guardado la guardia del mandamiento de __יהוה__ su Elohim.",
+          "tth": "No abandonaron a sus hermanos <em>por</em> estos muchos días hasta este día, y han guardado la guardia del mandamiento de יהוה su Elohim.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 4,
-          "tth": "Y ahora, ha hecho descansar __יהוה__ su Elohim a sus hermanos, como había hablado a ellos; y ahora, giren y vayan para ustedes a sus tiendas, a la tierra de su propiedad, la cual dio a ustedes Moshéh, siervo de __יהוה__, en el <em>otro</em> lado del Iardén¹²⁰.",
+          "tth": "Y ahora, ha hecho descansar יהוה su Elohim a sus hermanos, como había hablado a ellos; y ahora, giren y vayan para ustedes a sus tiendas, a la tierra de su propiedad, la cual dio a ustedes Moshéh, siervo de יהוה, en el <em>otro</em> lado del Iardén¹²⁰.",
           "footnotes": [
             {
               "marker": "¹²⁰",
@@ -4395,7 +4395,7 @@
         },
         {
           "verse": 5,
-          "tth": "Sólo, guarden mucho para hacer el mandamiento y la Torah que les ordenó Moshéh, siervo de __יהוה__, para amar a __יהוה__ su Elohim, y para caminar en todos sus caminos, y para guardar sus mandamientos, y para aferrarse a Él, y para servirle con todo su corazón y con todo su ser.",
+          "tth": "Sólo, guarden mucho para hacer el mandamiento y la Torah que les ordenó Moshéh, siervo de יהוה, para amar a יהוה su Elohim, y para caminar en todos sus caminos, y para guardar sus mandamientos, y para aferrarse a Él, y para servirle con todo su corazón y con todo su ser.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4419,7 +4419,7 @@
         },
         {
           "verse": 9,
-          "tth": "Y regresaron y se fueron los hijos de Reubén, los hijos de Gad y la media tribu de Menasheh, de los hijos de Israel, de Shiloh, que <em>está</em> en la tierra de Kenáan, para ir a la tierra de Guilad, a la tierra de su propiedad que habían tomado posesión en ella por boca de __יהוה__, por mano de Moshéh.",
+          "tth": "Y regresaron y se fueron los hijos de Reubén, los hijos de Gad y la media tribu de Menasheh, de los hijos de Israel, de Shiloh, que <em>está</em> en la tierra de Kenáan, para ir a la tierra de Guilad, a la tierra de su propiedad que habían tomado posesión en ella por boca de יהוה, por mano de Moshéh.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "El altar junto al Iardén"
@@ -4469,13 +4469,13 @@
         },
         {
           "verse": 16,
-          "tth": "Así dice toda la congregación de __יהוה__: “¿Qué es esta infidelidad, que han sido infieles con el Elohim de Israel, para regresar hoy de detrás de __יהוה,__ en que construyeron para ustedes un altar para rebelarse hoy contra __יהוה__?",
+          "tth": "Así dice toda la congregación de יהוה: “¿Qué es esta infidelidad, que han sido infieles con el Elohim de Israel, para regresar hoy de detrás de יהוה, en que construyeron para ustedes un altar para rebelarse hoy contra יהוה?",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 17,
-          "tth": "¿Es poca para nosotros la iniquidad de Peor, la cual no estamos puros de ella hasta este día, y sucedió la plaga¹²² (Lit.: golpe) en la congregación de __יהוה__?,",
+          "tth": "¿Es poca para nosotros la iniquidad de Peor, la cual no estamos puros de ella hasta este día, y sucedió la plaga¹²² (Lit.: golpe) en la congregación de יהוה?,",
           "footnotes": [
             {
               "marker": "¹²²",
@@ -4488,13 +4488,13 @@
         },
         {
           "verse": 18,
-          "tth": "pero ustedes regresaron hoy de detrás de __יהוה__. ¡Y sucederá <em>que</em> ustedes son rebeldes hoy contra __יהוה__, y mañana con toda la congregación de Israel se enfurecerá!",
+          "tth": "pero ustedes regresaron hoy de detrás de יהוה. ¡Y sucederá <em>que</em> ustedes son rebeldes hoy contra יהוה, y mañana con toda la congregación de Israel se enfurecerá!",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 19,
-          "tth": "Pero si es impura la tierra de su propiedad, crucen para ustedes a la tierra de la propiedad de __יהוה__, que mora allí el Mishkán¹²³, y tomen posesión en medio de nosotros. Pero contra __יהוה__ no se rebelen, y con nosotros no se rebelen edificando para ustedes un altar aparte del altar de __יהוה__ nuestro Elohim.",
+          "tth": "Pero si es impura la tierra de su propiedad, crucen para ustedes a la tierra de la propiedad de יהוה, que mora allí el Mishkán¹²³, y tomen posesión en medio de nosotros. Pero contra יהוה no se rebelen, y con nosotros no se rebelen edificando para ustedes un altar aparte del altar de יהוה nuestro Elohim.",
           "footnotes": [
             {
               "marker": "¹²³",
@@ -4519,7 +4519,7 @@
         },
         {
           "verse": 22,
-          "tth": "¡El Elohim¹²⁴, __יהוה__, El Elohim, __יהוה__! Él sabe; e Israel, él sabrá. Si <em>fue</em> con rebelión y si <em>fue</em> con infidelidad contra __יהוה__, no nos salves este día.",
+          "tth": "¡El Elohim¹²⁴, יהוה, El Elohim, יהוה! Él sabe; e Israel, él sabrá. Si <em>fue</em> con rebelión y si <em>fue</em> con infidelidad contra יהוה, no nos salves este día.",
           "footnotes": [
             {
               "marker": "¹²⁴",
@@ -4532,7 +4532,7 @@
         },
         {
           "verse": 23,
-          "tth": "<em>Si</em> construimos para nosotros un altar para regresar de detrás de __יהוה__, y si para hacer subir sobre él ofrenda ascendida¹²⁵ y ofrenda de grano¹²⁶, y si para hacer sobre él sacrificios de retribución, __יהוה__, Él demandará.",
+          "tth": "<em>Si</em> construimos para nosotros un altar para regresar de detrás de יהוה, y si para hacer subir sobre él ofrenda ascendida¹²⁵ y ofrenda de grano¹²⁶, y si para hacer sobre él sacrificios de retribución, יהוה, Él demandará.",
           "footnotes": [
             {
               "marker": "¹²⁵",
@@ -4551,13 +4551,13 @@
         },
         {
           "verse": 24,
-          "tth": "Pero si no, por preocupación de un asunto hemos hecho esto, diciendo: “Mañana dirán sus hijos a nuestros hijos, diciendo: ‘¿Qué <em>hay</em> para ustedes y para __יהוה__, Elohim de Israel?",
+          "tth": "Pero si no, por preocupación de un asunto hemos hecho esto, diciendo: “Mañana dirán sus hijos a nuestros hijos, diciendo: ‘¿Qué <em>hay</em> para ustedes y para יהוה, Elohim de Israel?",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 25,
-          "tth": "La frontera puso __יהוה__ entre nosotros y ustedes, hijos de Reubén e hijos de Gad, al Iardén; no hay para ustedes parte con __יהוה’__. Y harían cesar sus hijos a nuestros hijos para no temer a __יהוה__.",
+          "tth": "La frontera puso יהוה entre nosotros y ustedes, hijos de Reubén e hijos de Gad, al Iardén; no hay para ustedes parte con יהוה’. Y harían cesar sus hijos a nuestros hijos para no temer a יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4569,13 +4569,13 @@
         },
         {
           "verse": 27,
-          "tth": "porque testigo este <em>será</em> entre nosotros y ustedes y nuestras generaciones después de nosotros, para servir con el servicio de __יהוה__ delante de Él con nuestras ofrendas ascendidas, con nuestros sacrificios y con nuestras retribuciones, y no dirán sus hijos mañana a nuestros hijos: ‘No hay para ustedes parte con __יהוה’__ ”.",
+          "tth": "porque testigo este <em>será</em> entre nosotros y ustedes y nuestras generaciones después de nosotros, para servir con el servicio de יהוה delante de Él con nuestras ofrendas ascendidas, con nuestros sacrificios y con nuestras retribuciones, y no dirán sus hijos mañana a nuestros hijos: ‘No hay para ustedes parte con יהוה’ ”.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 28,
-          "tth": "Y dijimos: “Y sucederá que dirán <em>esto</em> a nosotros y a nuestras generaciones mañana, pero diremos: ‘Vean la construcción¹²⁷ del altar de __יהוה__ que hicieron nuestros padres, no para ofrendas ascendidas y no para sacrificios, porque testigo es él entre nosotros y ustedes’ ”.",
+          "tth": "Y dijimos: “Y sucederá que dirán <em>esto</em> a nosotros y a nuestras generaciones mañana, pero diremos: ‘Vean la construcción¹²⁷ del altar de יהוה que hicieron nuestros padres, no para ofrendas ascendidas y no para sacrificios, porque testigo es él entre nosotros y ustedes’ ”.",
           "footnotes": [
             {
               "marker": "¹²⁷",
@@ -4588,7 +4588,7 @@
         },
         {
           "verse": 29,
-          "tth": "¡Lejos <em>esté</em> de nosotros¹²⁸ rebelarse contra __יהוה__ y regresar hoy de detrás de __יהוה__ para construir un altar para ofrenda ascendida, para ofrenda de grano y para sacrificio, aparte del altar de __יהוה__ nuestro Elohim que <em>está</em> delante de su Mishkán!",
+          "tth": "¡Lejos <em>esté</em> de nosotros¹²⁸ rebelarse contra יהוה y regresar hoy de detrás de יהוה para construir un altar para ofrenda ascendida, para ofrenda de grano y para sacrificio, aparte del altar de יהוה nuestro Elohim que <em>está</em> delante de su Mishkán!",
           "footnotes": [
             {
               "marker": "¹²⁸",
@@ -4607,7 +4607,7 @@
         },
         {
           "verse": 31,
-          "tth": "Y dijo Pinjas, hijo de Eleazar el sacerdote, a los hijos de Reubén, a los hijos de Gad y a los hijos de Menasheh: Hoy sabemos que en medio de nosotros <em>está</em> __יהוה__, que no cometieron contra __יהוה__ esta infidelidad; entonces, ustedes rescataron a los hijos de Israel de la mano de __יהוה__.",
+          "tth": "Y dijo Pinjas, hijo de Eleazar el sacerdote, a los hijos de Reubén, a los hijos de Gad y a los hijos de Menasheh: Hoy sabemos que en medio de nosotros <em>está</em> יהוה, que no cometieron contra יהוה esta infidelidad; entonces, ustedes rescataron a los hijos de Israel de la mano de יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4625,7 +4625,7 @@
         },
         {
           "verse": 34,
-          "tth": "Y llamaron los hijos de Reubén y los hijos de Gad al altar “Ed”, porque testigo¹²⁹ es él entre nosotros <em>de</em> que __יהוה__ es el Elohim.",
+          "tth": "Y llamaron los hijos de Reubén y los hijos de Gad al altar “Ed”, porque testigo¹²⁹ es él entre nosotros <em>de</em> que יהוה es el Elohim.",
           "footnotes": [
             {
               "marker": "¹²⁹",
@@ -4643,7 +4643,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y sucedió por muchos días después de que había dado descanso __יהוה__ a Israel de todos sus enemigos de alrededor, y Yehoshúa <em>era</em> viejo entrado en días,",
+          "tth": "Y sucedió por muchos días después de que había dado descanso יהוה a Israel de todos sus enemigos de alrededor, y Yehoshúa <em>era</em> viejo entrado en días,",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4655,7 +4655,7 @@
         },
         {
           "verse": 3,
-          "tth": "Y ustedes han visto todo lo que ha hecho __יהוה__ su Elohim a todas estas naciones debido a ustedes, porque __יהוה__ su Elohim, Él luchó por ustedes.",
+          "tth": "Y ustedes han visto todo lo que ha hecho יהוה su Elohim a todas estas naciones debido a ustedes, porque יהוה su Elohim, Él luchó por ustedes.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4667,7 +4667,7 @@
         },
         {
           "verse": 5,
-          "tth": "Y __יהוה__ su Elohim, Él las empujará debido a ustedes y las desposeerá delante de ustedes; y poseerán su tierra, como ha hablado __יהוה__ su Elohim a ustedes.",
+          "tth": "Y יהוה su Elohim, Él las empujará debido a ustedes y las desposeerá delante de ustedes; y poseerán su tierra, como ha hablado יהוה su Elohim a ustedes.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4692,25 +4692,25 @@
         },
         {
           "verse": 8,
-          "tth": "sino que en __יהוה__ su Elohim se aferrarán, como han hecho hasta este día.",
+          "tth": "sino que en יהוה su Elohim se aferrarán, como han hecho hasta este día.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 9,
-          "tth": "Y desposeyó __יהוה__ de delante de ustedes las naciones grandes y tremendas; y ustedes, no se afirmó hombre contra sus rostros hasta este día.",
+          "tth": "Y desposeyó יהוה de delante de ustedes las naciones grandes y tremendas; y ustedes, no se afirmó hombre contra sus rostros hasta este día.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 10,
-          "tth": "Un hombre de ustedes perseguirá <em>a</em> mil, porque __יהוה__ su Elohim, Él lucha por ustedes, como les ha hablado.",
+          "tth": "Un hombre de ustedes perseguirá <em>a</em> mil, porque יהוה su Elohim, Él lucha por ustedes, como les ha hablado.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 11,
-          "tth": "Y tengan mucho cuidado, por sus vidas, para amar a __יהוה__ su Elohim.",
+          "tth": "Y tengan mucho cuidado, por sus vidas, para amar a יהוה su Elohim.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4729,25 +4729,25 @@
         },
         {
           "verse": 13,
-          "tth": "sabiendo sabrán que no volverá __יהוה__ su Elohim a desposeer a estas naciones de delante de ustedes, y serán a ustedes por trampa y por obstáculo, y por azote en sus laterales y por espinas en sus ojos, hasta perecer ustedes de sobre esta tierra buena que dio a ustedes __יהוה__ su Elohim.",
+          "tth": "sabiendo sabrán que no volverá יהוה su Elohim a desposeer a estas naciones de delante de ustedes, y serán a ustedes por trampa y por obstáculo, y por azote en sus laterales y por espinas en sus ojos, hasta perecer ustedes de sobre esta tierra buena que dio a ustedes יהוה su Elohim.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 14,
-          "tth": "Y he aquí, yo me voy hoy por el camino de toda la tierra, y sabrán ustedes con todo su corazón y con todo su ser que no ha caído una palabra de todas las palabras buenas que habló __יהוה__ su Elohim sobre ustedes; todo ha venido <em>a pasar</em> a ustedes, no cayó de ella una palabra.",
+          "tth": "Y he aquí, yo me voy hoy por el camino de toda la tierra, y sabrán ustedes con todo su corazón y con todo su ser que no ha caído una palabra de todas las palabras buenas que habló יהוה su Elohim sobre ustedes; todo ha venido <em>a pasar</em> a ustedes, no cayó de ella una palabra.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 15,
-          "tth": "Y sucederá <em>que</em> conforme ha venido sobre ustedes toda la palabra buena que habló __יהוה__ su Elohim a ustedes, así hará venir __יהוה__ sobre ustedes toda la palabra mala, hasta destruirlos de sobre esta tierra buena que les dio a ustedes __יהוה__ su Elohim.",
+          "tth": "Y sucederá <em>que</em> conforme ha venido sobre ustedes toda la palabra buena que habló יהוה su Elohim a ustedes, así hará venir יהוה sobre ustedes toda la palabra mala, hasta destruirlos de sobre esta tierra buena que les dio a ustedes יהוה su Elohim.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 16,
-          "tth": "Cuando traspasen el Pacto de __יהוה__ su Elohim el cual les ordenó, y vayan y sirvan otros dioses, y se inclinen a ellos, se encenderá la ira de __יהוה__ contra ustedes, y perecerán rápidamente de sobre la tierra buena que dio a ustedes.",
+          "tth": "Cuando traspasen el Pacto de יהוה su Elohim el cual les ordenó, y vayan y sirvan otros dioses, y se inclinen a ellos, se encenderá la ira de יהוה contra ustedes, y perecerán rápidamente de sobre la tierra buena que dio a ustedes.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Discurso de Yehoshúa en Shejem"
@@ -4765,7 +4765,7 @@
         },
         {
           "verse": 2,
-          "tth": "Y dijo Yehoshúa a todo el pueblo: Así ha dicho __יהוה__, Elohim de Israel: “En el <em>otro</em> lado del río habitaron sus padres desde la antigüedad, Téraj, padre de Abraham y padre de Najor, y servían <em>a</em> otros dioses.",
+          "tth": "Y dijo Yehoshúa a todo el pueblo: Así ha dicho יהוה, Elohim de Israel: “En el <em>otro</em> lado del río habitaron sus padres desde la antigüedad, Téraj, padre de Abraham y padre de Najor, y servían <em>a</em> otros dioses.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4802,7 +4802,7 @@
         },
         {
           "verse": 7,
-          "tth": "Y gritaron a __יהוה__, y Él puso oscuridad entres ustedes y los mitzrim¹³³, e hizo venir sobre ellos el mar, y los cubrió; y vieron sus ojos lo que hice en Mitzráim. Y habitaron en el desierto muchos días.",
+          "tth": "Y gritaron a יהוה, y Él puso oscuridad entres ustedes y los mitzrim¹³³, e hizo venir sobre ellos el mar, y los cubrió; y vieron sus ojos lo que hice en Mitzráim. Y habitaron en el desierto muchos días.",
           "footnotes": [
             {
               "marker": "¹³³",
@@ -4864,19 +4864,19 @@
         },
         {
           "verse": 14,
-          "tth": "Y ahora, teman a __יהוה__ y sírvanle con integridad y con verdad; desvíen los dioses que sirvieron sus padres en el <em>otro</em> lado del río y en Mitzráim, ¡y sirvan a __יהוה__!",
+          "tth": "Y ahora, teman a יהוה y sírvanle con integridad y con verdad; desvíen los dioses que sirvieron sus padres en el <em>otro</em> lado del río y en Mitzráim, ¡y sirvan a יהוה!",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 15,
-          "tth": "Y si es malo en sus ojos servir a __יהוה__, elijan para ustedes hoy a quién servirán: si a los dioses que sirvieron sus padres que <em>estaban</em> del <em>otro</em> lado del río, y si a los dioses del emorí, que ustedes habitan en su tierra; pero yo y mi casa serviremos a __יהוה__.",
+          "tth": "Y si es malo en sus ojos servir a יהוה, elijan para ustedes hoy a quién servirán: si a los dioses que sirvieron sus padres que <em>estaban</em> del <em>otro</em> lado del río, y si a los dioses del emorí, que ustedes habitan en su tierra; pero yo y mi casa serviremos a יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 16,
-          "tth": "Y respondió el pueblo, y dijo: ¡Lejos <em>esté</em> de nosotros¹³⁶ de abandonar a __יהוה__ para servir otros dioses!",
+          "tth": "Y respondió el pueblo, y dijo: ¡Lejos <em>esté</em> de nosotros¹³⁶ de abandonar a יהוה para servir otros dioses!",
           "footnotes": [
             {
               "marker": "¹³⁶",
@@ -4889,20 +4889,20 @@
         },
         {
           "verse": 17,
-          "tth": "Porque __יהוה__ Elohim nuestro, Él <em>nos</em> hizo subir a nosotros y a nuestros padres de la tierra de Mitzráim, de la casa de esclavos, y el que hizo ante nuestros ojos estas grandes señales y nos guardó en todo el camino que caminamos en él y en todos los pueblos que pasamos en medio de ellos.",
+          "tth": "Porque יהוה Elohim nuestro, Él <em>nos</em> hizo subir a nosotros y a nuestros padres de la tierra de Mitzráim, de la casa de esclavos, y el que hizo ante nuestros ojos estas grandes señales y nos guardó en todo el camino que caminamos en él y en todos los pueblos que pasamos en medio de ellos.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 18,
-          "tth": "Y expulsó __יהוה__ a todos los pueblos, y al emorí, habitante de la tierra, de delante de nosotros. También nosotros serviremos a __יהוה__, porque Él <em>es</em> nuestro Elohim.",
+          "tth": "Y expulsó יהוה a todos los pueblos, y al emorí, habitante de la tierra, de delante de nosotros. También nosotros serviremos a יהוה, porque Él <em>es</em> nuestro Elohim.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Pacto del pueblo en Shejem"
         },
         {
           "verse": 19,
-          "tth": "Y dijo Yehoshúa al pueblo: No podrán servir a __יהוה__, porque Elohim Santo¹³⁷ es Él, El celoso¹³⁸ es Él, no soportará a sus transgresiones y a sus pecados.",
+          "tth": "Y dijo Yehoshúa al pueblo: No podrán servir a יהוה, porque Elohim Santo¹³⁷ es Él, El celoso¹³⁸ es Él, no soportará a sus transgresiones y a sus pecados.",
           "footnotes": [
             {
               "marker": "¹³⁷",
@@ -4921,31 +4921,31 @@
         },
         {
           "verse": 20,
-          "tth": "Cuando abandonen a __יהוה__ y sirvan dioses de extranjero, Él volverá y hará mal a ustedes, y los consumirá después de que hizo bien a ustedes.",
+          "tth": "Cuando abandonen a יהוה y sirvan dioses de extranjero, Él volverá y hará mal a ustedes, y los consumirá después de que hizo bien a ustedes.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 21,
-          "tth": "Y dijo el pueblo a Yehoshúa: No, porque a __יהוה__ serviremos.",
+          "tth": "Y dijo el pueblo a Yehoshúa: No, porque a יהוה serviremos.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 22,
-          "tth": "Y dijo Yehoshúa al pueblo: Testigos <em>son</em> ustedes contra ustedes <em>mismos</em>, porque eligieron para ustedes a __יהוה__, para servirle. Y dijeron: Testigos <em>somos</em>.",
+          "tth": "Y dijo Yehoshúa al pueblo: Testigos <em>son</em> ustedes contra ustedes <em>mismos</em>, porque eligieron para ustedes a יהוה, para servirle. Y dijeron: Testigos <em>somos</em>.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 23,
-          "tth": "Y ahora, desvíen a los dioses de extranjero que <em>están</em> en medio de ustedes, e inclinen su corazón a __יהוה__, Elohim de Israel.",
+          "tth": "Y ahora, desvíen a los dioses de extranjero que <em>están</em> en medio de ustedes, e inclinen su corazón a יהוה, Elohim de Israel.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 24,
-          "tth": "Y dijo el pueblo a Yehoshúa: A __יהוה__ Elohim nuestro serviremos, y a su voz escucharemos.",
+          "tth": "Y dijo el pueblo a Yehoshúa: A יהוה Elohim nuestro serviremos, y a su voz escucharemos.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4976,7 +4976,7 @@
         },
         {
           "verse": 26,
-          "tth": "Y escribió Yehoshúa estas palabras en el rollo de la Torah de Elohim; y tomó una piedra grande y la levantó allí debajo del roble que <em>está</em> en el Mikdash¹⁴² de __יהוה__.",
+          "tth": "Y escribió Yehoshúa estas palabras en el rollo de la Torah de Elohim; y tomó una piedra grande y la levantó allí debajo del roble que <em>está</em> en el Mikdash¹⁴² de יהוה.",
           "footnotes": [
             {
               "marker": "¹⁴²",
@@ -4989,7 +4989,7 @@
         },
         {
           "verse": 27,
-          "tth": "Y dijo Yehoshúa a todo el pueblo: He aquí, esta piedra será en nosotros por testigo, porque ella ha escuchado todas las palabras de __יהוה__ que habló con nosotros, y será contra ustedes por testigo, no sea que engañen a su Elohim.",
+          "tth": "Y dijo Yehoshúa a todo el pueblo: He aquí, esta piedra será en nosotros por testigo, porque ella ha escuchado todas las palabras de יהוה que habló con nosotros, y será contra ustedes por testigo, no sea que engañen a su Elohim.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5001,7 +5001,7 @@
         },
         {
           "verse": 29,
-          "tth": "Y sucedió después de estas cosas, murió Yehoshúa, hijo de Nun, siervo de __יהוה__, de edad de ciento diez años.",
+          "tth": "Y sucedió después de estas cosas, murió Yehoshúa, hijo de Nun, siervo de יהוה, de edad de ciento diez años.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5013,7 +5013,7 @@
         },
         {
           "verse": 31,
-          "tth": "Y sirvió Israel a __יהוה__ todos los días de Yehoshúa y todos los días de los ancianos que hicieron largos <em>sus</em> días después de Yehoshúa y que conocieron toda obra de __יהוה__ que hizo a Israel.",
+          "tth": "Y sirvió Israel a יהוה todos los días de Yehoshúa y todos los días de los ancianos que hicieron largos <em>sus</em> días después de Yehoshúa y que conocieron toda obra de יהוה que hizo a Israel.",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/iejezkel.json
+++ b/data/tth_2/json/iejezkel.json
@@ -9204,7 +9204,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y cuando hagan caer el goral³⁰⁵ a la tierra en herencia, ofrecerán³⁰⁶ una contribución a __יהוה__, santidad de la tierra; la longitud <em>será de</em> veinticinco mil <em>codos</em>, de longitud; y la anchura, diez mil³⁰⁷. Santidad³⁰⁸ será esto en toda su frontera alrededor.",
+          "tth": "Y cuando hagan caer el goral³⁰⁵ a la tierra en herencia, ofrecerán³⁰⁶ una contribución a יהוה, santidad de la tierra; la longitud <em>será de</em> veinticinco mil <em>codos</em>, de longitud; y la anchura, diez mil³⁰⁷. Santidad³⁰⁸ será esto en toda su frontera alrededor.",
           "footnotes": [
             {
               "marker": "³⁰⁵",
@@ -9340,7 +9340,7 @@
         },
         {
           "verse": 15,
-          "tth": "y un cordero del rebaño, de los doscientos de la tierra regada de Israel, para ofrenda de grano, para ofrenda ascendida y para retribuciones, para hacer reconciliación por ustedes’ –declaración de Adonai __יהוה__.",
+          "tth": "y un cordero del rebaño, de los doscientos de la tierra regada de Israel, para ofrenda de grano, para ofrenda ascendida y para retribuciones, para hacer reconciliación por ustedes’ –declaración de Adonai יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -9378,7 +9378,7 @@
         },
         {
           "verse": 18,
-          "tth": "Así ha dicho Adonai __יהוה__: ‘En el <em>mes</em> primero, en el <em>día</em> uno del mes, tomarás un toro hijo del ganado, íntegro, y limpiarás del pecado el santuario.",
+          "tth": "Así ha dicho Adonai יהוה: ‘En el <em>mes</em> primero, en el <em>día</em> uno del mes, tomarás un toro hijo del ganado, íntegro, y limpiarás del pecado el santuario.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -9408,7 +9408,7 @@
         },
         {
           "verse": 23,
-          "tth": "Y <em>en</em> los siete días de la fiesta hará ofrenda ascendida a __יהוה__, siete toros y siete carneros íntegros, diariamente, los siete días, y <em>en</em> ofrenda por el pecado, un peludo de las cabras diariamente.",
+          "tth": "Y <em>en</em> los siete días de la fiesta hará ofrenda ascendida a יהוה, siete toros y siete carneros íntegros, diariamente, los siete días, y <em>en</em> ofrenda por el pecado, un peludo de las cabras diariamente.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -9432,7 +9432,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Así ha dicho Adonai __יהוה__: ‘La puerta del patio interior que mira al este estará cerrada los seis días del trabajo, y en el día del Shabat será abierta, y en el día de la luna nueva será abierta.",
+          "tth": "Así ha dicho Adonai יהוה: ‘La puerta del patio interior que mira al este estará cerrada los seis días del trabajo, y en el día del Shabat será abierta, y en el día de la luna nueva será abierta.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -9451,7 +9451,7 @@
         },
         {
           "verse": 3,
-          "tth": "Y se postrará el pueblo de la tierra <em>a</em> la entrada de esa puerta en los Shabatot³¹⁸ y en las lunas nuevas ante el rostro de __יהוה__.",
+          "tth": "Y se postrará el pueblo de la tierra <em>a</em> la entrada de esa puerta en los Shabatot³¹⁸ y en las lunas nuevas ante el rostro de יהוה.",
           "footnotes": [
             {
               "marker": "³¹⁸",
@@ -9464,7 +9464,7 @@
         },
         {
           "verse": 4,
-          "tth": "Y la ofrenda ascendida que acercará el príncipe a __יהוה__ en el día del Shabat <em>será:</em> seis corderos íntegros y un carnero íntegro.",
+          "tth": "Y la ofrenda ascendida que acercará el príncipe a יהוה en el día del Shabat <em>será:</em> seis corderos íntegros y un carnero íntegro.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -9494,7 +9494,7 @@
         },
         {
           "verse": 9,
-          "tth": "Y cuando venga el pueblo de la tierra delante de __יהוה__ en los tiempos señalados³¹⁹, el que entre <em>por</em> el camino de la puerta del norte para postrarse, saldrá <em>por</em> el camino de la puerta del sur, y el que entre <em>por</em> el camino de la puerta del sur, saldrá <em>por</em> el camino de la puerta hacia el norte, no volverá <em>por</em> el camino de la puerta por la cual haya entrado, porque <em>por</em> en frente de ella saldrá.",
+          "tth": "Y cuando venga el pueblo de la tierra delante de יהוה en los tiempos señalados³¹⁹, el que entre <em>por</em> el camino de la puerta del norte para postrarse, saldrá <em>por</em> el camino de la puerta del sur, y el que entre <em>por</em> el camino de la puerta del sur, saldrá <em>por</em> el camino de la puerta hacia el norte, no volverá <em>por</em> el camino de la puerta por la cual haya entrado, porque <em>por</em> en frente de ella saldrá.",
           "footnotes": [
             {
               "marker": "³¹⁹",
@@ -9526,19 +9526,19 @@
         },
         {
           "verse": 12,
-          "tth": "Y cuando haga el príncipe una ofrenda voluntaria, ofrenda ascendida o retribuciones a voluntariedad para __יהוה__, se abrirá para él la puerta que mira al este, y hará su ofrenda ascendida y sus retribuciones como hará en el día del Shabat. Y saldrá y cerrará la puerta después de su salida.",
+          "tth": "Y cuando haga el príncipe una ofrenda voluntaria, ofrenda ascendida o retribuciones a voluntariedad para יהוה, se abrirá para él la puerta que mira al este, y hará su ofrenda ascendida y sus retribuciones como hará en el día del Shabat. Y saldrá y cerrará la puerta después de su salida.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 13,
-          "tth": "Y un cordero hijo de su año, íntegro, harás como ofrenda ascendida diariamente a __יהוה__; de mañana en mañana lo harás.",
+          "tth": "Y un cordero hijo de su año, íntegro, harás como ofrenda ascendida diariamente a יהוה; de mañana en mañana lo harás.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 14,
-          "tth": "Y una ofrenda de grano harás junto a él de mañana en mañana, un sexto del efáh, y de aceite un tercio del hin para humedecer la harina fina; ofrenda de grano a __יהוה__, decreto olam³²¹ continuamente.",
+          "tth": "Y una ofrenda de grano harás junto a él de mañana en mañana, un sexto del efáh, y de aceite un tercio del hin para humedecer la harina fina; ofrenda de grano a יהוה, decreto olam³²¹ continuamente.",
           "footnotes": [
             {
               "marker": "³²¹",
@@ -9557,7 +9557,7 @@
         },
         {
           "verse": 16,
-          "tth": "Así ha dicho Adonai __יהוה__: ‘Cuando dé el príncipe un regalo a un hombre de sus hijos, su herencia es esta, para sus hijos será; posesión de ellos es esta en herencia.",
+          "tth": "Así ha dicho Adonai יהוה: ‘Cuando dé el príncipe un regalo a un hombre de sus hijos, su herencia es esta, para sus hijos será; posesión de ellos es esta en herencia.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -9768,7 +9768,7 @@
         },
         {
           "verse": 13,
-          "tth": "Así ha dicho Adonai __יהוה__: Esta es la frontera por la que poseerán como herencia la tierra para las doce tribus de Israel; Iosef tendrá dos porciones de medida³³⁴.",
+          "tth": "Así ha dicho Adonai יהוה: Esta es la frontera por la que poseerán como herencia la tierra para las doce tribus de Israel; Iosef tendrá dos porciones de medida³³⁴.",
           "footnotes": [
             {
               "marker": "³³⁴",
@@ -9849,7 +9849,7 @@
         },
         {
           "verse": 23,
-          "tth": "Y será que en la tribu que resida el extranjero, allí le darán su herencia –declaración de Adonai __יהוה__.",
+          "tth": "Y será que en la tribu que resida el extranjero, allí le darán su herencia –declaración de Adonai יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -10069,7 +10069,7 @@
         },
         {
           "verse": 29,
-          "tth": "Esta es la tierra que harán caer goral³⁴³ por herencia para las tribus de Israel, y estas son sus porciones –declaración de Adonai __יהוה__.",
+          "tth": "Esta es la tierra que harán caer goral³⁴³ por herencia para las tribus de Israel, y estas son sus porciones –declaración de Adonai יהוה.",
           "footnotes": [
             {
               "marker": "³⁴³",
@@ -10112,7 +10112,7 @@
         },
         {
           "verse": 35,
-          "tth": "Alrededor habrá dieciocho mil codos; y el nombre de la ciudad desde ese día será: __יהוה__ Shamah³⁴⁴.",
+          "tth": "Alrededor habrá dieciocho mil codos; y el nombre de la ciudad desde ese día será: יהוה Shamah³⁴⁴.",
           "footnotes": [
             {
               "marker": "³⁴⁴",

--- a/data/tth_2/json/ieshaiahu.json
+++ b/data/tth_2/json/ieshaiahu.json
@@ -5376,7 +5376,7 @@
         },
         {
           "verse": 2,
-          "tth": "floreciendo, florecerá, y se regocijará también con regocijo y gritará de júbilo.La gloria del Lebanón será dada a ella, el esplendor del Carmel y el Sharón.Ellos verán la gloria de __יהוה__, el esplendor de nuestro Elohim.",
+          "tth": "floreciendo, florecerá, y se regocijará también con regocijo y gritará de júbilo.La gloria del Lebanón será dada a ella, el esplendor del Carmel y el Sharón.Ellos verán la gloria de יהוה, el esplendor de nuestro Elohim.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5424,7 +5424,7 @@
         },
         {
           "verse": 10,
-          "tth": "Y los rescatados de __יהוה__ volverán, y entrarán en Tzión con grito de júbiloy alegría olam¹⁸⁹ sobre sus cabezas. Gozo y alegría alcanzarán, y huirán la tristeza y el suspiro¹⁹⁰. Invasión de Sanjerib",
+          "tth": "Y los rescatados de יהוה volverán, y entrarán en Tzión con grito de júbiloy alegría olam¹⁸⁹ sobre sus cabezas. Gozo y alegría alcanzarán, y huirán la tristeza y el suspiro¹⁹⁰. Invasión de Sanjerib",
           "footnotes": [],
           "hebrew_terms": []
         }

--- a/data/tth_2/json/ioel.json
+++ b/data/tth_2/json/ioel.json
@@ -529,7 +529,7 @@
         },
         {
           "verse": 8,
-          "tth": "Y venderé a sus hijos y a sus hijas en mano de los hijos de Iehudáh, y ellos los venderán a los shevaim²⁴, a una nación lejana –porque __יהוה__ ha hablado.",
+          "tth": "Y venderé a sus hijos y a sus hijas en mano de los hijos de Iehudáh, y ellos los venderán a los shevaim²⁴, a una nación lejana –porque יהוה ha hablado.",
           "footnotes": [
             {
               "marker": "²⁴",
@@ -554,7 +554,7 @@
         },
         {
           "verse": 11,
-          "tth": "Apresúrense²⁵ y vengan todas las naciones de alrededor, y se reunirán allá.Haz descender, __יהוה__, a tus fuertes²⁶",
+          "tth": "Apresúrense²⁵ y vengan todas las naciones de alrededor, y se reunirán allá.Haz descender, יהוה, a tus fuertes²⁶",
           "footnotes": [
             {
               "marker": "²⁵",

--- a/data/tth_2/json/malaji.json
+++ b/data/tth_2/json/malaji.json
@@ -15,13 +15,13 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Carga, palabra de __יהוה__ a Israel por mano de Malají.",
+          "tth": "Carga, palabra de יהוה a Israel por mano de Malají.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 2,
-          "tth": "Yo los he amado –dijo __יהוה__–. Y ustedes han dicho: ¿En qué nos has amado? ¿No <em>era</em> Esav hermano de Yaakov? –declaración de __יהוה__–, y amé a Yaakov,",
+          "tth": "Yo los he amado –dijo יהוה–. Y ustedes han dicho: ¿En qué nos has amado? ¿No <em>era</em> Esav hermano de Yaakov? –declaración de יהוה–, y amé a Yaakov,",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -33,38 +33,38 @@
         },
         {
           "verse": 4,
-          "tth": "Porque dirá Edom: Hemos sido destrozados, pero volveremos y edificaremos las desolaciones. Así ha dicho __יהוה__ Tzebaot: Ellos edificarán y Yo derribaré. Y los llamarán frontera de maldad y el pueblo <em>con</em> el que se ha enfurecido __יהוה__ hasta siempre.",
+          "tth": "Porque dirá Edom: Hemos sido destrozados, pero volveremos y edificaremos las desolaciones. Así ha dicho יהוה Tzebaot: Ellos edificarán y Yo derribaré. Y los llamarán frontera de maldad y el pueblo <em>con</em> el que se ha enfurecido יהוה hasta siempre.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 5,
-          "tth": "Y sus ojos <em>lo</em> verán, y ustedes dirán: Será grande __יהוה__ por encima de la frontera de Israel.",
+          "tth": "Y sus ojos <em>lo</em> verán, y ustedes dirán: Será grande יהוה por encima de la frontera de Israel.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Pecado de los sacerdotes"
         },
         {
           "verse": 6,
-          "tth": "Un hijo honra <em>al</em> padre, y un siervo a su amo. Y si Yo soy Padre, ¿dónde está mi honor? Y si Yo soy Amo, ¿dónde está mi temor? –ha dicho __יהוה__ Tzebaot a ustedes, los sacerdotes que desprecian mi Nombre–. Y ustedes dicen: “¿En qué hemos despreciado tu Nombre? ”",
+          "tth": "Un hijo honra <em>al</em> padre, y un siervo a su amo. Y si Yo soy Padre, ¿dónde está mi honor? Y si Yo soy Amo, ¿dónde está mi temor? –ha dicho יהוה Tzebaot a ustedes, los sacerdotes que desprecian mi Nombre–. Y ustedes dicen: “¿En qué hemos despreciado tu Nombre? ”",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 7,
-          "tth": "Acercan sobre mi altar pan profanado. Y ustedes dicen: “¿En qué te hemos profanado? ” En que ustedes dicen: “La mesa de __יהוה__ es despreciable”.",
+          "tth": "Acercan sobre mi altar pan profanado. Y ustedes dicen: “¿En qué te hemos profanado? ” En que ustedes dicen: “La mesa de יהוה es despreciable”.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 8,
-          "tth": "Y cuando acercan un ciego para sacrificar, ¿no es malo? Y cuando acercan un cojo y un enfermo, ¿no es malo? ¡Acércalo, por favor, a tu gobernador! ¿Te aceptará o levantará tu rostro? –ha dicho __יהוה__ Tzebaot.",
+          "tth": "Y cuando acercan un ciego para sacrificar, ¿no es malo? Y cuando acercan un cojo y un enfermo, ¿no es malo? ¡Acércalo, por favor, a tu gobernador! ¿Te aceptará o levantará tu rostro? –ha dicho יהוה Tzebaot.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 9,
-          "tth": "Y ahora, rueguen por favor al rostro de El¹, y nos tendrá misericordia. ¡De la mano de ustedes ha sido esto! ¿Él levantará los rostros de ustedes? –ha dicho __יהוה__ Tzebaot.",
+          "tth": "Y ahora, rueguen por favor al rostro de El¹, y nos tendrá misericordia. ¡De la mano de ustedes ha sido esto! ¿Él levantará los rostros de ustedes? –ha dicho יהוה Tzebaot.",
           "footnotes": [
             {
               "marker": "¹",
@@ -77,13 +77,13 @@
         },
         {
           "verse": 10,
-          "tth": "¡Quién <em>habrá</em> incluso entre ustedes que cierre las puertas, y no encendieran mi altar por nada! No hay para Mí deleite en ustedes –ha dicho __יהוה__ Tzebaot– y ofrenda de grano no aceptaré de la mano de ustedes.",
+          "tth": "¡Quién <em>habrá</em> incluso entre ustedes que cierre las puertas, y no encendieran mi altar por nada! No hay para Mí deleite en ustedes –ha dicho יהוה Tzebaot– y ofrenda de grano no aceptaré de la mano de ustedes.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 11,
-          "tth": "Porque desde el amanecer del sol y hasta su puesta, grande es mi Nombre entre las naciones, y en todo lugar incienso <em>será</em> acercado a mi Nombre, y ofrenda de grano limpia; porque grande es mi Nombre entre las naciones –ha dicho __יהוה__ Tzebaot.",
+          "tth": "Porque desde el amanecer del sol y hasta su puesta, grande es mi Nombre entre las naciones, y en todo lugar incienso <em>será</em> acercado a mi Nombre, y ofrenda de grano limpia; porque grande es mi Nombre entre las naciones –ha dicho יהוה Tzebaot.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -95,7 +95,7 @@
         },
         {
           "verse": 13,
-          "tth": "Y dicen: “He aquí, ¡qué cansancio! ” Y lo despreciaron² –ha dicho __יהוה__ Tzebaot– Y trajeron lo robado, cojo y enfermo, y trajeron la ofrenda de grano, ¿la aceptaré de la mano de ustedes? –ha dicho __יהוה__.",
+          "tth": "Y dicen: “He aquí, ¡qué cansancio! ” Y lo despreciaron² –ha dicho יהוה Tzebaot– Y trajeron lo robado, cojo y enfermo, y trajeron la ofrenda de grano, ¿la aceptaré de la mano de ustedes? –ha dicho יהוה.",
           "footnotes": [
             {
               "marker": "²",
@@ -108,7 +108,7 @@
         },
         {
           "verse": 14,
-          "tth": "¡Y excluido el engañoso que tiene en su rebaño un macho y <em>lo</em> promete, pero sacrifica uno dañado a Adonai! Porque Rey Grande soy Yo –ha dicho __יהוה__ Tzebaot– y mi Nombre, temido entre los gentiles.",
+          "tth": "¡Y excluido el engañoso que tiene en su rebaño un macho y <em>lo</em> promete, pero sacrifica uno dañado a Adonai! Porque Rey Grande soy Yo –ha dicho יהוה Tzebaot– y mi Nombre, temido entre los gentiles.",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -125,7 +125,7 @@
         },
         {
           "verse": 2,
-          "tth": "Si no escuchan, y si no ponen sobre el corazón dar honor a mi Nombre –ha dicho __יהוה__ Tzebaot–, enviaré en ustedes la exclusión, y excluiré sus bendiciones; y además, la he excluido, porque ustedes no <em>lo</em> han puesto sobre el corazón.",
+          "tth": "Si no escuchan, y si no ponen sobre el corazón dar honor a mi Nombre –ha dicho יהוה Tzebaot–, enviaré en ustedes la exclusión, y excluiré sus bendiciones; y además, la he excluido, porque ustedes no <em>lo</em> han puesto sobre el corazón.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -137,7 +137,7 @@
         },
         {
           "verse": 4,
-          "tth": "Y sabrán que he enviado a ustedes este mandamiento para que sea mi pacto con Levi –ha dicho __יהוה__ Tzebaot.",
+          "tth": "Y sabrán que he enviado a ustedes este mandamiento para que sea mi pacto con Levi –ha dicho יהוה Tzebaot.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -162,13 +162,13 @@
         },
         {
           "verse": 7,
-          "tth": "Porque los labios del sacerdote guardarán el conocimiento, y la Torah buscarán de su boca, porque mensajero de __יהוה__ Tzebaot es él.",
+          "tth": "Porque los labios del sacerdote guardarán el conocimiento, y la Torah buscarán de su boca, porque mensajero de יהוה Tzebaot es él.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 8,
-          "tth": "Y ustedes se han desviado del camino, han hecho tropezar <em>a</em> muchos en la Torah, han corrompido el pacto de Levi –dijo __יהוה__ Tzebaot.",
+          "tth": "Y ustedes se han desviado del camino, han hecho tropezar <em>a</em> muchos en la Torah, han corrompido el pacto de Levi –dijo יהוה Tzebaot.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -194,7 +194,7 @@
         },
         {
           "verse": 11,
-          "tth": "Ha traicionado Iehudáh, y abominación se ha hecho en Israel y en Yerushaláim, porque ha profanado Iehudáh la Santidad de __יהוה__ <em>con</em> que ha amado⁶, y se ha casado <em>con</em> la hija de un dios extraño.",
+          "tth": "Ha traicionado Iehudáh, y abominación se ha hecho en Israel y en Yerushaláim, porque ha profanado Iehudáh la Santidad de יהוה <em>con</em> que ha amado⁶, y se ha casado <em>con</em> la hija de un dios extraño.",
           "footnotes": [
             {
               "marker": "⁶",
@@ -207,13 +207,13 @@
         },
         {
           "verse": 12,
-          "tth": "Cortará __יהוה__ al hombre que lo haga, <em>al</em> que está despierto y <em>al</em> que responde, de las tiendas de Yaakov, y <em>aunque</em> acerque ofrenda de grano a __יהוה__ Tzebaot.",
+          "tth": "Cortará יהוה al hombre que lo haga, <em>al</em> que está despierto y <em>al</em> que responde, de las tiendas de Yaakov, y <em>aunque</em> acerque ofrenda de grano a יהוה Tzebaot.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 13,
-          "tth": "Y esta segunda <em>cosa</em> ustedes hacen: cubriendo de lágrimas el altar de __יהוה__, llanto y gemido, debido a que Él ya no mira hacia la ofrenda de grano ni <em>la</em> toma <em>con</em> aceptación⁷ de la mano de ustedes.",
+          "tth": "Y esta segunda <em>cosa</em> ustedes hacen: cubriendo de lágrimas el altar de יהוה, llanto y gemido, debido a que Él ya no mira hacia la ofrenda de grano ni <em>la</em> toma <em>con</em> aceptación⁷ de la mano de ustedes.",
           "footnotes": [
             {
               "marker": "⁷",
@@ -226,7 +226,7 @@
         },
         {
           "verse": 14,
-          "tth": "Y ustedes dicen: “¿Por qué? ” Porque __יהוה__ ha sido testigo entre tú y la mujer de tu juventud, a la cual tú has traicionado, ¡y ella es tu compañera y la mujer de tu pacto!",
+          "tth": "Y ustedes dicen: “¿Por qué? ” Porque יהוה ha sido testigo entre tú y la mujer de tu juventud, a la cual tú has traicionado, ¡y ella es tu compañera y la mujer de tu pacto!",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -251,13 +251,13 @@
         },
         {
           "verse": 16,
-          "tth": "Porque Él odia el divorcio –ha dicho __יהוה__, Elohim de Israel– y <em>al</em> que cubre de violencia sobre su vestido –ha dicho __יהוה__ Tzebaot–. Tengan cuidado en su espíritu, y no traicionen.",
+          "tth": "Porque Él odia el divorcio –ha dicho יהוה, Elohim de Israel– y <em>al</em> que cubre de violencia sobre su vestido –ha dicho יהוה Tzebaot–. Tengan cuidado en su espíritu, y no traicionen.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 17,
-          "tth": "Han cansado <em>a</em> __יהוה__ con sus palabras. Y ustedes dicen: ¿En qué hemos cansado? En que dicen: Todo el que hace mal es bueno en los ojos de __יהוה__, y en ellos Él se deleita; o: ¿Dónde está el Elohim del juicio?",
+          "tth": "Han cansado <em>a</em> יהוה con sus palabras. Y ustedes dicen: ¿En qué hemos cansado? En que dicen: Todo el que hace mal es bueno en los ojos de יהוה, y en ellos Él se deleita; o: ¿Dónde está el Elohim del juicio?",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -268,7 +268,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Heme aquí, envío <em>a</em> mi mensajero, y preparará el camino delante de Mí¹⁰. Y de repente vendrá a su Hejal¹¹ el Adón¹², <em>al</em> que ustedes buscan; y el mensajero del pacto <em>en</em> quien ustedes se deleitan, he aquí, viene –ha dicho __יהוה__ Tzebaot.",
+          "tth": "Heme aquí, envío <em>a</em> mi mensajero, y preparará el camino delante de Mí¹⁰. Y de repente vendrá a su Hejal¹¹ el Adón¹², <em>al</em> que ustedes buscan; y el mensajero del pacto <em>en</em> quien ustedes se deleitan, he aquí, viene –ha dicho יהוה Tzebaot.",
           "footnotes": [
             {
               "marker": "¹⁰",
@@ -299,32 +299,32 @@
         },
         {
           "verse": 3,
-          "tth": "Y Él se sentará, refinador y purificador de la plata, y purificará a los hijos de Levi y los refinará como al oro y como a la plata; y serán para __יהוה__ los que acerquen ofrenda de grano en justicia.",
+          "tth": "Y Él se sentará, refinador y purificador de la plata, y purificará a los hijos de Levi y los refinará como al oro y como a la plata; y serán para יהוה los que acerquen ofrenda de grano en justicia.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 4,
-          "tth": "Y será agradable a __יהוה__ la ofrenda de grano de Iehudáh y Yerushaláim, como <em>en</em> los días de la antigüedad y como <em>en</em> los años antiguos.",
+          "tth": "Y será agradable a יהוה la ofrenda de grano de Iehudáh y Yerushaláim, como <em>en</em> los días de la antigüedad y como <em>en</em> los años antiguos.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 5,
-          "tth": "Y me acercaré a ustedes para el juicio, y seré testigo veloz contra los hechiceros, contra los adúlteros, contra los que juran para mentira y contra los que oprimen el pago del asalariado, la viuda y el huérfano, y <em>contra</em> los torcedores del extranjero y los que no me temen –ha dicho __יהוה__ Tzebaot.",
+          "tth": "Y me acercaré a ustedes para el juicio, y seré testigo veloz contra los hechiceros, contra los adúlteros, contra los que juran para mentira y contra los que oprimen el pago del asalariado, la viuda y el huérfano, y <em>contra</em> los torcedores del extranjero y los que no me temen –ha dicho יהוה Tzebaot.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 6,
-          "tth": "Porque Yo, __יהוה__, no cambio, y ustedes, hijos de Yaakov no han sido acabados.",
+          "tth": "Porque Yo, יהוה, no cambio, y ustedes, hijos de Yaakov no han sido acabados.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "El décimo y la terumáh"
         },
         {
           "verse": 7,
-          "tth": "Desde los días de sus padres ustedes se han desviado de mis estatutos y no los guardaron. ¡Vuelvan a Mí y Yo volveré a ustedes! –ha dicho __יהוה__ Tzebaot. Y ustedes dicen: “¿Cómo volveremos? ”",
+          "tth": "Desde los días de sus padres ustedes se han desviado de mis estatutos y no los guardaron. ¡Vuelvan a Mí y Yo volveré a ustedes! –ha dicho יהוה Tzebaot. Y ustedes dicen: “¿Cómo volveremos? ”",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -349,7 +349,7 @@
         },
         {
           "verse": 10,
-          "tth": "Traigan todo el décimo a la casa del almacén, y haya alimento en mi casa; y pruébenme, por favor, en esto –ha dicho __יהוה__ Tzebaot– si no les abriré las ventanas de los cielos, y derramaré para ustedes bendición hasta no <em>dar</em> abasto.",
+          "tth": "Traigan todo el décimo a la casa del almacén, y haya alimento en mi casa; y pruébenme, por favor, en esto –ha dicho יהוה Tzebaot– si no les abriré las ventanas de los cielos, y derramaré para ustedes bendición hasta no <em>dar</em> abasto.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -368,20 +368,20 @@
         },
         {
           "verse": 12,
-          "tth": "Y los felicitarán todas las naciones, porque serán ustedes una tierra de deleite –ha dicho __יהוה__ Tzebaot.",
+          "tth": "Y los felicitarán todas las naciones, porque serán ustedes una tierra de deleite –ha dicho יהוה Tzebaot.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Distinción entre el justificado y el condenado"
         },
         {
           "verse": 13,
-          "tth": "Fueron fuertes contra Mí sus palabras –ha dicho __יהוה__–. Y ustedes dicen: ¿Qué hemos hablado contra ti?",
+          "tth": "Fueron fuertes contra Mí sus palabras –ha dicho יהוה–. Y ustedes dicen: ¿Qué hemos hablado contra ti?",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 14,
-          "tth": "Han dicho: “Vanidad es servir <em>a</em> Elohim. ¿Y qué ganancia <em>hay</em>?, porque hemos guardado su guardia y porque hemos caminado tristemente¹⁵ delante de __יהוה__ Tzebaot.",
+          "tth": "Han dicho: “Vanidad es servir <em>a</em> Elohim. ¿Y qué ganancia <em>hay</em>?, porque hemos guardado su guardia y porque hemos caminado tristemente¹⁵ delante de יהוה Tzebaot.",
           "footnotes": [
             {
               "marker": "¹⁵",
@@ -400,13 +400,13 @@
         },
         {
           "verse": 16,
-          "tth": "Entonces se hablaron los temerosos de __יהוה__, un hombre a su compañero, y prestó atención __יהוה__ y escuchó, y fue escrito un rollo de memoria delante de Él para los temerosos de __יהוה__ y para los que piensan <em>en</em> su Nombre.",
+          "tth": "Entonces se hablaron los temerosos de יהוה, un hombre a su compañero, y prestó atención יהוה y escuchó, y fue escrito un rollo de memoria delante de Él para los temerosos de יהוה y para los que piensan <em>en</em> su Nombre.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 17,
-          "tth": "Y ellos serán para Mí –ha dicho __יהוה__ Tzebaot–, para el día <em>en</em> que Yo haga adquisición¹⁶, y tendré compasión por ellos como tiene compasión un hombre por su hijo, el siervo suyo.",
+          "tth": "Y ellos serán para Mí –ha dicho יהוה Tzebaot–, para el día <em>en</em> que Yo haga adquisición¹⁶, y tendré compasión por ellos como tiene compasión un hombre por su hijo, el siervo suyo.",
           "footnotes": [
             {
               "marker": "¹⁶",
@@ -419,7 +419,7 @@
         },
         {
           "verse": 18,
-          "tth": "Y volverán y verán entre el justificado y el condenado, entre el siervo de Elohim y el que no le sirve. <em>El gran día de</em>__יהוה__",
+          "tth": "Y volverán y verán entre el justificado y el condenado, entre el siervo de Elohim y el que no le sirve. <em>El gran día de</em> יהוה",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -430,7 +430,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Porque he aquí, el día viene, quema como el horno, y serán todos los insolentes y todo hacedor de condenación <em>como</em> paja; y los prenderá fuego el día que viene –ha dicho __יהוה__ Tzebaot–, que no les dejará raíz y rama.",
+          "tth": "Porque he aquí, el día viene, quema como el horno, y serán todos los insolentes y todo hacedor de condenación <em>como</em> paja; y los prenderá fuego el día que viene –ha dicho יהוה Tzebaot–, que no les dejará raíz y rama.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -449,7 +449,7 @@
         },
         {
           "verse": 3,
-          "tth": "Y aplastarán <em>a</em> los malvados, porque ellos serán ceniza debajo de las plantas de los pies de ustedes, en el día que Yo haga –ha dicho __יהוה__ Tzebaot.",
+          "tth": "Y aplastarán <em>a</em> los malvados, porque ellos serán ceniza debajo de las plantas de los pies de ustedes, en el día que Yo haga –ha dicho יהוה Tzebaot.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -468,7 +468,7 @@
         },
         {
           "verse": 5,
-          "tth": "He aquí, Yo envío para ustedes a Eliyah el profeta antes de venir el día de __יהוה__, el grande y el temible.",
+          "tth": "He aquí, Yo envío para ustedes a Eliyah el profeta antes de venir el día de יהוה, el grande y el temible.",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/melajim_alef.json
+++ b/data/tth_2/json/melajim_alef.json
@@ -126,7 +126,7 @@
         },
         {
           "verse": 17,
-          "tth": "Y ella le dijo: Amo mío, tú juraste por __יהוה__ tu Elohim a tu sierva: “Porque Shelomóh tu hijo reinará después de mí, y él se sentará sobre mi trono”.",
+          "tth": "Y ella le dijo: Amo mío, tú juraste por יהוה tu Elohim a tu sierva: “Porque Shelomóh tu hijo reinará después de mí, y él se sentará sobre mi trono”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -198,13 +198,13 @@
         },
         {
           "verse": 29,
-          "tth": "Y juró el rey, y dijo: Vive __יהוה__, que ha redimido mi ser de toda angustia,",
+          "tth": "Y juró el rey, y dijo: Vive יהוה, que ha redimido mi ser de toda angustia,",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 30,
-          "tth": "que como juré a ti por __יהוה__, Elohim de Israel, diciendo: “Porque Shelomóh tu hijo reinará después de mí y él se sentará sobre mi trono en mi lugar”, pues así haré este día.",
+          "tth": "que como juré a ti por יהוה, Elohim de Israel, diciendo: “Porque Shelomóh tu hijo reinará después de mí y él se sentará sobre mi trono en mi lugar”, pues así haré este día.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -240,13 +240,13 @@
         },
         {
           "verse": 36,
-          "tth": "Y respondió Benaiáhu, hijo de Iehoiada, al rey, y dijo: ¡Amén! ¡Así dirá __יהוה__, Elohim de mi amo el rey!",
+          "tth": "Y respondió Benaiáhu, hijo de Iehoiada, al rey, y dijo: ¡Amén! ¡Así dirá יהוה, Elohim de mi amo el rey!",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 37,
-          "tth": "Como ha estado __יהוה__ con mi amo el rey, así estará con Shelomóh, y engrandecerá más su trono que el trono de mi amo el rey David.",
+          "tth": "Como ha estado יהוה con mi amo el rey, así estará con Shelomóh, y engrandecerá más su trono que el trono de mi amo el rey David.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -332,7 +332,7 @@
         },
         {
           "verse": 48,
-          "tth": "Y también así dijo el rey: ¡Bendito es __יהוה__, Elohim de Israel!, que ha permitido hoy que él se siente sobre mi trono, y mis ojos vieron.",
+          "tth": "Y también así dijo el rey: ¡Bendito es יהוה, Elohim de Israel!, que ha permitido hoy que él se siente sobre mi trono, y mis ojos vieron.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -385,13 +385,13 @@
         },
         {
           "verse": 3,
-          "tth": "Y guardarás la guardia de __יהוה__ tu Elohim para ir en sus caminos, para guardar sus estatutos, sus mandamientos y sus procesos legales y sus testimonios, conforme a la escritura en la Torah de Moshéh, a fin de que seas prudente con todo lo que hagas y con todo lo que te vuelvas allí,",
+          "tth": "Y guardarás la guardia de יהוה tu Elohim para ir en sus caminos, para guardar sus estatutos, sus mandamientos y sus procesos legales y sus testimonios, conforme a la escritura en la Torah de Moshéh, a fin de que seas prudente con todo lo que hagas y con todo lo que te vuelvas allí,",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 4,
-          "tth": "a fin de que levante __יהוה__ su palabra que habló sobre mí, diciendo: “Si guardan tus hijos su camino, para andar delante de Mí en verdad, con todo su corazón y con todo su ser”, diciendo: “No será cortado de ti hombre de sobre el trono de Israel”.",
+          "tth": "a fin de que levante יהוה su palabra que habló sobre mí, diciendo: “Si guardan tus hijos su camino, para andar delante de Mí en verdad, con todo su corazón y con todo su ser”, diciendo: “No será cortado de ti hombre de sobre el trono de Israel”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -429,7 +429,7 @@
         },
         {
           "verse": 8,
-          "tth": "Y he aquí, contigo está Shimei, hijo de Guerá, benieminí de Bajurím; y él me despreció con enfermizo desprecio en el día de mi ida a Majanáim; pero descendió a mi encuentro al Iardén⁹, y juré a él por __יהוה__, diciendo: “¡Si te mataría con espada! ”",
+          "tth": "Y he aquí, contigo está Shimei, hijo de Guerá, benieminí de Bajurím; y él me despreció con enfermizo desprecio en el día de mi ida a Majanáim; pero descendió a mi encuentro al Iardén⁹, y juré a él por יהוה, diciendo: “¡Si te mataría con espada! ”",
           "footnotes": [
             {
               "marker": "⁹",
@@ -478,7 +478,7 @@
         },
         {
           "verse": 15,
-          "tth": "Y él dijo: Tú sabes que para mí era el reino y sobre mí ponían en todo Israel sus rostros para reinar; pero se ha volteado el reino y ha sido para mi hermano, porque de __יהוה__ era para él.",
+          "tth": "Y él dijo: Tú sabes que para mí era el reino y sobre mí ponían en todo Israel sus rostros para reinar; pero se ha volteado el reino y ha sido para mi hermano, porque de יהוה era para él.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -533,13 +533,13 @@
         },
         {
           "verse": 23,
-          "tth": "Y juró el rey Shelomóh por __יהוה__, diciendo: Así hará a mí Elohim, y así aumentará, que contra su vida ha hablado Adoniyáhu esta palabra.",
+          "tth": "Y juró el rey Shelomóh por יהוה, diciendo: Así hará a mí Elohim, y así aumentará, que contra su vida ha hablado Adoniyáhu esta palabra.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 24,
-          "tth": "Y ahora, vive __יהוה__ que me ha afirmado y me ha hecho sentar sobre el trono de David mi padre, y que ha hecho para mí una casa como había hablado, que hoy morirá Adoniyáhu.",
+          "tth": "Y ahora, vive יהוה que me ha afirmado y me ha hecho sentar sobre el trono de David mi padre, y que ha hecho para mí una casa como había hablado, que hoy morirá Adoniyáhu.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -551,31 +551,31 @@
         },
         {
           "verse": 26,
-          "tth": "Y a Ebiatar el sacerdote dijo el rey: A Anatot ve, a tu campo, porque hombre de muerte eres tú; pero en este día no te haré morir, porque cargaste el arca de Adonai __יהוה__ delante de David mi padre, y porque fuiste afligido con todo lo que fue afligido mi padre.",
+          "tth": "Y a Ebiatar el sacerdote dijo el rey: A Anatot ve, a tu campo, porque hombre de muerte eres tú; pero en este día no te haré morir, porque cargaste el arca de Adonai יהוה delante de David mi padre, y porque fuiste afligido con todo lo que fue afligido mi padre.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 27,
-          "tth": "Y expulsó Shelomóh a Ebiatar de ser sacerdote de __יהוה__, para cumplir la palabra de __יהוה__ que habló sobre la casa de Elí en Shiloh.",
+          "tth": "Y expulsó Shelomóh a Ebiatar de ser sacerdote de יהוה, para cumplir la palabra de יהוה que habló sobre la casa de Elí en Shiloh.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 28,
-          "tth": "Y el informe vino hasta Ioab, porque Ioab se había vuelto tras de Adoniyáh, pero tras de Abshalom no se volvió; y huyó Ioab a la Tienda de __יהוה__, y se apoderó de los cuernos del altar.",
+          "tth": "Y el informe vino hasta Ioab, porque Ioab se había vuelto tras de Adoniyáh, pero tras de Abshalom no se volvió; y huyó Ioab a la Tienda de יהוה, y se apoderó de los cuernos del altar.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 29,
-          "tth": "Y fue dado a conocer al rey Shelomóh que había huido Ioab a la Tienda de __יהוה__, y he aquí, estaba al lado del altar. Y envió Shelomóh a Benaiáhu, hijo de Iehoiada, diciendo: Ve, golpea contra él.",
+          "tth": "Y fue dado a conocer al rey Shelomóh que había huido Ioab a la Tienda de יהוה, y he aquí, estaba al lado del altar. Y envió Shelomóh a Benaiáhu, hijo de Iehoiada, diciendo: Ve, golpea contra él.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 30,
-          "tth": "Y entró Benaiáhu a la Tienda de __יהוה__, y le dijo: Así ha dicho el rey: “¡Sal! ” Y él dijo: No, porque aquí moriré. Y regresó Benaiáhu al rey la palabra, diciendo: Así habló Ioab y así me respondió.",
+          "tth": "Y entró Benaiáhu a la Tienda de יהוה, y le dijo: Así ha dicho el rey: “¡Sal! ” Y él dijo: No, porque aquí moriré. Y regresó Benaiáhu al rey la palabra, diciendo: Así habló Ioab y así me respondió.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -587,13 +587,13 @@
         },
         {
           "verse": 32,
-          "tth": "Y hará volver __יהוה__ su sangre sobre su cabeza, que ha golpeado contra dos hombres más justos y buenos que él y los mató con la espada, y mi padre David no sabía: a Abner, hijo de Ner, jefe del ejército de Israel, y a Amasa, hijo de Ieter, jefe del ejército de Iehudáh.",
+          "tth": "Y hará volver יהוה su sangre sobre su cabeza, que ha golpeado contra dos hombres más justos y buenos que él y los mató con la espada, y mi padre David no sabía: a Abner, hijo de Ner, jefe del ejército de Israel, y a Amasa, hijo de Ieter, jefe del ejército de Iehudáh.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 33,
-          "tth": "Y volverá la sangre de ellos en la cabeza de Ioab y en la cabeza de su simiente para siempre; pero para David y para su simiente, para su casa y para su trono, habrá shalom hasta el olam¹¹ de con __יהוה__.",
+          "tth": "Y volverá la sangre de ellos en la cabeza de Ioab y en la cabeza de su simiente para siempre; pero para David y para su simiente, para su casa y para su trono, habrá shalom hasta el olam¹¹ de con יהוה.",
           "footnotes": [
             {
               "marker": "¹¹",
@@ -674,25 +674,25 @@
         },
         {
           "verse": 42,
-          "tth": "Y envió el rey y llamó a Shimei, y le dijo: ¿No te hice jurar por __יהוה__ y te repetí, diciendo: “En el día de tu salida y de tu ida de aquí para allá, ciertamente sabrás que muriendo, morirás”? Y me dijiste: “Buena es la palabra, he oído”.",
+          "tth": "Y envió el rey y llamó a Shimei, y le dijo: ¿No te hice jurar por יהוה y te repetí, diciendo: “En el día de tu salida y de tu ida de aquí para allá, ciertamente sabrás que muriendo, morirás”? Y me dijiste: “Buena es la palabra, he oído”.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 43,
-          "tth": "¿Y por qué no guardaste el juramento de __יהוה__ y el mandamiento que ordené sobre ti?",
+          "tth": "¿Y por qué no guardaste el juramento de יהוה y el mandamiento que ordené sobre ti?",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 44,
-          "tth": "Y dijo el rey a Shimei: Tú sabes todo el mal que conoce tu corazón que hiciste a David mi padre; y hará volver __יהוה__ tu maldad en tu cabeza.",
+          "tth": "Y dijo el rey a Shimei: Tú sabes todo el mal que conoce tu corazón que hiciste a David mi padre; y hará volver יהוה tu maldad en tu cabeza.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 45,
-          "tth": "Pero el rey Shelomóh será bendito, y el trono de David será firme delante de __יהוה__ hasta el olam.",
+          "tth": "Pero el rey Shelomóh será bendito, y el trono de David será firme delante de יהוה hasta el olam.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -709,7 +709,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y se emparentó Shelomóh con Faraón, rey de Mitzráim, y tomó a la hija de Faraón y la trajo a la ciudad de David mientras¹⁵ acababa de edificar su casa, la casa de __יהוה__ y el muro de Yerushaláim alrededor.",
+          "tth": "Y se emparentó Shelomóh con Faraón, rey de Mitzráim, y tomó a la hija de Faraón y la trajo a la ciudad de David mientras¹⁵ acababa de edificar su casa, la casa de יהוה y el muro de Yerushaláim alrededor.",
           "footnotes": [
             {
               "marker": "¹⁵",
@@ -722,13 +722,13 @@
         },
         {
           "verse": 2,
-          "tth": "Sólo que el pueblo sacrificaba en los lugares altos, pues no se había edificado casa al Nombre de __יהוה__ hasta aquellos días. Sabiduría de Shelomóh",
+          "tth": "Sólo que el pueblo sacrificaba en los lugares altos, pues no se había edificado casa al Nombre de יהוה hasta aquellos días. Sabiduría de Shelomóh",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 3,
-          "tth": "Y amó Shelomóh a __יהוה__, al andar en los decretos de David su padre, sólo que en los lugares altos él sacrificaba y quemaba incienso.",
+          "tth": "Y amó Shelomóh a יהוה, al andar en los decretos de David su padre, sólo que en los lugares altos él sacrificaba y quemaba incienso.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -740,7 +740,7 @@
         },
         {
           "verse": 5,
-          "tth": "En Guibeón apareció __יהוה__ a Shelomóh en un sueño esa noche, y dijo Elohim: Pide, ¿qué te daré?",
+          "tth": "En Guibeón apareció יהוה a Shelomóh en un sueño esa noche, y dijo Elohim: Pide, ¿qué te daré?",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -759,7 +759,7 @@
         },
         {
           "verse": 7,
-          "tth": "Y ahora, __יהוה__ Elohim mío, Tú has hecho reinar a tu siervo en lugar de David mi padre, pero yo soy un joven pequeño, no sé salir y entrar.",
+          "tth": "Y ahora, יהוה Elohim mío, Tú has hecho reinar a tu siervo en lugar de David mi padre, pero yo soy un joven pequeño, no sé salir y entrar.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1166,19 +1166,19 @@
         },
         {
           "verse": 3,
-          "tth": "Tú conoces a David mi padre, que no pudo edificar una casa al Nombre de __יהוה__ su Elohim debido a la guerra en que lo rodearon, hasta ponerlos __יהוה__ abajo de las palmas de sus pies.",
+          "tth": "Tú conoces a David mi padre, que no pudo edificar una casa al Nombre de יהוה su Elohim debido a la guerra en que lo rodearon, hasta ponerlos יהוה abajo de las palmas de sus pies.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 4,
-          "tth": "Pero ahora me ha hecho descansar __יהוה__ mi Elohim a mí de alrededor; no hay adversario y no hay ocurrencia mala.",
+          "tth": "Pero ahora me ha hecho descansar יהוה mi Elohim a mí de alrededor; no hay adversario y no hay ocurrencia mala.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 5,
-          "tth": "Y he aquí, digo de construir una casa para el Nombre de __יהוה__ mi Elohim, como habló __יהוה__ a David mi padre, diciendo: “Tu hijo quien pondré en tu lugar sobre tu trono, él edificará la casa a mi Nombre”.",
+          "tth": "Y he aquí, digo de construir una casa para el Nombre de יהוה mi Elohim, como habló יהוה a David mi padre, diciendo: “Tu hijo quien pondré en tu lugar sobre tu trono, él edificará la casa a mi Nombre”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1190,7 +1190,7 @@
         },
         {
           "verse": 7,
-          "tth": "Y sucedió que cuando escuchó Jiram las palabras de Shelomóh, se alegró mucho y dijo: ¡Bendito sea __יהוה__ hoy, que dio a David un hijo sabio sobre este pueblo grande!",
+          "tth": "Y sucedió que cuando escuchó Jiram las palabras de Shelomóh, se alegró mucho y dijo: ¡Bendito sea יהוה hoy, que dio a David un hijo sabio sobre este pueblo grande!",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1233,7 +1233,7 @@
         },
         {
           "verse": 12,
-          "tth": "Y יהוה dio sabiduría a Shelomóh, como había hablado a él, y hubo shalom entre Jiram y Shelomóh, e hicieron²⁶ un pacto los dos. Edificación de la casa de __יהוה__",
+          "tth": "Y יהוה dio sabiduría a Shelomóh, como había hablado a él, y hubo shalom entre Jiram y Shelomóh, e hicieron²⁶ un pacto los dos. Edificación de la casa de יהוה",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1287,7 +1287,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y sucedió que en el año cuatrocientos ochenta de la salida de los hijos de Israel de la tierra de Mitzráim, en el año cuarto, en el mes de Ziv²⁹, este es el mes segundo, del reinado de Shelomóh sobre Israel, él edificó la casa para __יהוה__.",
+          "tth": "Y sucedió que en el año cuatrocientos ochenta de la salida de los hijos de Israel de la tierra de Mitzráim, en el año cuarto, en el mes de Ziv²⁹, este es el mes segundo, del reinado de Shelomóh sobre Israel, él edificó la casa para יהוה.",
           "footnotes": [
             {
               "marker": "²⁹",
@@ -1300,7 +1300,7 @@
         },
         {
           "verse": 2,
-          "tth": "Y la casa que edificó el rey Shelomóh para __יהוה__, setenta codos era su largo, veinte su ancho, y treinta codos su alto.",
+          "tth": "Y la casa que edificó el rey Shelomóh para יהוה, setenta codos era su largo, veinte su ancho, y treinta codos su alto.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1361,7 +1361,7 @@
         },
         {
           "verse": 11,
-          "tth": "Y fue la palabra de __יהוה__ a Shelomóh, diciendo:",
+          "tth": "Y fue la palabra de יהוה a Shelomóh, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1429,7 +1429,7 @@
         },
         {
           "verse": 19,
-          "tth": "Y la habitación más interna en medio de la casa, desde adentro, él afirmó para poner allí el arca del Pacto de __יהוה__.",
+          "tth": "Y la habitación más interna en medio de la casa, desde adentro, él afirmó para poner allí el arca del Pacto de יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1544,7 +1544,7 @@
         },
         {
           "verse": 37,
-          "tth": "En el año cuarto se fundó la casa de __יהוה__, en el mes lunar de Ziv³⁵.",
+          "tth": "En el año cuarto se fundó la casa de יהוה, en el mes lunar de Ziv³⁵.",
           "footnotes": [
             {
               "marker": "³⁵",
@@ -1641,7 +1641,7 @@
         },
         {
           "verse": 12,
-          "tth": "Y el gran patio tenía alrededor tres filas de piedras talladas y una fila de vigas cortadas de cedros; y así fue para el patio de la casa de __יהוה__, el interior, y para el pórtico de la casa. Jiram trabaja en la obra",
+          "tth": "Y el gran patio tenía alrededor tres filas de piedras talladas y una fila de vigas cortadas de cedros; y así fue para el patio de la casa de יהוה, el interior, y para el pórtico de la casa. Jiram trabaja en la obra",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1878,7 +1878,7 @@
         },
         {
           "verse": 40,
-          "tth": "E hizo Jiram las fuentes, las palas y los tazones. Y acabó Jiram de hacer todo el trabajo que hizo para el rey Shelomóh en la casa de __יהוה__:",
+          "tth": "E hizo Jiram las fuentes, las palas y los tazones. Y acabó Jiram de hacer todo el trabajo que hizo para el rey Shelomóh en la casa de יהוה:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1908,7 +1908,7 @@
         },
         {
           "verse": 45,
-          "tth": "y las ollas, las palas y los tazones; y todos estos utensilios que hizo Jiram para el rey Shelomóh en la casa de __יהוה__ eran de cobre pulido.",
+          "tth": "y las ollas, las palas y los tazones; y todos estos utensilios que hizo Jiram para el rey Shelomóh en la casa de יהוה eran de cobre pulido.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1933,7 +1933,7 @@
         },
         {
           "verse": 48,
-          "tth": "E hizo Shelomóh todos los utensilios que estaban en la casa de __יהוה__: el altar de oro y la mesa de oro que sobre ella estaba el pan del Rostro;",
+          "tth": "E hizo Shelomóh todos los utensilios que estaban en la casa de יהוה: el altar de oro y la mesa de oro que sobre ella estaba el pan del Rostro;",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1965,7 +1965,7 @@
         },
         {
           "verse": 51,
-          "tth": "Y fue completada toda la obra que hizo el rey Shelomóh en la casa de __יהוה__. Y trajo Shelomóh las santidades de David su padre: la plata, el oro y los utensilios, los puso en los tesoros de la casa de __יהוה__. El arca es llevada al Templo",
+          "tth": "Y fue completada toda la obra que hizo el rey Shelomóh en la casa de יהוה. Y trajo Shelomóh las santidades de David su padre: la plata, el oro y los utensilios, los puso en los tesoros de la casa de יהוה. El arca es llevada al Templo",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -1976,7 +1976,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Entonces reunió Shelomóh a los ancianos de Israel, a todas las cabezas de las tribus, jefes de los padres de los hijos de Israel, hacia el rey Shelomóh en Yerushaláim, para hacer subir el arca del Pacto de __יהוה__ de la ciudad de David, esta es Tzión.",
+          "tth": "Entonces reunió Shelomóh a los ancianos de Israel, a todas las cabezas de las tribus, jefes de los padres de los hijos de Israel, hacia el rey Shelomóh en Yerushaláim, para hacer subir el arca del Pacto de יהוה de la ciudad de David, esta es Tzión.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1994,7 +1994,7 @@
         },
         {
           "verse": 4,
-          "tth": "Y subieron el arca de __יהוה__, la Tienda del Mo’ed⁵² y todos los utensilios de la Santidad que estaban en la Tienda, y los subieron los sacerdotes y los leviím⁵³.",
+          "tth": "Y subieron el arca de יהוה, la Tienda del Mo’ed⁵² y todos los utensilios de la Santidad que estaban en la Tienda, y los subieron los sacerdotes y los leviím⁵³.",
           "footnotes": [
             {
               "marker": "⁵²",
@@ -2019,7 +2019,7 @@
         },
         {
           "verse": 6,
-          "tth": "Y trajeron los sacerdotes el arca del Pacto de __יהוה__ a su lugar, a la habitación más interna⁵⁴ de la casa, a la Santidad de Santidades, debajo de las alas de los querubines.",
+          "tth": "Y trajeron los sacerdotes el arca del Pacto de יהוה a su lugar, a la habitación más interna⁵⁴ de la casa, a la Santidad de Santidades, debajo de las alas de los querubines.",
           "footnotes": [
             {
               "marker": "⁵⁴",
@@ -2044,7 +2044,7 @@
         },
         {
           "verse": 9,
-          "tth": "No había en el arca nada excepto las dos tablas de piedra que dejó allí Moshéh en Joreb, donde hizo⁵⁵ __יהוה__ con los hijos de Israel el pacto en su salida de la tierra de Mitzráim.",
+          "tth": "No había en el arca nada excepto las dos tablas de piedra que dejó allí Moshéh en Joreb, donde hizo⁵⁵ יהוה con los hijos de Israel el pacto en su salida de la tierra de Mitzráim.",
           "footnotes": [
             {
               "marker": "⁵⁵",
@@ -2063,13 +2063,13 @@
         },
         {
           "verse": 11,
-          "tth": "Y no pudieron los sacerdotes pararse para ministrar debido a la nube, porque llenó la gloria de __יהוה__ la casa de __יהוה__.",
+          "tth": "Y no pudieron los sacerdotes pararse para ministrar debido a la nube, porque llenó la gloria de יהוה la casa de יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 12,
-          "tth": "Entonces dijo Shelomóh: __יהוה__ dijo de morar en la densa nube.",
+          "tth": "Entonces dijo Shelomóh: יהוה dijo de morar en la densa nube.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2100,7 +2100,7 @@
         },
         {
           "verse": 15,
-          "tth": "y dijo: Bendito sea __יהוה__, Elohim de Israel, que habló con su boca a David mi padre, y con su mano lo ha completado, diciendo:",
+          "tth": "y dijo: Bendito sea יהוה, Elohim de Israel, que habló con su boca a David mi padre, y con su mano lo ha completado, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2112,13 +2112,13 @@
         },
         {
           "verse": 17,
-          "tth": "Y estuvo con el corazón de mi padre el edificar una casa al Nombre de __יהוה__, Elohim de Israel.",
+          "tth": "Y estuvo con el corazón de mi padre el edificar una casa al Nombre de יהוה, Elohim de Israel.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 18,
-          "tth": "Pero dijo __יהוה__ a David mi padre: “Porque estuvo con tu corazón el edificar una casa a mi Nombre, bien hiciste que estuviera con tu corazón.",
+          "tth": "Pero dijo יהוה a David mi padre: “Porque estuvo con tu corazón el edificar una casa a mi Nombre, bien hiciste que estuviera con tu corazón.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2130,25 +2130,25 @@
         },
         {
           "verse": 20,
-          "tth": "Y levantó __יהוה__ su palabra la cual habló, y me he levantado en lugar de David mi padre y me he sentado sobre el trono de Israel, como había hablado __יהוה__, y he edificado la casa al Nombre de __יהוה__, Elohim de Israel.",
+          "tth": "Y levantó יהוה su palabra la cual habló, y me he levantado en lugar de David mi padre y me he sentado sobre el trono de Israel, como había hablado יהוה, y he edificado la casa al Nombre de יהוה, Elohim de Israel.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 21,
-          "tth": "Y puse allí un lugar para el arca, que allí está el pacto de __יהוה__ el cual hizo⁵⁸ con nuestros padres cuando los hizo salir de la tierra de Mitzráim. Oración de dedicación de la casa",
+          "tth": "Y puse allí un lugar para el arca, que allí está el pacto de יהוה el cual hizo⁵⁸ con nuestros padres cuando los hizo salir de la tierra de Mitzráim. Oración de dedicación de la casa",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 22,
-          "tth": "Y se paró Shelomóh delante del altar de __יהוה__ frente a toda la asamblea de Israel, y extendió sus palmas a los cielos.",
+          "tth": "Y se paró Shelomóh delante del altar de יהוה frente a toda la asamblea de Israel, y extendió sus palmas a los cielos.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 23,
-          "tth": "y dijo: ¡__יהוה__, Elohim de Israel! No hay como Tú dios en los cielos de arriba, ni sobre la tierra de abajo, que guardas el pacto y haces misericordia para tus siervos, los que andan delante de ti con todo su corazón,",
+          "tth": "y dijo: ¡יהוה, Elohim de Israel! No hay como Tú dios en los cielos de arriba, ni sobre la tierra de abajo, que guardas el pacto y haces misericordia para tus siervos, los que andan delante de ti con todo su corazón,",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2160,7 +2160,7 @@
         },
         {
           "verse": 25,
-          "tth": "Y ahora, __יהוה__, Elohim de Israel, guarda para tu siervo David mi padre lo que hablaste a él, diciendo: “No será cortado de ti hombre de delante de Mí que se siente sobre el trono de Israel, sólo si guardan tus hijos su camino, para andar delante de Mí como tú has andado delante de Mí”.",
+          "tth": "Y ahora, יהוה, Elohim de Israel, guarda para tu siervo David mi padre lo que hablaste a él, diciendo: “No será cortado de ti hombre de delante de Mí que se siente sobre el trono de Israel, sólo si guardan tus hijos su camino, para andar delante de Mí como tú has andado delante de Mí”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2178,7 +2178,7 @@
         },
         {
           "verse": 28,
-          "tth": "Pero, vuélvete hacia la oración de tu siervo y hacia su súplica, ¡__יהוה__, Elohim mío!, para escuchar el clamor y la oración que tu siervo ora delante de ti hoy;",
+          "tth": "Pero, vuélvete hacia la oración de tu siervo y hacia su súplica, ¡יהוה, Elohim mío!, para escuchar el clamor y la oración que tu siervo ora delante de ti hoy;",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2281,7 +2281,7 @@
         },
         {
           "verse": 44,
-          "tth": "Cuando salga tu pueblo a la batalla sobre su enemigo, por el camino que los envíes, y oren a __יהוה__ hacia el camino de la ciudad que has escogido a ella, y hacia la casa que he edificado a tu Nombre,",
+          "tth": "Cuando salga tu pueblo a la batalla sobre su enemigo, por el camino que los envíes, y oren a יהוה hacia el camino de la ciudad que has escogido a ella, y hacia la casa que he edificado a tu Nombre,",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2349,13 +2349,13 @@
         },
         {
           "verse": 53,
-          "tth": "Porque Tú los has separado para ti por herencia de entre todos los pueblos de la tierra, como hablaste por mano de Moshéh tu siervo, cuando sacaste a nuestros padres de Mitzráim, ¡Adonai __יהוה__!",
+          "tth": "Porque Tú los has separado para ti por herencia de entre todos los pueblos de la tierra, como hablaste por mano de Moshéh tu siervo, cuando sacaste a nuestros padres de Mitzráim, ¡Adonai יהוה!",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 54,
-          "tth": "Y sucedió que cuando terminó Shelomóh de pronunciar en juicio a __יהוה__ toda esta tefilah y súplica, se levantó de delante del altar de __יהוה__, de arrodillarse sobre sus rodillas y sus palmas extendidas a los cielos.",
+          "tth": "Y sucedió que cuando terminó Shelomóh de pronunciar en juicio a יהוה toda esta tefilah y súplica, se levantó de delante del altar de יהוה, de arrodillarse sobre sus rodillas y sus palmas extendidas a los cielos.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2367,13 +2367,13 @@
         },
         {
           "verse": 56,
-          "tth": "¡Bendito sea __יהוה__!, que ha dado descanso a su pueblo Israel, conforme a todo lo que habló; no ha caído una palabra de toda su buena palabra que habló por mano de Moshéh, su siervo.",
+          "tth": "¡Bendito sea יהוה!, que ha dado descanso a su pueblo Israel, conforme a todo lo que habló; no ha caído una palabra de toda su buena palabra que habló por mano de Moshéh, su siervo.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 57,
-          "tth": "Estará __יהוה__ nuestro Elohim con nosotros como estuvo con nuestros padres; no nos dejará y no nos abandonará,",
+          "tth": "Estará יהוה nuestro Elohim con nosotros como estuvo con nuestros padres; no nos dejará y no nos abandonará,",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2404,37 +2404,37 @@
         },
         {
           "verse": 59,
-          "tth": "Y estén estas palabras mías, las cuales he suplicado delante de __יהוה__, cercanas a __יהוה__ nuestro Elohim día y noche, para hacer justicia de su siervo y justicia de su pueblo Israel, cosa de un día en su día;",
+          "tth": "Y estén estas palabras mías, las cuales he suplicado delante de יהוה, cercanas a יהוה nuestro Elohim día y noche, para hacer justicia de su siervo y justicia de su pueblo Israel, cosa de un día en su día;",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 60,
-          "tth": "a fin de conocer todos los pueblos de la tierra que __יהוה__, Él es el Elohim, no hay más.",
+          "tth": "a fin de conocer todos los pueblos de la tierra que יהוה, Él es el Elohim, no hay más.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 61,
-          "tth": "Y estén sus corazones completos con __יהוה__ Elohim nuestro, para andar en sus decretos y para guardar sus mandamientos, como este día.",
+          "tth": "Y estén sus corazones completos con יהוה Elohim nuestro, para andar en sus decretos y para guardar sus mandamientos, como este día.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 62,
-          "tth": "Y el rey, y todo el pueblo con él, sacrificaron sacrificios delante de __יהוה__.",
+          "tth": "Y el rey, y todo el pueblo con él, sacrificaron sacrificios delante de יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 63,
-          "tth": "Sacrificó Shelomóh un sacrificio de retribuciones, el cual sacrificó a __יהוה__, veintidós mil bueyes y ciento veinte mil ovejas. Y dedicaron la casa de __יהוה__, el rey y todos los hijos de Israel.",
+          "tth": "Sacrificó Shelomóh un sacrificio de retribuciones, el cual sacrificó a יהוה, veintidós mil bueyes y ciento veinte mil ovejas. Y dedicaron la casa de יהוה, el rey y todos los hijos de Israel.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 64,
-          "tth": "En aquel día consagró el rey el centro del patio que estaba delante de la casa de __יהוה__, pues hizo allí la ofrenda ascendida, la ofrenda de grano y las grosuras de las retribuciones; porque el altar de cobre que estaba delante de __יהוה__ era pequeño para contener la ofrenda ascendida⁶⁵, la ofrenda de grano⁶⁶ y las grosuras de las retribuciones⁶⁷.",
+          "tth": "En aquel día consagró el rey el centro del patio que estaba delante de la casa de יהוה, pues hizo allí la ofrenda ascendida, la ofrenda de grano y las grosuras de las retribuciones; porque el altar de cobre que estaba delante de יהוה era pequeño para contener la ofrenda ascendida⁶⁵, la ofrenda de grano⁶⁶ y las grosuras de las retribuciones⁶⁷.",
           "footnotes": [
             {
               "marker": "⁶⁵",
@@ -2459,13 +2459,13 @@
         },
         {
           "verse": 65,
-          "tth": "E hizo Shelomóh en aquel tiempo la fiesta, y todo Israel con él, una gran asamblea desde la entrada de Jamat hasta el arroyo de Mitzráim, delante de __יהוה__ nuestro Elohim, siete días y siete días, catorce días.",
+          "tth": "E hizo Shelomóh en aquel tiempo la fiesta, y todo Israel con él, una gran asamblea desde la entrada de Jamat hasta el arroyo de Mitzráim, delante de יהוה nuestro Elohim, siete días y siete días, catorce días.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 66,
-          "tth": "En el día octavo envió al pueblo. Y bendijeron al rey y se fueron a sus tiendas alegres y agradables de corazón por todo el bien que había hecho __יהוה__ a David su siervo y a Israel su pueblo. Pacto de Elohim con Shelomóh",
+          "tth": "En el día octavo envió al pueblo. Y bendijeron al rey y se fueron a sus tiendas alegres y agradables de corazón por todo el bien que había hecho יהוה a David su siervo y a Israel su pueblo. Pacto de Elohim con Shelomóh",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -2476,19 +2476,19 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y sucedió que cuando acabó Shelomóh de edificar la casa de __יהוה__ y la casa del rey, y todo el deseo de Shelomóh que le placía hacer,",
+          "tth": "Y sucedió que cuando acabó Shelomóh de edificar la casa de יהוה y la casa del rey, y todo el deseo de Shelomóh que le placía hacer,",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 2,
-          "tth": "se apareció __יהוה__ a Shelomóh por segunda vez, como se había aparecido a él en Guibeón.",
+          "tth": "se apareció יהוה a Shelomóh por segunda vez, como se había aparecido a él en Guibeón.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 3,
-          "tth": "Y le dijo __יהוה__: He oído tu tefilah⁶⁸ y tu súplica que has suplicado delante de Mí; he consagrado esta casa que has edificado, para poner mi Nombre allí hasta siempre; y estarán mis ojos y mi corazón allí todos los días.",
+          "tth": "Y le dijo יהוה: He oído tu tefilah⁶⁸ y tu súplica que has suplicado delante de Mí; he consagrado esta casa que has edificado, para poner mi Nombre allí hasta siempre; y estarán mis ojos y mi corazón allí todos los días.",
           "footnotes": [
             {
               "marker": "⁶⁸",
@@ -2525,7 +2525,7 @@
         },
         {
           "verse": 8,
-          "tth": "Y esta casa que es exaltada⁶⁹, todo el que pase por ella se horrorizará y silbará, y dirán: “¿Por qué ha hecho __יהוה__ así a esta tierra y a esta casa? ”",
+          "tth": "Y esta casa que es exaltada⁶⁹, todo el que pase por ella se horrorizará y silbará, y dirán: “¿Por qué ha hecho יהוה así a esta tierra y a esta casa? ”",
           "footnotes": [
             {
               "marker": "⁶⁹",
@@ -2538,7 +2538,7 @@
         },
         {
           "verse": 9,
-          "tth": "Y dirán: “Porque abandonaron a __יהוה__ su Elohim, que hizo salir a sus padres de la tierra de Mitzráim, y se han aferrado a otros dioses, y se inclinaron a ellos y les sirvieron; por eso __יהוה__ ha traído sobre ellos todo este mal”. Otras actividades de Shelomóh",
+          "tth": "Y dirán: “Porque abandonaron a יהוה su Elohim, que hizo salir a sus padres de la tierra de Mitzráim, y se han aferrado a otros dioses, y se inclinaron a ellos y les sirvieron; por eso יהוה ha traído sobre ellos todo este mal”. Otras actividades de Shelomóh",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2581,7 +2581,7 @@
         },
         {
           "verse": 15,
-          "tth": "Y este es el asunto de la fuerza laboral que levantó el rey Shelomóh para construir la casa de __יהוה__ y su casa, el Milo, el muro de Yerushaláim, Jatzor, Meguidó y Gazer.",
+          "tth": "Y este es el asunto de la fuerza laboral que levantó el rey Shelomóh para construir la casa de יהוה y su casa, el Milo, el muro de Yerushaláim, Jatzor, Meguidó y Gazer.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2655,7 +2655,7 @@
         },
         {
           "verse": 25,
-          "tth": "Y hacía subir Shelomóh tres veces en el año ofrendas ascendidas y retribuciones sobre el altar que había construido a __יהוה__, y quemaba incienso con ello, que estaba delante de יהוה; y completó la casa.",
+          "tth": "Y hacía subir Shelomóh tres veces en el año ofrendas ascendidas y retribuciones sobre el altar que había construido a יהוה, y quemaba incienso con ello, que estaba delante de יהוה; y completó la casa.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2684,7 +2684,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "La reina de Shebá escuchó de la fama⁷³ de Shelomóh, por el Nombre de __יהוה__, y vino a probarlo con acertijos.",
+          "tth": "La reina de Shebá escuchó de la fama⁷³ de Shelomóh, por el Nombre de יהוה, y vino a probarlo con acertijos.",
           "footnotes": [
             {
               "marker": "⁷³",
@@ -2715,7 +2715,7 @@
         },
         {
           "verse": 5,
-          "tth": "la comida de su mesa, las viviendas de sus siervos, el porte de sus ministros y sus vestimentas, sus coperos, y su ascenso por el cual subía a⁷⁴ la casa de __יהוה__, y no hubo más argumento⁷⁵ en ella.",
+          "tth": "la comida de su mesa, las viviendas de sus siervos, el porte de sus ministros y sus vestimentas, sus coperos, y su ascenso por el cual subía a⁷⁴ la casa de יהוה, y no hubo más argumento⁷⁵ en ella.",
           "footnotes": [
             {
               "marker": "⁷⁴",
@@ -2752,7 +2752,7 @@
         },
         {
           "verse": 9,
-          "tth": "Sea __יהוה__ tu Elohim bendito, que se deleitó en ti para ponerte sobre el trono de Israel; por el amor de __יהוה__ hacia Israel para siempre, te puso por rey para hacer juicio y justicia.",
+          "tth": "Sea יהוה tu Elohim bendito, que se deleitó en ti para ponerte sobre el trono de Israel; por el amor de יהוה hacia Israel para siempre, te puso por rey para hacer juicio y justicia.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2770,7 +2770,7 @@
         },
         {
           "verse": 12,
-          "tth": "E hizo el rey con las maderas de sándalos balaustres⁷⁶ para la casa de __יהוה__ y para la casa del rey; y liras y arpas para los cantores; no ha venido así maderas de sándalos y no se ha visto hasta este día.",
+          "tth": "E hizo el rey con las maderas de sándalos balaustres⁷⁶ para la casa de יהוה y para la casa del rey; y liras y arpas para los cantores; no ha venido así maderas de sándalos y no se ha visto hasta este día.",
           "footnotes": [
             {
               "marker": "⁷⁶",
@@ -2913,7 +2913,7 @@
         },
         {
           "verse": 29,
-          "tth": "Y subía y salía un carro de Mitzráim por seiscientos shekel de plata, y un caballo por ciento cincuenta, y así para todos los reyes de los jitim⁸² y para los reyes de Aram por su mano los sacaban. Shelomóh se desvía de __יהוה__",
+          "tth": "Y subía y salía un carro de Mitzráim por seiscientos shekel de plata, y un caballo por ciento cincuenta, y así para todos los reyes de los jitim⁸² y para los reyes de Aram por su mano los sacaban. Shelomóh se desvía de יהוה",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -2930,7 +2930,7 @@
         },
         {
           "verse": 2,
-          "tth": "de las naciones las cuales había dicho __יהוה__ a los hijos de Israel: No entrarán en ellas, y ellas no entrarán en ustedes, ciertamente inclinarán su corazón tras de sus dioses. A ellas se aferró Shelomóh por amor.",
+          "tth": "de las naciones las cuales había dicho יהוה a los hijos de Israel: No entrarán en ellas, y ellas no entrarán en ustedes, ciertamente inclinarán su corazón tras de sus dioses. A ellas se aferró Shelomóh por amor.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2942,7 +2942,7 @@
         },
         {
           "verse": 4,
-          "tth": "Y sucedió que por el tiempo de la vejez de Shelomóh, sus mujeres inclinaron su corazón tras de otros dioses, y no fue su corazón completo con __יהוה__ su Elohim, como el corazón de David su padre.",
+          "tth": "Y sucedió que por el tiempo de la vejez de Shelomóh, sus mujeres inclinaron su corazón tras de otros dioses, y no fue su corazón completo con יהוה su Elohim, como el corazón de David su padre.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2967,7 +2967,7 @@
         },
         {
           "verse": 6,
-          "tth": "E hizo Shelomóh lo malo en los ojos de __יהוה__, y no fue pleno tras de __יהוה__, como David su padre.",
+          "tth": "E hizo Shelomóh lo malo en los ojos de יהוה, y no fue pleno tras de יהוה, como David su padre.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2985,13 +2985,13 @@
         },
         {
           "verse": 9,
-          "tth": "Y se enojó __יהוה__ con Shelomóh, porque había inclinado su corazón de __יהוה__, Elohim de Israel, que se le había aparecido dos veces;",
+          "tth": "Y se enojó יהוה con Shelomóh, porque había inclinado su corazón de יהוה, Elohim de Israel, que se le había aparecido dos veces;",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 10,
-          "tth": "y le había ordenado sobre esta cosa, para no ir tras de otros dioses, pero no guardó lo que había ordenado __יהוה__. Elohim",
+          "tth": "y le había ordenado sobre esta cosa, para no ir tras de otros dioses, pero no guardó lo que había ordenado יהוה. Elohim",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3003,7 +3003,7 @@
         },
         {
           "verse": 11,
-          "tth": "Y dijo __יהוה__ a Shelomóh: Porque ha sido esto contigo, y no has guardado mi pacto y mis estatutos que he ordenado sobre ti, ciertamente arrancaré⁸⁵ el reino de sobre ti, y lo daré a tu siervo.",
+          "tth": "Y dijo יהוה a Shelomóh: Porque ha sido esto contigo, y no has guardado mi pacto y mis estatutos que he ordenado sobre ti, ciertamente arrancaré⁸⁵ el reino de sobre ti, y lo daré a tu siervo.",
           "footnotes": [
             {
               "marker": "⁸⁵",
@@ -3028,7 +3028,7 @@
         },
         {
           "verse": 14,
-          "tth": "Y levantó __יהוה__ un adversario a Shelomóh, a Hadad el edomí⁸⁶, de la simiente del rey era él en Edom.",
+          "tth": "Y levantó יהוה un adversario a Shelomóh, a Hadad el edomí⁸⁶, de la simiente del rey era él en Edom.",
           "footnotes": [
             {
               "marker": "⁸⁶",
@@ -3171,7 +3171,7 @@
         },
         {
           "verse": 31,
-          "tth": "y dijo a Iarobam: Toma para ti diez pedazos, porque así dice __יהוה__, Elohim de Israel: “He aquí, Yo arrancaré el reino de la mano de Shelomóh, y daré a ti diez tribus;",
+          "tth": "y dijo a Iarobam: Toma para ti diez pedazos, porque así dice יהוה, Elohim de Israel: “He aquí, Yo arrancaré el reino de la mano de Shelomóh, y daré a ti diez tribus;",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3345,7 +3345,7 @@
         },
         {
           "verse": 15,
-          "tth": "Y no escuchó el rey al pueblo, porque era de __יהוה__ el giro de los acontecimientos, a fin de hacer levantar su palabra la cual había hablado __יהוה__ por mano de Ajiyah el shiloní⁹³ a Iarobam, hijo de Nebat.",
+          "tth": "Y no escuchó el rey al pueblo, porque era de יהוה el giro de los acontecimientos, a fin de hacer levantar su palabra la cual había hablado יהוה por mano de Ajiyah el shiloní⁹³ a Iarobam, hijo de Nebat.",
           "footnotes": [
             {
               "marker": "⁹³",
@@ -3406,7 +3406,7 @@
         },
         {
           "verse": 24,
-          "tth": "“Así dijo __יהוה__: ‘No subirán y no lucharán con sus hermanos los hijos de Israel; vuelvan, cada hombre, a su casa, porque de Mí ha sido esta cosa’ ”. Y escucharon a la palabra de __יהוה__, y se volvieron para irse conforme a la palabra de __יהוה__.",
+          "tth": "“Así dijo יהוה: ‘No subirán y no lucharán con sus hermanos los hijos de Israel; vuelvan, cada hombre, a su casa, porque de Mí ha sido esta cosa’ ”. Y escucharon a la palabra de יהוה, y se volvieron para irse conforme a la palabra de יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3424,7 +3424,7 @@
         },
         {
           "verse": 27,
-          "tth": "si sube este pueblo a hacer sacrificios en la casa de __יהוה__ en Yerushaláim, y se volverá el corazón de este pueblo hacia su amo, hacia Rejabam, rey de Iehudáh, y me matarán y volverán a Rejabam, rey de Iehudáh.",
+          "tth": "si sube este pueblo a hacer sacrificios en la casa de יהוה en Yerushaláim, y se volverá el corazón de este pueblo hacia su amo, hacia Rejabam, rey de Iehudáh, y me matarán y volverán a Rejabam, rey de Iehudáh.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3471,13 +3471,13 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y he aquí, un hombre de Elohim vino de Iehudáh por palabra de __יהוה__ a Betel, y Iarobam estaba parado sobre el altar para quemar incienso.",
+          "tth": "Y he aquí, un hombre de Elohim vino de Iehudáh por palabra de יהוה a Betel, y Iarobam estaba parado sobre el altar para quemar incienso.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 2,
-          "tth": "Y proclamó sobre⁹⁴ el altar por palabra de __יהוה__, y dijo: ¡altar, altar!, así dijo __יהוה__: “He aquí, un hijo nacerá a la casa de David, Ioshiyahu su nombre, y sacrificará sobre ti a los sacerdotes de los lugares altos que queman incienso sobre ti, y huesos de hombre serán quemados sobre ti”.",
+          "tth": "Y proclamó sobre⁹⁴ el altar por palabra de יהוה, y dijo: ¡altar, altar!, así dijo יהוה: “He aquí, un hijo nacerá a la casa de David, Ioshiyahu su nombre, y sacrificará sobre ti a los sacerdotes de los lugares altos que queman incienso sobre ti, y huesos de hombre serán quemados sobre ti”.",
           "footnotes": [
             {
               "marker": "⁹⁴",
@@ -3490,7 +3490,7 @@
         },
         {
           "verse": 3,
-          "tth": "Y dio en aquel día una maravilla, diciendo: Esta es la maravilla que ha hablado __יהוה__: “He aquí, el altar se rasgará, y se derramará la gordura que está sobre él”.",
+          "tth": "Y dio en aquel día una maravilla, diciendo: Esta es la maravilla que ha hablado יהוה: “He aquí, el altar se rasgará, y se derramará la gordura que está sobre él”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3502,13 +3502,13 @@
         },
         {
           "verse": 5,
-          "tth": "Y el altar se rasgó, y se derramó la gordura del altar, conforme a la maravilla que había dado el hombre de Elohim por palabra de __יהוה__.",
+          "tth": "Y el altar se rasgó, y se derramó la gordura del altar, conforme a la maravilla que había dado el hombre de Elohim por palabra de יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 6,
-          "tth": "Y respondió el rey, y dijo al hombre de Elohim: Ruega, por favor, al rostro de __יהוה__ tu Elohim, y entra en juicio por mí, y sea regresada mi mano a mí. Y rogó el hombre de Elohim al rostro de __יהוה__, y le fue regresada la mano del rey, y fue como al principio.",
+          "tth": "Y respondió el rey, y dijo al hombre de Elohim: Ruega, por favor, al rostro de יהוה tu Elohim, y entra en juicio por mí, y sea regresada mi mano a mí. Y rogó el hombre de Elohim al rostro de יהוה, y le fue regresada la mano del rey, y fue como al principio.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3526,7 +3526,7 @@
         },
         {
           "verse": 9,
-          "tth": "Porque así se me ordenó por palabra de __יהוה__, diciendo: “No comerás pan y no beberás agua, y no volverás por el camino que fuiste”.",
+          "tth": "Porque así se me ordenó por palabra de יהוה, diciendo: “No comerás pan y no beberás agua, y no volverás por el camino que fuiste”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3574,7 +3574,7 @@
         },
         {
           "verse": 17,
-          "tth": "Porque vino palabra a mí por la palabra de __יהוה__: “No comerás pan y no beberás allí agua, no volverás para ir por el camino que fuiste por él”.",
+          "tth": "Porque vino palabra a mí por la palabra de יהוה: “No comerás pan y no beberás allí agua, no volverás para ir por el camino que fuiste por él”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3592,13 +3592,13 @@
         },
         {
           "verse": 20,
-          "tth": "Y sucedió que ellos estaban sentados a la mesa, y fue la palabra de __יהוה__ en el profeta que lo había hecho volver;",
+          "tth": "Y sucedió que ellos estaban sentados a la mesa, y fue la palabra de יהוה en el profeta que lo había hecho volver;",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 21,
-          "tth": "y proclamó al hombre de Elohim que vino de Iehudáh, diciendo: Así dice __יהוה__: “Porque te has rebelado contra la boca de __יהוה__, y no guardaste el mandamiento que te ha ordenado __יהוה__ tu Elohim,",
+          "tth": "y proclamó al hombre de Elohim que vino de Iehudáh, diciendo: Así dice יהוה: “Porque te has rebelado contra la boca de יהוה, y no guardaste el mandamiento que te ha ordenado יהוה tu Elohim,",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3634,7 +3634,7 @@
         },
         {
           "verse": 26,
-          "tth": "Y oyó el profeta que lo había hecho volver del camino, y dijo: El hombre de Elohim es él, que se rebeló a la boca de __יהוה__; y lo entregó __יהוה__ al león, y lo desgarró y lo mató, conforme a la palabra de __יהוה__ que le había hablado.",
+          "tth": "Y oyó el profeta que lo había hecho volver del camino, y dijo: El hombre de Elohim es él, que se rebeló a la boca de יהוה; y lo entregó יהוה al león, y lo desgarró y lo mató, conforme a la palabra de יהוה que le había hablado.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3670,7 +3670,7 @@
         },
         {
           "verse": 32,
-          "tth": "Porque ciertamente sucederá⁹⁵ la palabra que proclamó por palabra de __יהוה__ sobre el altar que está en Betel y sobre todas las casas de los lugares altos que están en las ciudades de Shomrón.",
+          "tth": "Porque ciertamente sucederá⁹⁵ la palabra que proclamó por palabra de יהוה sobre el altar que está en Betel y sobre todas las casas de los lugares altos que están en las ciudades de Shomrón.",
           "footnotes": [
             {
               "marker": "⁹⁵",
@@ -3731,7 +3731,7 @@
         },
         {
           "verse": 5,
-          "tth": "Mas __יהוה__ dijo a Ajiyah: He aquí, la mujer de Iarobam viene a buscar palabra de ti sobre su hijo, pues enfermó está él. Como esto y como esto dirás a ella, y será que cuando venga, ella actuará como extraña. Profecía de Ajiyah contra Iarobam",
+          "tth": "Mas יהוה dijo a Ajiyah: He aquí, la mujer de Iarobam viene a buscar palabra de ti sobre su hijo, pues enfermó está él. Como esto y como esto dirás a ella, y será que cuando venga, ella actuará como extraña. Profecía de Ajiyah contra Iarobam",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3743,7 +3743,7 @@
         },
         {
           "verse": 7,
-          "tth": "Ve, di a Iarobam: “Así dijo __יהוה__, Elohim de Israel: ‘Porque te elevé de entre el pueblo y te puse como líder sobre mi pueblo Israel,",
+          "tth": "Ve, di a Iarobam: “Así dijo יהוה, Elohim de Israel: ‘Porque te elevé de entre el pueblo y te puse como líder sobre mi pueblo Israel,",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3774,7 +3774,7 @@
         },
         {
           "verse": 11,
-          "tth": "El que muera de Iarobam en la ciudad, lo comerán los perros. Y el que muera en el campo, lo comerán las aves del cielo; porque __יהוה__ ha hablado’ ”.",
+          "tth": "El que muera de Iarobam en la ciudad, lo comerán los perros. Y el que muera en el campo, lo comerán las aves del cielo; porque יהוה ha hablado’ ”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3786,19 +3786,19 @@
         },
         {
           "verse": 13,
-          "tth": "Y lo lamentará todo Israel y lo enterrarán, pues este solo entrará de Iarobam a la tumba, pues fue hallado en él algo bueno hacia __יהוה__, Elohim de Israel, en la casa de Iarobam.",
+          "tth": "Y lo lamentará todo Israel y lo enterrarán, pues este solo entrará de Iarobam a la tumba, pues fue hallado en él algo bueno hacia יהוה, Elohim de Israel, en la casa de Iarobam.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 14,
-          "tth": "Y levantará __יהוה__ para sí un rey sobre Israel, que cortará a la casa de Iarobam este día, y, ¿qué también ahora?",
+          "tth": "Y levantará יהוה para sí un rey sobre Israel, que cortará a la casa de Iarobam este día, y, ¿qué también ahora?",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 15,
-          "tth": "Y golpeará __יהוה__ a Israel, como se sacude la caña en el agua, y arrancará a Israel de sobre esta buena tierra que dio a sus padres, y los dispersará del otro lado del río, porque han hecho sus Asheráh, haciendo enfurecer a __יהוה__.",
+          "tth": "Y golpeará יהוה a Israel, como se sacude la caña en el agua, y arrancará a Israel de sobre esta buena tierra que dio a sus padres, y los dispersará del otro lado del río, porque han hecho sus Asheráh, haciendo enfurecer a יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3816,7 +3816,7 @@
         },
         {
           "verse": 18,
-          "tth": "Y lo enterraron y lo lamentaron, todo Israel, conforme a la palabra de __יהוה__ que habló por mano de su siervo Ajiyáhu, el profeta.",
+          "tth": "Y lo enterraron y lo lamentaron, todo Israel, conforme a la palabra de יהוה que habló por mano de su siervo Ajiyáhu, el profeta.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3834,13 +3834,13 @@
         },
         {
           "verse": 21,
-          "tth": "Y Rejabam, hijo de Shelomóh, reinó en Iehudáh. Edad de cuarenta y un años tenía Rejabam en su reinar, y diecisiete años reinó en Yerushaláim, la ciudad que escogió __יהוה__ para poner su Nombre allí de entre todas las tribus de Israel. Y el nombre de su madre era Naamáh, la amonit.",
+          "tth": "Y Rejabam, hijo de Shelomóh, reinó en Iehudáh. Edad de cuarenta y un años tenía Rejabam en su reinar, y diecisiete años reinó en Yerushaláim, la ciudad que escogió יהוה para poner su Nombre allí de entre todas las tribus de Israel. Y el nombre de su madre era Naamáh, la amonit.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 22,
-          "tth": "E hizo Iehudáh lo malo en los ojos de __יהוה__, y lo provocaron a celos más que todo lo que habían hecho sus padres con sus pecados que habían pecado.",
+          "tth": "E hizo Iehudáh lo malo en los ojos de יהוה, y lo provocaron a celos más que todo lo que habían hecho sus padres con sus pecados que habían pecado.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3859,7 +3859,7 @@
         },
         {
           "verse": 24,
-          "tth": "Y también prostitutos paganos hubo en la tierra. Hicieron conforme a todas las abominaciones de las naciones que había desposeído __יהוה__ de delante de los hijos de Israel.",
+          "tth": "Y también prostitutos paganos hubo en la tierra. Hicieron conforme a todas las abominaciones de las naciones que había desposeído יהוה de delante de los hijos de Israel.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3871,7 +3871,7 @@
         },
         {
           "verse": 26,
-          "tth": "Y tomó los tesoros de la casa de __יהוה__ y los tesoros de la casa del rey, y todo tomó. Y tomó todos los escudos de oro que había hecho Shelomóh.",
+          "tth": "Y tomó los tesoros de la casa de יהוה y los tesoros de la casa del rey, y todo tomó. Y tomó todos los escudos de oro que había hecho Shelomóh.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3883,7 +3883,7 @@
         },
         {
           "verse": 28,
-          "tth": "Y sucedía que cada vez que entraba el rey a la casa de __יהוה__, se los llevaban los corredores; y los regresaban a la cámara de los corredores.",
+          "tth": "Y sucedía que cada vez que entraba el rey a la casa de יהוה, se los llevaban los corredores; y los regresaban a la cámara de los corredores.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3924,19 +3924,19 @@
         },
         {
           "verse": 3,
-          "tth": "Y anduvo en todos los pecados de su padre que había hecho antes de él; y no fue su corazón completo con __יהוה__, su Elohim, como el corazón de David, su padre.",
+          "tth": "Y anduvo en todos los pecados de su padre que había hecho antes de él; y no fue su corazón completo con יהוה, su Elohim, como el corazón de David, su padre.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 4,
-          "tth": "Pero por causa de David, le dio __יהוה__ su Elohim una lámpara en Yerushaláim, para levantar a su hijo después de él y para afirmar a Yerushaláim,",
+          "tth": "Pero por causa de David, le dio יהוה su Elohim una lámpara en Yerushaláim, para levantar a su hijo después de él y para afirmar a Yerushaláim,",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 5,
-          "tth": "porque hizo David lo recto en los ojos de __יהוה__, y no se apartó de todo lo que le había ordenado todos los días de su vida, solamente en el asunto de Uriyah el jití¹⁰⁰.",
+          "tth": "porque hizo David lo recto en los ojos de יהוה, y no se apartó de todo lo que le había ordenado todos los días de su vida, solamente en el asunto de Uriyah el jití¹⁰⁰.",
           "footnotes": [
             {
               "marker": "¹⁰⁰",
@@ -3979,7 +3979,7 @@
         },
         {
           "verse": 11,
-          "tth": "E hizo Asá lo recto en los ojos de __יהוה__, como David su padre.",
+          "tth": "E hizo Asá lo recto en los ojos de יהוה, como David su padre.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3997,13 +3997,13 @@
         },
         {
           "verse": 14,
-          "tth": "Y los lugares altos no fueron apartados; pero el corazón de Asá fue completo con __יהוה__ todos sus días.",
+          "tth": "Y los lugares altos no fueron apartados; pero el corazón de Asá fue completo con יהוה todos sus días.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 15,
-          "tth": "Y trajo las santidades de su padre y sus santidades a la casa de __יהוה__: plata, oro y utensilios.",
+          "tth": "Y trajo las santidades de su padre y sus santidades a la casa de יהוה: plata, oro y utensilios.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4021,7 +4021,7 @@
         },
         {
           "verse": 18,
-          "tth": "Y tomó Asá toda la plata y el oro que habían quedado en los tesoros de la casa de __יהוה__ y los tesoros de la casa del rey, y los dio en mano de sus siervos. Y los envió el rey Asá hacia Ben Hadad, hijo de Tabrimón, hijo de Jezión, rey de Aram, que habitaba en Damések, diciendo:",
+          "tth": "Y tomó Asá toda la plata y el oro que habían quedado en los tesoros de la casa de יהוה y los tesoros de la casa del rey, y los dio en mano de sus siervos. Y los envió el rey Asá hacia Ben Hadad, hijo de Tabrimón, hijo de Jezión, rey de Aram, que habitaba en Damések, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4069,7 +4069,7 @@
         },
         {
           "verse": 26,
-          "tth": "E hizo lo malo en los ojos de __יהוה__, y anduvo en el camino de su padre y en su pecado con el cual hizo pecar a Israel.",
+          "tth": "E hizo lo malo en los ojos de יהוה, y anduvo en el camino de su padre y en su pecado con el cual hizo pecar a Israel.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4100,7 +4100,7 @@
         },
         {
           "verse": 29,
-          "tth": "Y sucedió que cuando reinó, hirió a toda la casa de Iarobam. No dejó ningún aliento¹⁰³ de Iarobam, hasta destruirlos, conforme a la palabra de __יהוה__ que habló por mano de su siervo Ajiyáh el shiloní;",
+          "tth": "Y sucedió que cuando reinó, hirió a toda la casa de Iarobam. No dejó ningún aliento¹⁰³ de Iarobam, hasta destruirlos, conforme a la palabra de יהוה que habló por mano de su siervo Ajiyáh el shiloní;",
           "footnotes": [
             {
               "marker": "¹⁰³",
@@ -4113,7 +4113,7 @@
         },
         {
           "verse": 30,
-          "tth": "por los pecados de Iarobam que había pecado, y con los cuales hizo pecar a Israel, por su irritación con que hizo enfurecer a __יהוה__, Elohim de Israel.",
+          "tth": "por los pecados de Iarobam que había pecado, y con los cuales hizo pecar a Israel, por su irritación con que hizo enfurecer a יהוה, Elohim de Israel.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4137,7 +4137,7 @@
         },
         {
           "verse": 34,
-          "tth": "E hizo lo malo en los ojos de __יהוה__, y anduvo en el camino de Iarobam y en su pecado con el cual hizo pecar a Israel. Palabra de Iehú contra Bashá",
+          "tth": "E hizo lo malo en los ojos de יהוה, y anduvo en el camino de Iarobam y en su pecado con el cual hizo pecar a Israel. Palabra de Iehú contra Bashá",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -4148,7 +4148,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y fue la palabra de __יהוה__ a Iehú, hijo de Janani, sobre Bashá, diciendo:",
+          "tth": "Y fue la palabra de יהוה a Iehú, hijo de Janani, sobre Bashá, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4184,7 +4184,7 @@
         },
         {
           "verse": 7,
-          "tth": "Y también, por mano de Iehú, hijo de Janani, el profeta, la palabra de __יהוה__ fue hacia Bashá y hacia su casa, por todo el mal que hizo en los ojos de __יהוה__ para hacerlo enfurecer con la obra de sus manos, al ser como la casa de Iarobam, y porque lo hirió. Reinados de Eláh, Zimri y Omri",
+          "tth": "Y también, por mano de Iehú, hijo de Janani, el profeta, la palabra de יהוה fue hacia Bashá y hacia su casa, por todo el mal que hizo en los ojos de יהוה para hacerlo enfurecer con la obra de sus manos, al ser como la casa de Iarobam, y porque lo hirió. Reinados de Eláh, Zimri y Omri",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4214,13 +4214,13 @@
         },
         {
           "verse": 12,
-          "tth": "Y destruyó Zimri a toda la casa de Bashá, conforme a la palabra de __יהוה__ que habló hacia Bashá por mano de Iehú el profeta;",
+          "tth": "Y destruyó Zimri a toda la casa de Bashá, conforme a la palabra de יהוה que habló hacia Bashá por mano de Iehú el profeta;",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 13,
-          "tth": "por todos los pecados de Bashá y los pecados de Eláh, su hijo, que pecaron y que hicieron pecar a Israel, para hacer enfurecer a __יהוה__, Elohim de Israel, con sus vanidades.",
+          "tth": "por todos los pecados de Bashá y los pecados de Eláh, su hijo, que pecaron y que hicieron pecar a Israel, para hacer enfurecer a יהוה, Elohim de Israel, con sus vanidades.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4263,7 +4263,7 @@
         },
         {
           "verse": 19,
-          "tth": "por su pecado que había pecado, para hacer mal en los ojos de __יהוה__, para andar en el camino de Iarobam, y por su pecado que había hecho al hacer pecar a Israel.",
+          "tth": "por su pecado que había pecado, para hacer mal en los ojos de יהוה, para andar en el camino de Iarobam, y por su pecado que había hecho al hacer pecar a Israel.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4306,13 +4306,13 @@
         },
         {
           "verse": 25,
-          "tth": "E hizo Omri lo malo en los ojos de __יהוה__, e hizo más mal que todos los que fueron antes de él;",
+          "tth": "E hizo Omri lo malo en los ojos de יהוה, e hizo más mal que todos los que fueron antes de él;",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 26,
-          "tth": "y anduvo en el camino de Iarobam, hijo de Nebat, y en sus pecados con que hizo pecar a Israel, para hacer enfurecer a __יהוה__, Elohim de Israel, con sus vanidades.",
+          "tth": "y anduvo en el camino de Iarobam, hijo de Nebat, y en sus pecados con que hizo pecar a Israel, para hacer enfurecer a יהוה, Elohim de Israel, con sus vanidades.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4336,7 +4336,7 @@
         },
         {
           "verse": 30,
-          "tth": "E hizo Ajab, hijo de Omri, lo malo en los ojos de __יהוה__ más que todos los que fueron antes de él.",
+          "tth": "E hizo Ajab, hijo de Omri, lo malo en los ojos de יהוה más que todos los que fueron antes de él.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4354,13 +4354,13 @@
         },
         {
           "verse": 33,
-          "tth": "E hizo Ajab a Asheráh. Y añadió Ajab para hacer, para indignar a __יהוה__, Elohim de Israel, más que todos los reyes de Israel que fueron antes de él.",
+          "tth": "E hizo Ajab a Asheráh. Y añadió Ajab para hacer, para indignar a יהוה, Elohim de Israel, más que todos los reyes de Israel que fueron antes de él.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 34,
-          "tth": "En sus días edificó Jiel el betelí¹⁰⁶, a Ierijó¹⁰⁷. En Abiram su primogénito la fundó, y en Segub su menor estableció sus puertas; conforme a la palabra de __יהוה__ que había hablado por mano de Yehoshúa, hijo de Nun¹⁰⁸. Eliyáhu predice la sequía",
+          "tth": "En sus días edificó Jiel el betelí¹⁰⁶, a Ierijó¹⁰⁷. En Abiram su primogénito la fundó, y en Segub su menor estableció sus puertas; conforme a la palabra de יהוה que había hablado por mano de Yehoshúa, hijo de Nun¹⁰⁸. Eliyáhu predice la sequía",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -4371,7 +4371,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y dijo Eliyáhu el tishbí¹⁰⁹, de los habitantes de Guilad, a Ajab: Vive __יהוה__, Elohim de Israel, que me paro delante de Él: “¡Si habría en estos dos años rocío y lluvia!, sino de acuerdo a mi palabra”.",
+          "tth": "Y dijo Eliyáhu el tishbí¹⁰⁹, de los habitantes de Guilad, a Ajab: Vive יהוה, Elohim de Israel, que me paro delante de Él: “¡Si habría en estos dos años rocío y lluvia!, sino de acuerdo a mi palabra”.",
           "footnotes": [
             {
               "marker": "¹⁰⁹",
@@ -4384,7 +4384,7 @@
         },
         {
           "verse": 2,
-          "tth": "Y fue la palabra de __יהוה__ a él, diciendo:",
+          "tth": "Y fue la palabra de יהוה a él, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4409,7 +4409,7 @@
         },
         {
           "verse": 5,
-          "tth": "Y él fue e hizo conforme la palabra de __יהוה__, y fue y habitó en el arroyo Kerit, que está sobre la faz del Iardén.",
+          "tth": "Y él fue e hizo conforme la palabra de יהוה, y fue y habitó en el arroyo Kerit, que está sobre la faz del Iardén.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4427,7 +4427,7 @@
         },
         {
           "verse": 8,
-          "tth": "Y fue la palabra de __יהוה__ a él, diciendo:",
+          "tth": "Y fue la palabra de יהוה a él, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4451,7 +4451,7 @@
         },
         {
           "verse": 12,
-          "tth": "Pero ella dijo: Vive __יהוה__, tu Elohim, ¡si hubiera para mí pastel! Sino que tengo una palma llena de harina en la vasija y un poco de aceite en la jarra, y heme aquí, recogiendo dos maderas, y entraré y lo prepararé para mí y para mi hijo, y comeremos y moriremos.",
+          "tth": "Pero ella dijo: Vive יהוה, tu Elohim, ¡si hubiera para mí pastel! Sino que tengo una palma llena de harina en la vasija y un poco de aceite en la jarra, y heme aquí, recogiendo dos maderas, y entraré y lo prepararé para mí y para mi hijo, y comeremos y moriremos.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4470,7 +4470,7 @@
         },
         {
           "verse": 14,
-          "tth": "Porque así dijo __יהוה__, Elohim de Israel: “La vasija de harina no se acabará y la jarra de aceite no faltará, hasta el día que dará __יהוה__ lluvia sobre la faz de la tierra”.",
+          "tth": "Porque así dijo יהוה, Elohim de Israel: “La vasija de harina no se acabará y la jarra de aceite no faltará, hasta el día que dará יהוה lluvia sobre la faz de la tierra”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4513,13 +4513,13 @@
         },
         {
           "verse": 20,
-          "tth": "Y clamó a __יהוה__, y dijo: ¡__יהוה__, Elohim mío!, ¿también sobre la viuda que yo resido con ella haz hecho mal para hacer morir a su hijo?",
+          "tth": "Y clamó a יהוה, y dijo: ¡יהוה, Elohim mío!, ¿también sobre la viuda que yo resido con ella haz hecho mal para hacer morir a su hijo?",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 21,
-          "tth": "Y se estiró sobre el niño tres veces, y clamó a __יהוה__, y dijo: ¡__יהוה__, Elohim mío!, vuelva, te ruego, el aliento de este niño a su interior¹¹³.",
+          "tth": "Y se estiró sobre el niño tres veces, y clamó a יהוה, y dijo: ¡יהוה, Elohim mío!, vuelva, te ruego, el aliento de este niño a su interior¹¹³.",
           "footnotes": [
             {
               "marker": "¹¹³",
@@ -4532,7 +4532,7 @@
         },
         {
           "verse": 22,
-          "tth": "Y oyó __יהוה__ a la voz de Eliyáhu, y volvió el aliento del niño a su interior, y vivió.",
+          "tth": "Y oyó יהוה a la voz de Eliyáhu, y volvió el aliento del niño a su interior, y vivió.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4544,7 +4544,7 @@
         },
         {
           "verse": 24,
-          "tth": "Y dijo la mujer a Eliyáhu: Ahora, por esto, conozco que hombre de Elohim eres tú, y la palabra de __יהוה__ en tu boca es verdad. Encuentro de Eliyáhu y Ajab",
+          "tth": "Y dijo la mujer a Eliyáhu: Ahora, por esto, conozco que hombre de Elohim eres tú, y la palabra de יהוה en tu boca es verdad. Encuentro de Eliyáhu y Ajab",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -4555,7 +4555,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y sucedió que muchos días después, la palabra de __יהוה__ fue a Eliyáhu en el año tercero, diciendo: Ve, muéstrate a Ajab, y daré lluvia sobre la faz de la tierra.",
+          "tth": "Y sucedió que muchos días después, la palabra de יהוה fue a Eliyáhu en el año tercero, diciendo: Ve, muéstrate a Ajab, y daré lluvia sobre la faz de la tierra.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4567,13 +4567,13 @@
         },
         {
           "verse": 3,
-          "tth": "Y llamó Ajab a Obadyáhu, que estaba sobre la casa; y Obadyáhu era temeroso de __יהוה__, mucho.",
+          "tth": "Y llamó Ajab a Obadyáhu, que estaba sobre la casa; y Obadyáhu era temeroso de יהוה, mucho.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 4,
-          "tth": "Y fue que cuando cortó Izebel a los profetas de __יהוה__, tomó Obadyáhu cien profetas y los escondió, cincuenta hombres por cueva, y les sustentó pan y agua.",
+          "tth": "Y fue que cuando cortó Izebel a los profetas de יהוה, tomó Obadyáhu cien profetas y los escondió, cincuenta hombres por cueva, y les sustentó pan y agua.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4609,7 +4609,7 @@
         },
         {
           "verse": 10,
-          "tth": "Vive __יהוה__ tu Elohim, ¡si hubiera nación y reino que no haya enviado mi amo allí a buscarte!, y decían: “No está”, y hacía jurar al reino y a la nación que no te habían hallado.",
+          "tth": "Vive יהוה tu Elohim, ¡si hubiera nación y reino que no haya enviado mi amo allí a buscarte!, y decían: “No está”, y hacía jurar al reino y a la nación que no te habían hallado.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4621,7 +4621,7 @@
         },
         {
           "verse": 12,
-          "tth": "Y sucederá que yo me iré de ti, y el Rúaj¹¹⁴ de __יהוה__ te llevará por donde no conozca; e iré a dar a conocer a Ajab y no te hallará, y me matará; y tu siervo, he temido a __יהוה__ desde mi juventud.",
+          "tth": "Y sucederá que yo me iré de ti, y el Rúaj¹¹⁴ de יהוה te llevará por donde no conozca; e iré a dar a conocer a Ajab y no te hallará, y me matará; y tu siervo, he temido a יהוה desde mi juventud.",
           "footnotes": [
             {
               "marker": "¹¹⁴",
@@ -4634,7 +4634,7 @@
         },
         {
           "verse": 13,
-          "tth": "¿No han dado a conocer a mi amo lo que hice cuando mató Izebel a los profetas de __יהוה__, y escondí de los profetas de __יהוה__ cien hombres, de cincuenta en cincuenta hombres en la cueva, y les sustenté pan y agua?",
+          "tth": "¿No han dado a conocer a mi amo lo que hice cuando mató Izebel a los profetas de יהוה, y escondí de los profetas de יהוה cien hombres, de cincuenta en cincuenta hombres en la cueva, y les sustenté pan y agua?",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4646,7 +4646,7 @@
         },
         {
           "verse": 15,
-          "tth": "Y dijo Eliyáhu: Vive __יהוה__ Tzebaot, que me paro delante de Él, que hoy me mostraré a él.",
+          "tth": "Y dijo Eliyáhu: Vive יהוה Tzebaot, que me paro delante de Él, que hoy me mostraré a él.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4664,7 +4664,7 @@
         },
         {
           "verse": 18,
-          "tth": "Y él dijo: No he perturbado a Israel, sino tú y la casa de tu padre, cuando abandonaron los mandamientos de __יהוה__, y fuiste tras de los baales¹¹⁵.",
+          "tth": "Y él dijo: No he perturbado a Israel, sino tú y la casa de tu padre, cuando abandonaron los mandamientos de יהוה, y fuiste tras de los baales¹¹⁵.",
           "footnotes": [
             {
               "marker": "¹¹⁵",
@@ -4689,13 +4689,13 @@
         },
         {
           "verse": 21,
-          "tth": "Y se acercó Eliyáhu a todo el pueblo, y dijo: ¿Hasta cuándo ustedes cojearán sobre dos opiniones divididas? Si __יהוה__ es el Elohim, vayan tras de Él; y si Baal, vayan tras de él. Y no le respondió el pueblo palabra.",
+          "tth": "Y se acercó Eliyáhu a todo el pueblo, y dijo: ¿Hasta cuándo ustedes cojearán sobre dos opiniones divididas? Si יהוה es el Elohim, vayan tras de Él; y si Baal, vayan tras de él. Y no le respondió el pueblo palabra.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 22,
-          "tth": "Y dijo Eliyáhu al pueblo: Yo he quedado por profeta de __יהוה__, sólo yo; pero los profetas de Baal son cuatrocientos cincuenta hombres.",
+          "tth": "Y dijo Eliyáhu al pueblo: Yo he quedado por profeta de יהוה, sólo yo; pero los profetas de Baal son cuatrocientos cincuenta hombres.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4714,7 +4714,7 @@
         },
         {
           "verse": 24,
-          "tth": "Y llamarán en el nombre de su dios, y yo llamaré en el Nombre de __יהוה__; y será que el Elohim que responda con fuego, él es el Elohim. Y respondió todo el pueblo, y dijeron: La palabra es buena.",
+          "tth": "Y llamarán en el nombre de su dios, y yo llamaré en el Nombre de יהוה; y será que el Elohim que responda con fuego, él es el Elohim. Y respondió todo el pueblo, y dijeron: La palabra es buena.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4763,7 +4763,7 @@
         },
         {
           "verse": 30,
-          "tth": "Y dijo Eliyáhu a todo el pueblo: Acérquense a mí. Y se acercó todo el pueblo a él. Y reparó¹¹⁹ el altar de __יהוה__ que había sido derribado.",
+          "tth": "Y dijo Eliyáhu a todo el pueblo: Acérquense a mí. Y se acercó todo el pueblo a él. Y reparó¹¹⁹ el altar de יהוה que había sido derribado.",
           "footnotes": [
             {
               "marker": "¹¹⁹",
@@ -4776,13 +4776,13 @@
         },
         {
           "verse": 31,
-          "tth": "Y tomó Eliyáhu doce piedras como el número de las tribus de los hijos de Yaakov, que fue la palabra de __יהוה__ a él, diciendo: Israel será tu nombre.",
+          "tth": "Y tomó Eliyáhu doce piedras como el número de las tribus de los hijos de Yaakov, que fue la palabra de יהוה a él, diciendo: Israel será tu nombre.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 32,
-          "tth": "Y construyó con las piedras un altar en el Nombre de __יהוה__, e hizo un canal, aproximadamente cabría dentro dos seah¹²⁰ de semilla, alrededor del altar.",
+          "tth": "Y construyó con las piedras un altar en el Nombre de יהוה, e hizo un canal, aproximadamente cabría dentro dos seah¹²⁰ de semilla, alrededor del altar.",
           "footnotes": [
             {
               "marker": "¹²⁰",
@@ -4813,13 +4813,13 @@
         },
         {
           "verse": 36,
-          "tth": "Y sucedió que en el ascender de la ofrenda, se acercó Eliyáhu el profeta, y dijo: __יהוה__, Elohim de Abraham, Itzjak e Israel, hoy se sabrá que Tú eres Elohim en Israel, y que yo soy tu siervo, y que por tus palabras he hecho todas estas cosas.",
+          "tth": "Y sucedió que en el ascender de la ofrenda, se acercó Eliyáhu el profeta, y dijo: יהוה, Elohim de Abraham, Itzjak e Israel, hoy se sabrá que Tú eres Elohim en Israel, y que yo soy tu siervo, y que por tus palabras he hecho todas estas cosas.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 37,
-          "tth": "Respóndeme, __יהוה__, respóndeme, y sabrá este pueblo que Tú, __יהוה__, eres el Elohim, y Tú has hecho¹²¹ volver sus corazones hacia atrás.",
+          "tth": "Respóndeme, יהוה, respóndeme, y sabrá este pueblo que Tú, יהוה, eres el Elohim, y Tú has hecho¹²¹ volver sus corazones hacia atrás.",
           "footnotes": [
             {
               "marker": "¹²¹",
@@ -4832,13 +4832,13 @@
         },
         {
           "verse": 38,
-          "tth": "Y cayó fuego de __יהוה__, y consumió la ofrenda ascendida, las maderas, las piedras y el polvo, y el agua que estaba en el canal lamió.",
+          "tth": "Y cayó fuego de יהוה, y consumió la ofrenda ascendida, las maderas, las piedras y el polvo, y el agua que estaba en el canal lamió.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 39,
-          "tth": "Y vio todo el pueblo, y cayeron sobre sus rostros, y dijeron: ¡יהוה, Él es el Elohim! ¡__יהוה__, Él es el Elohim!",
+          "tth": "Y vio todo el pueblo, y cayeron sobre sus rostros, y dijeron: ¡יהוה, Él es el Elohim! ¡יהוה, Él es el Elohim!",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4887,7 +4887,7 @@
         },
         {
           "verse": 46,
-          "tth": "Y la mano de __יהוה__ estaba sobre Eliyáhu, y ciñó sus lomos y corrió delante de Ajab hasta tu entrada a Izreel. Eliyáhu huye de Izebel hasta Joreb",
+          "tth": "Y la mano de יהוה estaba sobre Eliyáhu, y ciñó sus lomos y corrió delante de Ajab hasta tu entrada a Izreel. Eliyáhu huye de Izebel hasta Joreb",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -4923,7 +4923,7 @@
         },
         {
           "verse": 4,
-          "tth": "Y él fue por el desierto camino de un día, y vino y se sentó debajo de una retama; y pidió a su vida para morir, y dijo: ¡Suficiente!, ahora, __יהוה__, toma mi vida, porque no soy más bueno yo que mis padres.",
+          "tth": "Y él fue por el desierto camino de un día, y vino y se sentó debajo de una retama; y pidió a su vida para morir, y dijo: ¡Suficiente!, ahora, יהוה, toma mi vida, porque no soy más bueno yo que mis padres.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4948,7 +4948,7 @@
         },
         {
           "verse": 7,
-          "tth": "Y volvió el mensajero de __יהוה__ por segunda vez, y lo tocó y dijo: Levántate, come, porque mucho para ti es el camino.",
+          "tth": "Y volvió el mensajero de יהוה por segunda vez, y lo tocó y dijo: Levántate, come, porque mucho para ti es el camino.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4960,25 +4960,25 @@
         },
         {
           "verse": 9,
-          "tth": "Y entró allí a una cueva, y pasó la noche allí; y he aquí, la palabra de __יהוה__ vino a él, y le dijo: ¿Qué hay para ti aquí, Eliyáhu?",
+          "tth": "Y entró allí a una cueva, y pasó la noche allí; y he aquí, la palabra de יהוה vino a él, y le dijo: ¿Qué hay para ti aquí, Eliyáhu?",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 10,
-          "tth": "Y él dijo: He sido muy celoso de __יהוה__, Elohei Tzebaot; porque han abandonado tu pacto los hijos de Israel, a tus altares han derribado, y a tus profetas han matado con espada; y he quedado yo, sólo yo, y buscan mi vida para tomarla.",
+          "tth": "Y él dijo: He sido muy celoso de יהוה, Elohei Tzebaot; porque han abandonado tu pacto los hijos de Israel, a tus altares han derribado, y a tus profetas han matado con espada; y he quedado yo, sólo yo, y buscan mi vida para tomarla.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 11,
-          "tth": "Y Él dijo: Sal y párate en el monte delante de __יהוה__. Y he aquí, __יהוה__ pasó, y un viento grande y fuerte arrancó los montes y rompió las peñas delante de __יהוה__; no estaba en el viento __יהוה__. Y después del viento, un temblor; no estaba en el temblor __יהוה__.",
+          "tth": "Y Él dijo: Sal y párate en el monte delante de יהוה. Y he aquí, יהוה pasó, y un viento grande y fuerte arrancó los montes y rompió las peñas delante de יהוה; no estaba en el viento יהוה. Y después del viento, un temblor; no estaba en el temblor יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 12,
-          "tth": "Y después del temblor, un fuego; no estaba en el fuego __יהוה__. Y después del fuego, una voz de un pequeño susurro.",
+          "tth": "Y después del temblor, un fuego; no estaba en el fuego יהוה. Y después del fuego, una voz de un pequeño susurro.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4990,13 +4990,13 @@
         },
         {
           "verse": 14,
-          "tth": "Y él dijo: He sido muy celoso de __יהוה__, Elohei Tzebaot; porque han abandonado tu pacto los hijos de Israel, a tus altares han derribado, y a tus profetas han matado con espada; y he quedado yo, sólo yo, y buscan mi vida para tomarla.",
+          "tth": "Y él dijo: He sido muy celoso de יהוה, Elohei Tzebaot; porque han abandonado tu pacto los hijos de Israel, a tus altares han derribado, y a tus profetas han matado con espada; y he quedado yo, sólo yo, y buscan mi vida para tomarla.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 15,
-          "tth": "Y le dijo __יהוה__: Ve, regresa por tu camino al desierto de Damések, y llegarás y ungirás a Jazael por rey sobre Aram;",
+          "tth": "Y le dijo יהוה: Ve, regresa por tu camino al desierto de Damések, y llegarás y ungirás a Jazael por rey sobre Aram;",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5115,13 +5115,13 @@
         },
         {
           "verse": 13,
-          "tth": "Y he aquí, un profeta se acercó a Ajab, rey de Israel, y dijo: Así dice __יהוה__: “¿Has visto a toda esta gran multitud? He aquí, Yo la daré en tu mano hoy, y sabrás que Yo soy __יהוה__”.",
+          "tth": "Y he aquí, un profeta se acercó a Ajab, rey de Israel, y dijo: Así dice יהוה: “¿Has visto a toda esta gran multitud? He aquí, Yo la daré en tu mano hoy, y sabrás que Yo soy יהוה”.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 14,
-          "tth": "Y dijo Ajab: ¿Por quién? Y él dijo: Así dice __יהוה__: “Por los jóvenes de los jefes de las provincias”. Y él dijo: ¿Quién ligará la batalla? Y él dijo: Tú.",
+          "tth": "Y dijo Ajab: ¿Por quién? Y él dijo: Así dice יהוה: “Por los jóvenes de los jefes de las provincias”. Y él dijo: ¿Quién ligará la batalla? Y él dijo: Tú.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5212,7 +5212,7 @@
         },
         {
           "verse": 28,
-          "tth": "Y se acercó un hombre de Elohim, y dijo al rey de Israel, y dijo: Así dice יהוה: “Porque ha dicho Aram: ‘Elohim de montes es __יהוה__, pero no es Elohim de valles Él’, daré a toda esta gran multitud en tu mano, y sabrán que Yo soy __יהוה__”.",
+          "tth": "Y se acercó un hombre de Elohim, y dijo al rey de Israel, y dijo: Así dice יהוה: “Porque ha dicho Aram: ‘Elohim de montes es יהוה, pero no es Elohim de valles Él’, daré a toda esta gran multitud en tu mano, y sabrán que Yo soy יהוה”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5275,13 +5275,13 @@
         },
         {
           "verse": 35,
-          "tth": "Y un hombre de los hijos de los profetas dijo a su prójimo por palabra de __יהוה__: Hiéreme, te ruego. Pero se negó el hombre a herirlo.",
+          "tth": "Y un hombre de los hijos de los profetas dijo a su prójimo por palabra de יהוה: Hiéreme, te ruego. Pero se negó el hombre a herirlo.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 36,
-          "tth": "Y le dijo: Porque no has escuchado a la voz de __יהוה__, he aquí, tú te irás de mí y te herirá el león. Y él se fue de su lado y lo encontró el león, y lo hirió.",
+          "tth": "Y le dijo: Porque no has escuchado a la voz de יהוה, he aquí, tú te irás de mí y te herirá el león. Y él se fue de su lado y lo encontró el león, y lo hirió.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5337,7 +5337,7 @@
         },
         {
           "verse": 42,
-          "tth": "Y él le dijo: Así dice __יהוה__: “Porque has enviado lejos al hombre de destrucción de tu mano, será tu vida en lugar de su vida y tu pueblo en lugar de su pueblo”.",
+          "tth": "Y él le dijo: Así dice יהוה: “Porque has enviado lejos al hombre de destrucción de tu mano, será tu vida en lugar de su vida y tu pueblo en lugar de su pueblo”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5373,7 +5373,7 @@
         },
         {
           "verse": 3,
-          "tth": "Pero dijo Nabot a Ajab: ¡Profanación a mí de __יהוה__ que te dé la herencia de mis padres!",
+          "tth": "Pero dijo Nabot a Ajab: ¡Profanación a mí de יהוה que te dé la herencia de mis padres!",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5464,7 +5464,7 @@
         },
         {
           "verse": 17,
-          "tth": "Y fue la palabra de __יהוה__ a Eliyáhu el tishbí¹³⁴, diciendo:",
+          "tth": "Y fue la palabra de יהוה a Eliyáhu el tishbí¹³⁴, diciendo:",
           "footnotes": [
             {
               "marker": "¹³⁴",
@@ -5483,13 +5483,13 @@
         },
         {
           "verse": 19,
-          "tth": "Y le hablarás, diciendo: “Así dijo __יהוה__: ‘¿Has asesinado, y además has tomado posesión? ’ ” Y le hablarás, diciendo: “Así dijo __יהוה__: ‘En el lugar donde lamieron los perros la sangre de Nabot, lamerán los perros tu sangre, también tú’ ”.",
+          "tth": "Y le hablarás, diciendo: “Así dijo יהוה: ‘¿Has asesinado, y además has tomado posesión? ’ ” Y le hablarás, diciendo: “Así dijo יהוה: ‘En el lugar donde lamieron los perros la sangre de Nabot, lamerán los perros tu sangre, también tú’ ”.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 20,
-          "tth": "Y dijo Ajab a Eliyáhu: ¿Me has hallado, enemigo mío? Y él dijo: Te he hallado, porque te has vendido para hacer el mal en los ojos de __יהוה__.",
+          "tth": "Y dijo Ajab a Eliyáhu: ¿Me has hallado, enemigo mío? Y él dijo: Te he hallado, porque te has vendido para hacer el mal en los ojos de יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5514,7 +5514,7 @@
         },
         {
           "verse": 23,
-          "tth": "Y también de Izebel ha hablado __יהוה__, diciendo: “Los perros comerán a Izebel en el muro¹³⁶ de Izreel”.",
+          "tth": "Y también de Izebel ha hablado יהוה, diciendo: “Los perros comerán a Izebel en el muro¹³⁶ de Izreel”.",
           "footnotes": [
             {
               "marker": "¹³⁶",
@@ -5533,13 +5533,13 @@
         },
         {
           "verse": 25,
-          "tth": "Pero no hubo nadie como Ajab, que se vendió para hacer el mal en los ojos de __יהוה__, que lo sedujo Izebel su mujer.",
+          "tth": "Pero no hubo nadie como Ajab, que se vendió para hacer el mal en los ojos de יהוה, que lo sedujo Izebel su mujer.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 26,
-          "tth": "E hizo muy abominablemente, al ir tras de los ídolos conforme a todo lo que había hecho el emorí, a quien desposeyó __יהוה__ de delante de los hijos de Israel.",
+          "tth": "E hizo muy abominablemente, al ir tras de los ídolos conforme a todo lo que había hecho el emorí, a quien desposeyó יהוה de delante de los hijos de Israel.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5558,7 +5558,7 @@
         },
         {
           "verse": 28,
-          "tth": "Y fue la palabra de __יהוה__ a Eliyáhu el tishbí, diciendo:",
+          "tth": "Y fue la palabra de יהוה a Eliyáhu el tishbí, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5599,7 +5599,7 @@
         },
         {
           "verse": 5,
-          "tth": "Y dijo Iehoshafat al rey de Israel: Consulta, por favor, ahora¹³⁸ a la palabra de __יהוה__.",
+          "tth": "Y dijo Iehoshafat al rey de Israel: Consulta, por favor, ahora¹³⁸ a la palabra de יהוה.",
           "footnotes": [
             {
               "marker": "¹³⁸",
@@ -5618,13 +5618,13 @@
         },
         {
           "verse": 7,
-          "tth": "Y dijo Iehoshafat: ¿No hay aquí un profeta de __יהוה__ aún, y consultemos de él?",
+          "tth": "Y dijo Iehoshafat: ¿No hay aquí un profeta de יהוה aún, y consultemos de él?",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 8,
-          "tth": "Y dijo el rey de Israel a Iehoshafat: Aún hay un hombre para consultar a __יהוה__ por él, pero yo lo odio, porque no ha profetizado sobre mí bien, sino que mal; Micaiehu, hijo de Imlaj. Y dijo Iehoshafat: No diga el rey así.",
+          "tth": "Y dijo el rey de Israel a Iehoshafat: Aún hay un hombre para consultar a יהוה por él, pero yo lo odio, porque no ha profetizado sobre mí bien, sino que mal; Micaiehu, hijo de Imlaj. Y dijo Iehoshafat: No diga el rey así.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5642,13 +5642,13 @@
         },
         {
           "verse": 11,
-          "tth": "E hizo para sí Tzidkiyah, hijo de Kenaanáh, un cuerno de hierro, y dijo: Así dice __יהוה__: “Con estos empujarás a Aram hasta acabarlos”.",
+          "tth": "E hizo para sí Tzidkiyah, hijo de Kenaanáh, un cuerno de hierro, y dijo: Así dice יהוה: “Con estos empujarás a Aram hasta acabarlos”.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 12,
-          "tth": "Y todos los profetas profetizaban así, diciendo: Sube a Ramot Guilad y tendrás éxito, y la dará __יהוה__ en mano del rey.",
+          "tth": "Y todos los profetas profetizaban así, diciendo: Sube a Ramot Guilad y tendrás éxito, y la dará יהוה en mano del rey.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5660,25 +5660,25 @@
         },
         {
           "verse": 14,
-          "tth": "Y dijo Micaiehu: Vive __יהוה__, que lo que me diga __יהוה__, eso hablaré.",
+          "tth": "Y dijo Micaiehu: Vive יהוה, que lo que me diga יהוה, eso hablaré.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 15,
-          "tth": "Y vino al rey, y le dijo el rey: Micaiehu, ¿iremos a Ramot Guilad para luchar, o desistiremos? Y él le dijo: Sube, y tendrás éxito, y la dará __יהוה__ en mano del rey.",
+          "tth": "Y vino al rey, y le dijo el rey: Micaiehu, ¿iremos a Ramot Guilad para luchar, o desistiremos? Y él le dijo: Sube, y tendrás éxito, y la dará יהוה en mano del rey.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 16,
-          "tth": "Y le dijo el rey: ¿Hasta cuántas veces he de hacerte jurar que no me hables sino la verdad en Nombre de __יהוה__?",
+          "tth": "Y le dijo el rey: ¿Hasta cuántas veces he de hacerte jurar que no me hables sino la verdad en Nombre de יהוה?",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 17,
-          "tth": "Y él dijo: He visto a todo Israel dispersado en los montes, como el rebaño que no tiene para sí pastor; y dijo __יהוה__: “No hay amos para estos, volverán cada hombre a su casa en shalom¹³⁹”.",
+          "tth": "Y él dijo: He visto a todo Israel dispersado en los montes, como el rebaño que no tiene para sí pastor; y dijo יהוה: “No hay amos para estos, volverán cada hombre a su casa en shalom¹³⁹”.",
           "footnotes": [
             {
               "marker": "¹³⁹",
@@ -5697,19 +5697,19 @@
         },
         {
           "verse": 19,
-          "tth": "Y dijo Micaiehu: Por eso, escucha la palabra de __יהוה__. He visto a __יהוה__ sentado sobre su trono, y todo el ejército de los cielos parado junto a Él, a su derecha y a su izquierda.",
+          "tth": "Y dijo Micaiehu: Por eso, escucha la palabra de יהוה. He visto a יהוה sentado sobre su trono, y todo el ejército de los cielos parado junto a Él, a su derecha y a su izquierda.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 20,
-          "tth": "Y dijo __יהוה__: “¿Quién persuadirá a Ajab, y subirá y caerá en Ramot Guilad? ” Y dijo este de esta manera, y este dijo de esta manera.",
+          "tth": "Y dijo יהוה: “¿Quién persuadirá a Ajab, y subirá y caerá en Ramot Guilad? ” Y dijo este de esta manera, y este dijo de esta manera.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 21,
-          "tth": "Y salió un espíritu y se paró delante de __יהוה__, y dijo: “Yo lo persuadiré”. Y le dijo __יהוה__: “¿Con qué? ”",
+          "tth": "Y salió un espíritu y se paró delante de יהוה, y dijo: “Yo lo persuadiré”. Y le dijo יהוה: “¿Con qué? ”",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5721,13 +5721,13 @@
         },
         {
           "verse": 23,
-          "tth": "Y ahora, he aquí, ha puesto __יהוה__ un espíritu de mentira en boca de todos tus profetas estos; y __יהוה__ ha hablado sobre ti mal.",
+          "tth": "Y ahora, he aquí, ha puesto יהוה un espíritu de mentira en boca de todos tus profetas estos; y יהוה ha hablado sobre ti mal.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 24,
-          "tth": "Y se acercó Tzidkiyahu, hijo de Kenaanáh, y golpeó a Micaiehu en la mejilla, y dijo: ¿Cómo¹⁴⁰ es esto que pasó el Rúaj¹⁴¹ de __יהוה__ de mí para hablarte a ti?",
+          "tth": "Y se acercó Tzidkiyahu, hijo de Kenaanáh, y golpeó a Micaiehu en la mejilla, y dijo: ¿Cómo¹⁴⁰ es esto que pasó el Rúaj¹⁴¹ de יהוה de mí para hablarte a ti?",
           "footnotes": [
             {
               "marker": "¹⁴⁰",
@@ -5771,7 +5771,7 @@
         },
         {
           "verse": 28,
-          "tth": "Y dijo Micaiehu: Si en verdad vuelves¹⁴³ en shalom, no ha hablado __יהוה__ por mí. Y dijo: ¡Oigan, pueblos todos!",
+          "tth": "Y dijo Micaiehu: Si en verdad vuelves¹⁴³ en shalom, no ha hablado יהוה por mí. Y dijo: ¡Oigan, pueblos todos!",
           "footnotes": [
             {
               "marker": "¹⁴³",
@@ -5852,7 +5852,7 @@
         },
         {
           "verse": 38,
-          "tth": "Y enjuagaron el carro por el estanque de Shomrón, y lamieron los perros su sangre, y las rameras se bañaban, conforme a la palabra de __יהוה__ que había hablado.",
+          "tth": "Y enjuagaron el carro por el estanque de Shomrón, y lamieron los perros su sangre, y las rameras se bañaban, conforme a la palabra de יהוה que había hablado.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5889,7 +5889,7 @@
         },
         {
           "verse": 43,
-          "tth": "Y anduvo en todo el camino de Asá su padre, no se desvió de él, para hacer lo recto en los ojos de __יהוה__. Sin embargo, los lugares altos no fueron apartados; todavía el pueblo sacrificaba y quemaba incienso en los lugares altos.",
+          "tth": "Y anduvo en todo el camino de Asá su padre, no se desvió de él, para hacer lo recto en los ojos de יהוה. Sin embargo, los lugares altos no fueron apartados; todavía el pueblo sacrificaba y quemaba incienso en los lugares altos.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5943,13 +5943,13 @@
         },
         {
           "verse": 52,
-          "tth": "E hizo lo malo en los ojos de __יהוה__, y anduvo en el camino de su padre y en el camino de su madre, y en el camino de Iarobam, hijo de Nebat, el que hizo pecar a Israel.",
+          "tth": "E hizo lo malo en los ojos de יהוה, y anduvo en el camino de su padre y en el camino de su madre, y en el camino de Iarobam, hijo de Nebat, el que hizo pecar a Israel.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 53,
-          "tth": "Y sirvió a Baal y se inclinó a él, e hizo enfurecer a __יהוה__, Elohim de Israel, conforme a todo lo que hizo su padre.",
+          "tth": "Y sirvió a Baal y se inclinó a él, e hizo enfurecer a יהוה, Elohim de Israel, conforme a todo lo que hizo su padre.",
           "footnotes": [],
           "hebrew_terms": []
         }

--- a/data/tth_2/json/melajim_bet.json
+++ b/data/tth_2/json/melajim_bet.json
@@ -34,7 +34,7 @@
         },
         {
           "verse": 3,
-          "tth": "Y el mensajero² de __יהוה__ habló a Eliyah el tishbí³: Levántate, sube al encuentro de los mensajeros del rey de Shomrón, y háblales: “¿No hay⁴ Elohim en Israel que ustedes van a consultar por Baal Zebub, dios de Ekrón? ”",
+          "tth": "Y el mensajero² de יהוה habló a Eliyah el tishbí³: Levántate, sube al encuentro de los mensajeros del rey de Shomrón, y háblales: “¿No hay⁴ Elohim en Israel que ustedes van a consultar por Baal Zebub, dios de Ekrón? ”",
           "footnotes": [
             {
               "marker": "²",
@@ -59,7 +59,7 @@
         },
         {
           "verse": 4,
-          "tth": "Y por eso, así dijo __יהוה__: “La cama la cual has subido allí, no bajarás de ella, porque muriendo, morirás”. Y se fue Eliyah.",
+          "tth": "Y por eso, así dijo יהוה: “La cama la cual has subido allí, no bajarás de ella, porque muriendo, morirás”. Y se fue Eliyah.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -71,7 +71,7 @@
         },
         {
           "verse": 6,
-          "tth": "Y ellos le dijeron: Un hombre subió a nuestro encuentro, y nos dijo: “Vayan, vuelvan al rey que los envió, y le hablarán: ‘Así dijo __יהוה__: “¿No hay Elohim en Israel que tú envías a consultar por Baal Zebub, dios de Ekrón? Por eso, la cama que has subido allí, no bajarás de ella, porque muriendo, morirás” ’ ”.",
+          "tth": "Y ellos le dijeron: Un hombre subió a nuestro encuentro, y nos dijo: “Vayan, vuelvan al rey que los envió, y le hablarán: ‘Así dijo יהוה: “¿No hay Elohim en Israel que tú envías a consultar por Baal Zebub, dios de Ekrón? Por eso, la cama que has subido allí, no bajarás de ella, porque muriendo, morirás” ’ ”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -125,19 +125,19 @@
         },
         {
           "verse": 15,
-          "tth": "Y habló el mensajero de __יהוה__ a Eliyáhu: Desciende con él, no tendrás temor de su rostro. Y se levantó y descendió con él al rey.",
+          "tth": "Y habló el mensajero de יהוה a Eliyáhu: Desciende con él, no tendrás temor de su rostro. Y se levantó y descendió con él al rey.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 16,
-          "tth": "Y le habló: Así dice __יהוה__: “Porque has enviado mensajeros a consultar por Baal Zebub, dios de Ekrón, ¿no hay Elohim en Israel para consultar por su palabra?; por eso, la cama que has subido allí, no bajarás de ella, porque muriendo, morirás”.",
+          "tth": "Y le habló: Así dice יהוה: “Porque has enviado mensajeros a consultar por Baal Zebub, dios de Ekrón, ¿no hay Elohim en Israel para consultar por su palabra?; por eso, la cama que has subido allí, no bajarás de ella, porque muriendo, morirás”.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 17,
-          "tth": "Y murió, conforme a la palabra de __יהוה__ que había hablado Eliyáhu. Y reinó Iehoram en su lugar en el año segundo de Iehoram, hijo de Iehoshafat, rey de Iehudáh, pues no había para él hijo.",
+          "tth": "Y murió, conforme a la palabra de יהוה que había hablado Eliyáhu. Y reinó Iehoram en su lugar en el año segundo de Iehoram, hijo de Iehoshafat, rey de Iehudáh, pues no había para él hijo.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -154,25 +154,25 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y sucedió que cuando iba a hacer subir __יהוה__ a Eliyáhu en una tempestad al cielo, se fue Eliyáhu, y Elishá, de Gilgal.",
+          "tth": "Y sucedió que cuando iba a hacer subir יהוה a Eliyáhu en una tempestad al cielo, se fue Eliyáhu, y Elishá, de Gilgal.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 2,
-          "tth": "Y dijo Eliyáhu a Elishá: Permanece por favor aquí, porque __יהוה__ me ha enviado hasta Betel. Y dijo Elishá: Vive __יהוה__ y vive tu ser, ¡si te abandonaría! Y descendieron a Betel.",
+          "tth": "Y dijo Eliyáhu a Elishá: Permanece por favor aquí, porque יהוה me ha enviado hasta Betel. Y dijo Elishá: Vive יהוה y vive tu ser, ¡si te abandonaría! Y descendieron a Betel.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 3,
-          "tth": "Y salieron los hijos de los profetas que estaban en Betel hacia Elishá, y le dijeron: ¿Sabes que hoy __יהוה__ tomará a tu amo de sobre tu cabeza? Y él dijo: También yo lo sé; callen.",
+          "tth": "Y salieron los hijos de los profetas que estaban en Betel hacia Elishá, y le dijeron: ¿Sabes que hoy יהוה tomará a tu amo de sobre tu cabeza? Y él dijo: También yo lo sé; callen.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 4,
-          "tth": "Y le dijo Eliyáhu: Elishá, permanece por favor aquí, porque __יהוה__ me ha enviado a Ierijó⁵. Y él dijo: Vive __יהוה__ y vive tu ser, ¡si te abandonaría! Y entraron a Ierijó.",
+          "tth": "Y le dijo Eliyáhu: Elishá, permanece por favor aquí, porque יהוה me ha enviado a Ierijó⁵. Y él dijo: Vive יהוה y vive tu ser, ¡si te abandonaría! Y entraron a Ierijó.",
           "footnotes": [
             {
               "marker": "⁵",
@@ -185,13 +185,13 @@
         },
         {
           "verse": 5,
-          "tth": "Y se acercaron los hijos de los profetas que estaban en Ierijó hacia Elishá, y dijeron a él: ¿Sabes que hoy __יהוה__ tomará a tu amo de sobre tu cabeza? Y él dijo: También yo lo sé; callen.",
+          "tth": "Y se acercaron los hijos de los profetas que estaban en Ierijó hacia Elishá, y dijeron a él: ¿Sabes que hoy יהוה tomará a tu amo de sobre tu cabeza? Y él dijo: También yo lo sé; callen.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 6,
-          "tth": "Y le dijo Eliyáhu: Permanece por favor aquí, porque __יהוה__ me ha enviado al Iardén⁶. Y él dijo: Vive __יהוה__ y vive tu ser, ¡si te abandonaría! Y se fueron los dos.",
+          "tth": "Y le dijo Eliyáhu: Permanece por favor aquí, porque יהוה me ha enviado al Iardén⁶. Y él dijo: Vive יהוה y vive tu ser, ¡si te abandonaría! Y se fueron los dos.",
           "footnotes": [
             {
               "marker": "⁶",
@@ -266,7 +266,7 @@
         },
         {
           "verse": 14,
-          "tth": "Y tomó el manto de Eliyáhu que se había caído de sobre él, y golpeó las aguas, y dijo: ¿Dónde está __יהוה__, Elohim de Eliyáhu? También él golpeó las aguas, y se dividieron aquí y allá, y cruzó Elishá.",
+          "tth": "Y tomó el manto de Eliyáhu que se había caído de sobre él, y golpeó las aguas, y dijo: ¿Dónde está יהוה, Elohim de Eliyáhu? También él golpeó las aguas, y se dividieron aquí y allá, y cruzó Elishá.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -278,7 +278,7 @@
         },
         {
           "verse": 16,
-          "tth": "Y le dijeron: He aquí, por favor, hay con tus siervos cincuenta hombres hijos de valor; irán, por favor, y buscarán a tu amo, quizás lo ha levantado el Rúaj de __יהוה__ y lo ha echado en uno de los montes o en uno de los valles. Y él dijo: No enviarán.",
+          "tth": "Y le dijeron: He aquí, por favor, hay con tus siervos cincuenta hombres hijos de valor; irán, por favor, y buscarán a tu amo, quizás lo ha levantado el Rúaj de יהוה y lo ha echado en uno de los montes o en uno de los valles. Y él dijo: No enviarán.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -308,7 +308,7 @@
         },
         {
           "verse": 21,
-          "tth": "Y él salió al lugar de la salida de las aguas, y echó allí sal, y dijo: Así dice __יהוה__: “He sanado a estas aguas, no habrá de allí más muerte ni causa de esterilidad”.",
+          "tth": "Y él salió al lugar de la salida de las aguas, y echó allí sal, y dijo: Así dice יהוה: “He sanado a estas aguas, no habrá de allí más muerte ni causa de esterilidad”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -326,7 +326,7 @@
         },
         {
           "verse": 24,
-          "tth": "Y él giró detrás de él y los vio, y los deshonró por el Nombre de __יהוה__. Y salieron dos osas del bosque y despedazaron de ellos a cuarenta y dos muchachos.",
+          "tth": "Y él giró detrás de él y los vio, y los deshonró por el Nombre de יהוה. Y salieron dos osas del bosque y despedazaron de ellos a cuarenta y dos muchachos.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -349,7 +349,7 @@
         },
         {
           "verse": 2,
-          "tth": "E hizo lo malo en los ojos de __יהוה__, pero no como su padre y como su madre, y apartó el pilar de Baal que había hecho su padre.",
+          "tth": "E hizo lo malo en los ojos de יהוה, pero no como su padre y como su madre, y apartó el pilar de Baal que había hecho su padre.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -397,31 +397,31 @@
         },
         {
           "verse": 10,
-          "tth": "Y dijo el rey de Israel: ¡Ah! ¡Porque ha llamado __יהוה__ a estos tres reyes para darlos en mano de Moab!",
+          "tth": "Y dijo el rey de Israel: ¡Ah! ¡Porque ha llamado יהוה a estos tres reyes para darlos en mano de Moab!",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 11,
-          "tth": "Y dijo Iehoshafat: ¿No hay aquí un profeta de __יהוה__, y podamos consultar a __יהוה__ por él? Y respondió uno de los siervos del rey de Israel, y dijo: Aquí está Elishá, hijo de Shafat, quien vertía aguas sobre la mano de Eliyáhu.",
+          "tth": "Y dijo Iehoshafat: ¿No hay aquí un profeta de יהוה, y podamos consultar a יהוה por él? Y respondió uno de los siervos del rey de Israel, y dijo: Aquí está Elishá, hijo de Shafat, quien vertía aguas sobre la mano de Eliyáhu.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 12,
-          "tth": "Y dijo Iehoshafat: Está con él la palabra de __יהוה__. Y descendieron a él el rey de Israel y Iehoshafat y el rey de Edom.",
+          "tth": "Y dijo Iehoshafat: Está con él la palabra de יהוה. Y descendieron a él el rey de Israel y Iehoshafat y el rey de Edom.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 13,
-          "tth": "Y dijo Elishá al rey de Israel: ¿Qué hay para mí y para ti? Ve a los profetas de tu padre y a los profetas de tu madre. Y le dijo el rey de Israel: No, porque ha llamado __יהוה__ a estos tres reyes para darlos en mano de Moab.",
+          "tth": "Y dijo Elishá al rey de Israel: ¿Qué hay para mí y para ti? Ve a los profetas de tu padre y a los profetas de tu madre. Y le dijo el rey de Israel: No, porque ha llamado יהוה a estos tres reyes para darlos en mano de Moab.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 14,
-          "tth": "Y dijo Elishá: Vive __יהוה__ Tzebaot, que me paro delante de Él, que si no fuera por el rostro de Iehoshafat, rey de Iehudáh, a quien yo respeto¹⁰, ¡si miraría hacia ti, y si te vería!",
+          "tth": "Y dijo Elishá: Vive יהוה Tzebaot, que me paro delante de Él, que si no fuera por el rostro de Iehoshafat, rey de Iehudáh, a quien yo respeto¹⁰, ¡si miraría hacia ti, y si te vería!",
           "footnotes": [
             {
               "marker": "¹⁰",
@@ -434,13 +434,13 @@
         },
         {
           "verse": 15,
-          "tth": "Mas ahora tomen para mí un músico. Y sucedió que cuando tocaba el músico, estuvo sobre él la mano de __יהוה__.",
+          "tth": "Mas ahora tomen para mí un músico. Y sucedió que cuando tocaba el músico, estuvo sobre él la mano de יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 16,
-          "tth": "Y él dijo: Así dijo __יהוה__: “Hagan en este torrente muchas zanjas¹¹”.",
+          "tth": "Y él dijo: Así dijo יהוה: “Hagan en este torrente muchas zanjas¹¹”.",
           "footnotes": [
             {
               "marker": "¹¹",
@@ -453,13 +453,13 @@
         },
         {
           "verse": 17,
-          "tth": "Porque así dice __יהוה__: “No verán viento y no verán lluvia, pero este torrente se llenará de aguas, y beberán ustedes y sus ganados y sus bestias”.",
+          "tth": "Porque así dice יהוה: “No verán viento y no verán lluvia, pero este torrente se llenará de aguas, y beberán ustedes y sus ganados y sus bestias”.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 18,
-          "tth": "Y es ligero esto en los ojos de __יהוה__. Y dará a Moab en manos de ustedes.",
+          "tth": "Y es ligero esto en los ojos de יהוה. Y dará a Moab en manos de ustedes.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -524,7 +524,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y una mujer de las mujeres de los hijos de los profetas gritó a Elishá, diciendo: Tu siervo, mi esposo, ha muerto, y tú sabes que tu siervo era temeroso a __יהוה__; y el acreedor ha venido a tomar a mis dos niños para él por esclavos.",
+          "tth": "Y una mujer de las mujeres de los hijos de los profetas gritó a Elishá, diciendo: Tu siervo, mi esposo, ha muerto, y tú sabes que tu siervo era temeroso a יהוה; y el acreedor ha venido a tomar a mis dos niños para él por esclavos.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -694,7 +694,7 @@
         },
         {
           "verse": 27,
-          "tth": "Y ella vino al hombre de Elohim, al monte, y se aferró de sus pies. Y se acercó Gejazi para empujarla, y dijo el hombre de Elohim: Suéltala, porque su ser amarga en ella, y __יהוה__ lo ha ocultado de mí y no me lo ha dado a conocer.",
+          "tth": "Y ella vino al hombre de Elohim, al monte, y se aferró de sus pies. Y se acercó Gejazi para empujarla, y dijo el hombre de Elohim: Suéltala, porque su ser amarga en ella, y יהוה lo ha ocultado de mí y no me lo ha dado a conocer.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -712,7 +712,7 @@
         },
         {
           "verse": 30,
-          "tth": "Y dijo la madre del muchacho: Vive __יהוה__ y vive tu ser, ¡si te abandonaría! Y él se levantó y fue detrás de ella.",
+          "tth": "Y dijo la madre del muchacho: Vive יהוה y vive tu ser, ¡si te abandonaría! Y él se levantó y fue detrás de ella.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -730,7 +730,7 @@
         },
         {
           "verse": 33,
-          "tth": "Y entró y cerró la puerta detrás de los dos, y oró a __יהוה__.",
+          "tth": "Y entró y cerró la puerta detrás de los dos, y oró a יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -804,13 +804,13 @@
         },
         {
           "verse": 43,
-          "tth": "Pero dijo su sirviente: ¿Cómo daré esto delante de cien hombres? Y él dijo: Dalos al pueblo, y comerán, porque así dijo __יהוה__: “Comerán y quedará”.",
+          "tth": "Pero dijo su sirviente: ¿Cómo daré esto delante de cien hombres? Y él dijo: Dalos al pueblo, y comerán, porque así dijo יהוה: “Comerán y quedará”.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 44,
-          "tth": "Y lo dio delante de ellos y comieron, y quedó, conforme a la palabra de __יהוה__. Elishá y Naamán",
+          "tth": "Y lo dio delante de ellos y comieron, y quedó, conforme a la palabra de יהוה. Elishá y Naamán",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -821,7 +821,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y Naamán, jefe del ejército del rey de Aram, era un gran hombre delante de su amo y levantado de rostro, porque por él había dado __יהוה__ la liberación a Aram. Y el hombre era poderoso de valor, pero metzorá¹⁶.",
+          "tth": "Y Naamán, jefe del ejército del rey de Aram, era un gran hombre delante de su amo y levantado de rostro, porque por él había dado יהוה la liberación a Aram. Y el hombre era poderoso de valor, pero metzorá¹⁶.",
           "footnotes": [
             {
               "marker": "¹⁶",

--- a/data/tth_2/json/romanos.json
+++ b/data/tth_2/json/romanos.json
@@ -474,13 +474,13 @@
         },
         {
           "verse": 23,
-          "tth": "El que en la Torah se gloría, ¿traspasando a la Torah, a __יהוה__ deshonras?",
+          "tth": "El que en la Torah se gloría, ¿traspasando a la Torah, a יהוה deshonras?",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 24,
-          "tth": "Porque el Nombre de __יהוה__ por ustedes es deshonrado entre los gentiles²¹, como está escrito.",
+          "tth": "Porque el Nombre de יהוה por ustedes es deshonrado entre los gentiles²¹, como está escrito.",
           "footnotes": [
             {
               "marker": "²¹",
@@ -567,7 +567,7 @@
         },
         {
           "verse": 4,
-          "tth": "¡Profanación! Será __יהוה__ firme²⁵ y todo hombre mentiroso, como está escrito: A fin de que estés justificado en tu hablar, limpio en tu juzgar²⁶.",
+          "tth": "¡Profanación! Será יהוה firme²⁵ y todo hombre mentiroso, como está escrito: A fin de que estés justificado en tu hablar, limpio en tu juzgar²⁶.",
           "footnotes": [
             {
               "marker": "²⁶",
@@ -827,7 +827,7 @@
         },
         {
           "verse": 30,
-          "tth": "Por eso, __יהוה__ es uno, el cual justifica por la emunah a la circuncisión y por la emunah a la incircuncisión.",
+          "tth": "Por eso, יהוה es uno, el cual justifica por la emunah a la circuncisión y por la emunah a la incircuncisión.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -856,7 +856,7 @@
         },
         {
           "verse": 3,
-          "tth": "¿Y qué dice la Escritura? Y se afirmó Abraham por __יהוה__, y la consideró a él justicia⁴⁴.",
+          "tth": "¿Y qué dice la Escritura? Y se afirmó Abraham por יהוה, y la consideró a él justicia⁴⁴.",
           "footnotes": [
             {
               "marker": "⁴⁴",
@@ -894,7 +894,7 @@
         },
         {
           "verse": 6,
-          "tth": "Como también David dice acerca de la felicidad del hombre al que le considera __יהוה__ justicia sin obras, diciendo:",
+          "tth": "Como también David dice acerca de la felicidad del hombre al que le considera יהוה justicia sin obras, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -906,7 +906,7 @@
         },
         {
           "verse": 8,
-          "tth": "¡Feliz el hombre que no le considera __יהוה__ iniquidad⁴⁷!",
+          "tth": "¡Feliz el hombre que no le considera יהוה iniquidad⁴⁷!",
           "footnotes": [
             {
               "marker": "⁴⁷",
@@ -3443,7 +3443,7 @@
         },
         {
           "verse": 11,
-          "tth": "Y otra vez: Alaben a __יהוה__, todos los gentiles; elógienlo, todos los pueblos¹⁷⁸.",
+          "tth": "Y otra vez: Alaben a יהוה, todos los gentiles; elógienlo, todos los pueblos¹⁷⁸.",
           "footnotes": [
             {
               "marker": "¹⁷⁸",

--- a/data/tth_2/json/shoftim.json
+++ b/data/tth_2/json/shoftim.json
@@ -15,7 +15,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y sucedió después de la muerte de Yehoshúa, <em>que</em> preguntaron los hijos de Israel a __יהוה__, diciendo: ¿Quién subirá por nosotros al kenaaní¹ en primera para luchar con él?",
+          "tth": "Y sucedió después de la muerte de Yehoshúa, <em>que</em> preguntaron los hijos de Israel a יהוה, diciendo: ¿Quién subirá por nosotros al kenaaní¹ en primera para luchar con él?",
           "footnotes": [
             {
               "marker": "¹",
@@ -28,7 +28,7 @@
         },
         {
           "verse": 2,
-          "tth": "Y dijo __יהוה__: Iehudáh subirá; he aquí, he dado la tierra en su mano.",
+          "tth": "Y dijo יהוה: Iehudáh subirá; he aquí, he dado la tierra en su mano.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4300,7 +4300,7 @@
         },
         {
           "verse": 18,
-          "tth": "Y se levantaron y subieron <em>a</em> Betel, y preguntaron a Elohim, y dijeron los hijos de Israel: ¿Quién subirá de nosotros en principio a la guerra con los hijos de Biniamín? Y dijo __יהוה__: Iehudáh en principio.",
+          "tth": "Y se levantaron y subieron <em>a</em> Betel, y preguntaron a Elohim, y dijeron los hijos de Israel: ¿Quién subirá de nosotros en principio a la guerra con los hijos de Biniamín? Y dijo יהוה: Iehudáh en principio.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4330,7 +4330,7 @@
         },
         {
           "verse": 23,
-          "tth": "Y subieron los hijos de Israel y lloraron delante de __יהוה__ hasta el atardecer, y preguntaron a __יהוה__, diciendo: ¿Me volveré a acercar para la guerra con los hijos de Biniamín, mi hermano? Y dijo __יהוה__: Suban hacia él.",
+          "tth": "Y subieron los hijos de Israel y lloraron delante de יהוה hasta el atardecer, y preguntaron a יהוה, diciendo: ¿Me volveré a acercar para la guerra con los hijos de Biniamín, mi hermano? Y dijo יהוה: Suban hacia él.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4348,19 +4348,19 @@
         },
         {
           "verse": 26,
-          "tth": "Y subieron todos los hijos de Israel y todo el pueblo y vinieron a Betel y lloraron; y permanecieron allí delante de __יהוה__ y ayunaron en ese día hasta el atardecer. Y ascendieron ofrendas ascendidas y retribuciones delante de __יהוה__.",
+          "tth": "Y subieron todos los hijos de Israel y todo el pueblo y vinieron a Betel y lloraron; y permanecieron allí delante de יהוה y ayunaron en ese día hasta el atardecer. Y ascendieron ofrendas ascendidas y retribuciones delante de יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 27,
-          "tth": "Y preguntaron los hijos de Israel a __יהוה__ (y allí <em>estaba</em> el arca del Pacto de Elohim en aquellos días,",
+          "tth": "Y preguntaron los hijos de Israel a יהוה (y allí <em>estaba</em> el arca del Pacto de Elohim en aquellos días,",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 28,
-          "tth": "y Pinjas, hijo de Eleazar, hijo de Aharón, <em>estaba</em> parado delante de ella en aquellos días), diciendo: ¿Volveré aún a salir a la guerra con los hijos de Biniamín, mi hermano, o desistiré? Y dijo __יהוה__: Suban, porque mañana lo daré en tu mano.",
+          "tth": "y Pinjas, hijo de Eleazar, hijo de Aharón, <em>estaba</em> parado delante de ella en aquellos días), diciendo: ¿Volveré aún a salir a la guerra con los hijos de Biniamín, mi hermano, o desistiré? Y dijo יהוה: Suban, porque mañana lo daré en tu mano.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Derrota de los hijos de Biniamín"
@@ -4403,7 +4403,7 @@
         },
         {
           "verse": 35,
-          "tth": "Y golpeó __יהוה__ a Biniamín delante de Israel, y destruyeron los hijos de Israel de Biniamín en ese día, veinticinco mil cien hombres, todos estos sacaban espada.",
+          "tth": "Y golpeó יהוה a Biniamín delante de Israel, y destruyeron los hijos de Israel de Biniamín en ese día, veinticinco mil cien hombres, todos estos sacaban espada.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4512,7 +4512,7 @@
         },
         {
           "verse": 3,
-          "tth": "Y dijeron: ¿Por qué, __יהוה__, Elohim de Israel, ha sucedido esto en Israel, de faltar hoy de Israel una tribu?",
+          "tth": "Y dijeron: ¿Por qué, יהוה, Elohim de Israel, ha sucedido esto en Israel, de faltar hoy de Israel una tribu?",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4524,7 +4524,7 @@
         },
         {
           "verse": 5,
-          "tth": "Y dijeron los hijos de Israel: ¿Quién <em>fue</em> el que no subió con la asamblea de todas las tribus de Israel hacia __יהוה__? Porque el gran juramento había para el que no había subido a __יהוה__, a Mitzpah, diciendo: Muriendo, morirá.",
+          "tth": "Y dijeron los hijos de Israel: ¿Quién <em>fue</em> el que no subió con la asamblea de todas las tribus de Israel hacia יהוה? Porque el gran juramento había para el que no había subido a יהוה, a Mitzpah, diciendo: Muriendo, morirá.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4536,13 +4536,13 @@
         },
         {
           "verse": 7,
-          "tth": "¿Qué haremos para ellos, para los que quedaron, por mujeres, y nosotros juramos por __יהוה__ para no dar a ellos de nuestras hijas por mujeres?",
+          "tth": "¿Qué haremos para ellos, para los que quedaron, por mujeres, y nosotros juramos por יהוה para no dar a ellos de nuestras hijas por mujeres?",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 8,
-          "tth": "Y dijeron: ¿Quién es una de las tribus de Israel que no subió hacia __יהוה__ a Mitzpah? Y he aquí, no vino hombre al campamento, de Iabesh Guilad, a la asamblea.",
+          "tth": "Y dijeron: ¿Quién es una de las tribus de Israel que no subió hacia יהוה a Mitzpah? Y he aquí, no vino hombre al campamento, de Iabesh Guilad, a la asamblea.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4591,7 +4591,7 @@
         },
         {
           "verse": 15,
-          "tth": "Y el pueblo se lamentó por Biniamín, porque había hecho __יהוה__ una brecha en las tribus de Israel.",
+          "tth": "Y el pueblo se lamentó por Biniamín, porque había hecho יהוה una brecha en las tribus de Israel.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4615,7 +4615,7 @@
         },
         {
           "verse": 19,
-          "tth": "Y dijeron: He aquí, una fiesta de __יהוה__ <em>hay</em> en Shiloh cada año¹²⁸, que <em>está</em> del norte de Betel, desde el brillo del sol del camino que sube de Betel a Shejem, y del sur de Lebonáh.",
+          "tth": "Y dijeron: He aquí, una fiesta de יהוה <em>hay</em> en Shiloh cada año¹²⁸, que <em>está</em> del norte de Betel, desde el brillo del sol del camino que sube de Betel a Shejem, y del sur de Lebonáh.",
           "footnotes": [
             {
               "marker": "¹²⁸",

--- a/data/tth_2/json/tehilim.json
+++ b/data/tth_2/json/tehilim.json
@@ -21,7 +21,7 @@
         },
         {
           "verse": 2,
-          "tth": "sino que en la Torah de __יהוה__<em>está</em> su deleite, y en su Torah medita de día y de noche!",
+          "tth": "sino que en la Torah de יהוה <em>está</em> su deleite, y en su Torah medita de día y de noche!",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -45,11 +45,12 @@
         },
         {
           "verse": 6,
-          "tth": "Porque conoce __יהוה__ el camino de los justificados, pero el camino de los condenados se perderá.",
+          "tth": "Porque conoce יהוה el camino de los justificados, pero el camino de los condenados se perderá.",
           "footnotes": [],
           "hebrew_terms": []
         }
-      ]
+      ],
+      "book_division": "LIBRO PRIMERO"
     },
     {
       "chapter": 2,
@@ -62,7 +63,7 @@
         },
         {
           "verse": 2,
-          "tth": "Se pararán los reyes de la tierra y los gobernantes se establecerán juntoscontra __יהוה__ y contra su Mesías¹:",
+          "tth": "Se pararán los reyes de la tierra y los gobernantes se establecerán juntoscontra יהוה y contra su Mesías¹:",
           "footnotes": [
             {
               "marker": "¹",
@@ -106,7 +107,7 @@
         },
         {
           "verse": 7,
-          "tth": "Contaré el decreto: __יהוה__ me dijo: “Mi Hijo eres tú, Yo, Día, te he engendrado.",
+          "tth": "Contaré el decreto: יהוה me dijo: “Mi Hijo eres tú, Yo, Día, te he engendrado.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -137,7 +138,7 @@
         },
         {
           "verse": 11,
-          "tth": "¡Sirvan a __יהוה__ con temor y regocíjense con temblor!",
+          "tth": "¡Sirvan a יהוה con temor y regocíjense con temblor!",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -155,7 +156,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "¡__יהוה__, cómo se aumentaron mis opresores! Muchos se levantan sobre mí.",
+          "tth": "¡יהוה, cómo se aumentaron mis opresores! Muchos se levantan sobre mí.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -174,19 +175,19 @@
         },
         {
           "verse": 3,
-          "tth": "Y Tú, __יהוה__, <em>eres</em> escudo a favor de mí, mi honra, y el que levanta mi cabeza.",
+          "tth": "Y Tú, יהוה, <em>eres</em> escudo a favor de mí, mi honra, y el que levanta mi cabeza.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 4,
-          "tth": "<em>Con</em> mi voz a __יהוה__ llamé, y me respondió desde el monte de su santidad. <em>Selah.</em>",
+          "tth": "<em>Con</em> mi voz a יהוה llamé, y me respondió desde el monte de su santidad. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 5,
-          "tth": "Yo me acosté y dormí, desperté, porque __יהוה__ me sostiene.",
+          "tth": "Yo me acosté y dormí, desperté, porque יהוה me sostiene.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -198,13 +199,13 @@
         },
         {
           "verse": 7,
-          "tth": "¡Levántate, __יהוה__! ¡Sálvame, Elohim mío! Porque has golpeado a todos mis enemigos <em>en la</em> mejilla, los dientes de los condenados has roto.",
+          "tth": "¡Levántate, יהוה! ¡Sálvame, Elohim mío! Porque has golpeado a todos mis enemigos <em>en la</em> mejilla, los dientes de los condenados has roto.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 8,
-          "tth": "¡De __יהוה__ es la salvación! ¡Sobre tu pueblo <em>sea</em> tu bendición!",
+          "tth": "¡De יהוה es la salvación! ¡Sobre tu pueblo <em>sea</em> tu bendición!",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Selah. Para el vencedor; con instrumentos de cuerda. Cántico de David."
@@ -242,7 +243,7 @@
         },
         {
           "verse": 3,
-          "tth": "Sepan que ha apartado __יהוה__ <em>al</em> bondadoso para sí.__יהוה__ escuchará cuando clame a Él.",
+          "tth": "Sepan que ha apartado יהוה <em>al</em> bondadoso para sí.יהוה escuchará cuando clame a Él.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -254,13 +255,13 @@
         },
         {
           "verse": 5,
-          "tth": "Sacrifiquen sacrificios de justicia, y confíen en __יהוה__.",
+          "tth": "Sacrifiquen sacrificios de justicia, y confíen en יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 6,
-          "tth": "Muchos dicen: ¿Quién nos mostrará el bien? ¡Alza sobre nosotros la luz de tu rostro, __יהוה__!",
+          "tth": "Muchos dicen: ¿Quién nos mostrará el bien? ¡Alza sobre nosotros la luz de tu rostro, יהוה!",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -272,7 +273,7 @@
         },
         {
           "verse": 8,
-          "tth": "En shalom⁸ juntamente me acostaré y dormiré⁹, porque solo Tú, __יהוה__, en confianza me harás habitar.",
+          "tth": "En shalom⁸ juntamente me acostaré y dormiré⁹, porque solo Tú, יהוה, en confianza me harás habitar.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Para el vencedor; con las flautas.Cántico de David."
@@ -284,7 +285,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "<em>A</em> mis dichos da oído, __יהוה__, comprende mi ferviente clamor¹⁰.",
+          "tth": "<em>A</em> mis dichos da oído, יהוה, comprende mi ferviente clamor¹⁰.",
           "footnotes": [
             {
               "marker": "¹⁰",
@@ -310,7 +311,7 @@
         },
         {
           "verse": 3,
-          "tth": "__יהוה__, de mañana escucharás mi voz, de mañana prepararé para ti, y vigilaré¹².",
+          "tth": "יהוה, de mañana escucharás mi voz, de mañana prepararé para ti, y vigilaré¹².",
           "footnotes": [
             {
               "marker": "¹²",
@@ -368,7 +369,7 @@
         },
         {
           "verse": 8,
-          "tth": "__יהוה__, condúceme en tu justicia debido a mis opresores; endereza delante de mí tu camino.",
+          "tth": "יהוה, condúceme en tu justicia debido a mis opresores; endereza delante de mí tu camino.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -392,7 +393,7 @@
         },
         {
           "verse": 12,
-          "tth": "Porque Tú bendecirás <em>al</em> justificado, __יהוה__, como <em>con</em> el pavés, <em>con</em> reconciliación lo rodearás.",
+          "tth": "Porque Tú bendecirás <em>al</em> justificado, יהוה, como <em>con</em> el pavés, <em>con</em> reconciliación lo rodearás.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Para el vencedor; con instrumentos de cuerda, sobre la octava. Cántico de David."
@@ -404,25 +405,25 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "__יהוה__, no en tu nariz me reprendas, ni en tu ardor me disciplines.",
+          "tth": "יהוה, no en tu nariz me reprendas, ni en tu ardor me disciplines.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 2,
-          "tth": "Inclínate con favor hacia mí, __יהוה__, pues débil soy yo; sáname, __יהוה__, porque tiemblan mis huesos.",
+          "tth": "Inclínate con favor hacia mí, יהוה, pues débil soy yo; sáname, יהוה, porque tiemblan mis huesos.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 3,
-          "tth": "Y mi ser tiembla mucho, y Tú, __יהוה__, ¿hasta cuándo?",
+          "tth": "Y mi ser tiembla mucho, y Tú, יהוה, ¿hasta cuándo?",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 4,
-          "tth": "Vuélvete, __יהוה__, rescata mi ser; sálvame, debido a tu bondad.",
+          "tth": "Vuélvete, יהוה, rescata mi ser; sálvame, debido a tu bondad.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -446,7 +447,7 @@
         },
         {
           "verse": 8,
-          "tth": "¡Apártense de mí, todos los hacedores de vacuidad¹⁶!, porque ha escuchado __יהוה__ la voz de mi llanto.",
+          "tth": "¡Apártense de mí, todos los hacedores de vacuidad¹⁶!, porque ha escuchado יהוה la voz de mi llanto.",
           "footnotes": [
             {
               "marker": "¹⁶",
@@ -459,7 +460,7 @@
         },
         {
           "verse": 9,
-          "tth": "Ha escuchado __יהוה__ mi súplica, __יהוה__ mi tefilah¹⁷ recibirá.",
+          "tth": "Ha escuchado יהוה mi súplica, יהוה mi tefilah¹⁷ recibirá.",
           "footnotes": [
             {
               "marker": "¹⁷",
@@ -472,7 +473,7 @@
         },
         {
           "verse": 10,
-          "tth": "Se avergonzarán y se aterrarán mucho todos mis enemigos; volverán y se avergonzarán de repente. <em>Shigaión¹⁸ de David, que cantó a</em>__יהוה__<em>sobre las palabras de Cush, benieminí¹⁹.</em>",
+          "tth": "Se avergonzarán y se aterrarán mucho todos mis enemigos; volverán y se avergonzarán de repente. <em>Shigaión¹⁸ de David, que cantó a</em> יהוה <em>sobre las palabras de Cush, benieminí¹⁹.</em>",
           "footnotes": [
             {
               "marker": "¹⁹",
@@ -633,7 +634,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "¡__יהוה__, Adón²⁵ nuestro, cuán glorioso es tu Nombre en toda la tierra, que has dado tu esplendor sobre los cielos!",
+          "tth": "¡יהוה, Adón²⁵ nuestro, cuán glorioso es tu Nombre en toda la tierra, que has dado tu esplendor sobre los cielos!",
           "footnotes": [
             {
               "marker": "²⁵",
@@ -695,7 +696,7 @@
         },
         {
           "verse": 9,
-          "tth": "¡__יהוה__, Adón nuestro, cuán glorioso es tu Nombre en toda la tierra!",
+          "tth": "¡יהוה, Adón nuestro, cuán glorioso es tu Nombre en toda la tierra!",
           "footnotes": [
             {
               "marker": "²⁷",
@@ -714,7 +715,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Confesaré <em>a</em> __יהוה__ con todo mi corazón, contaré todas tus maravillas.",
+          "tth": "Confesaré <em>a</em> יהוה con todo mi corazón, contaré todas tus maravillas.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -764,7 +765,7 @@
         },
         {
           "verse": 7,
-          "tth": "Pero __יהוה__ para siempre permanecerá, ha establecido para el juicio su trono,",
+          "tth": "Pero יהוה para siempre permanecerá, ha establecido para el juicio su trono,",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -776,19 +777,19 @@
         },
         {
           "verse": 9,
-          "tth": "Y será __יהוה__ alto refugio para el oprimido, alto refugio para tiempos en estrechez.",
+          "tth": "Y será יהוה alto refugio para el oprimido, alto refugio para tiempos en estrechez.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 10,
-          "tth": "Y confiarán en ti los que conocen tu Nombre, porque no has abandonado <em>a</em> los que te buscan, __יהוה__.",
+          "tth": "Y confiarán en ti los que conocen tu Nombre, porque no has abandonado <em>a</em> los que te buscan, יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 11,
-          "tth": "¡Canten a __יהוה__, que mora en Tzión!, ¡den a conocer en los pueblos sus acciones!",
+          "tth": "¡Canten a יהוה, que mora en Tzión!, ¡den a conocer en los pueblos sus acciones!",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -800,7 +801,7 @@
         },
         {
           "verse": 13,
-          "tth": "Inclínate hacia mí con favor, __יהוה__; mira mi aflicción <em>por causa</em> de mis odiadores, el que me levanta de las puertas de la muerte,",
+          "tth": "Inclínate hacia mí con favor, יהוה; mira mi aflicción <em>por causa</em> de mis odiadores, el que me levanta de las puertas de la muerte,",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -818,7 +819,7 @@
         },
         {
           "verse": 16,
-          "tth": "Se ha hecho conocer __יהוה__, juicio ha hecho.En la obra de sus palmas fue atrapado el condenado. <em>Higaión</em>³⁰<em>Selah</em>³¹<em>.</em>",
+          "tth": "Se ha hecho conocer יהוה, juicio ha hecho.En la obra de sus palmas fue atrapado el condenado. <em>Higaión</em>³⁰<em>Selah</em>³¹<em>.</em>",
           "footnotes": [
             {
               "marker": "³⁰",
@@ -849,13 +850,13 @@
         },
         {
           "verse": 19,
-          "tth": "¡Levántate, __יהוה__!, no se fortalecerá el hombre; serán juzgadas las naciones sobre tu rostro.",
+          "tth": "¡Levántate, יהוה!, no se fortalecerá el hombre; serán juzgadas las naciones sobre tu rostro.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 20,
-          "tth": "Pon temor, __יהוה__, para ellos; aprenderán las naciones <em>que</em> son hombres. <em>Selah</em>.",
+          "tth": "Pon temor, יהוה, para ellos; aprenderán las naciones <em>que</em> son hombres. <em>Selah</em>.",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -866,7 +867,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "¿Por qué, __יהוה__, te paras en la lejanía, te ocultas para los tiempos en estrechez?",
+          "tth": "¿Por qué, יהוה, te paras en la lejanía, te ocultas para los tiempos en estrechez?",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -885,7 +886,7 @@
         },
         {
           "verse": 3,
-          "tth": "Porque se alaba el condenado por el deseo de su ser, y el codicioso maldice³³ <em>y</em> desprecia <em>a</em> __יהוה__.",
+          "tth": "Porque se alaba el condenado por el deseo de su ser, y el codicioso maldice³³ <em>y</em> desprecia <em>a</em> יהוה.",
           "footnotes": [
             {
               "marker": "³³",
@@ -966,7 +967,7 @@
         },
         {
           "verse": 12,
-          "tth": "¡Levántate, __יהוה__! ¡El, alza tu mano!, no te olvidarás de los afligidos.",
+          "tth": "¡Levántate, יהוה! ¡El, alza tu mano!, no te olvidarás de los afligidos.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -990,13 +991,13 @@
         },
         {
           "verse": 16,
-          "tth": "__יהוה__ es Rey <em>por</em> siempre y siempre, han perecido las naciones de su tierra.",
+          "tth": "יהוה es Rey <em>por</em> siempre y siempre, han perecido las naciones de su tierra.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 17,
-          "tth": "El deseo de los afligidos has oído, __יהוה__; afirmarás su corazón, estará atento tu oído",
+          "tth": "El deseo de los afligidos has oído, יהוה; afirmarás su corazón, estará atento tu oído",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1014,7 +1015,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "En __יהוה__ me he refugiado; ¿cómo dicen a mi ser: Huye al monte de ustedes <em>como</em> ave?",
+          "tth": "En יהוה me he refugiado; ¿cómo dicen a mi ser: Huye al monte de ustedes <em>como</em> ave?",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1032,13 +1033,13 @@
         },
         {
           "verse": 4,
-          "tth": "__יהוה__ <em>está</em> en el Hejal de su santidad; __יהוה__, en los cielos <em>está</em> su trono; sus ojos mirarán, sus párpados examinarán <em>a</em> los hijos de Adam.",
+          "tth": "יהוה <em>está</em> en el Hejal de su santidad; יהוה, en los cielos <em>está</em> su trono; sus ojos mirarán, sus párpados examinarán <em>a</em> los hijos de Adam.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 5,
-          "tth": "__יהוה__ <em>al</em> justificado examinará; y <em>al</em> condenado y <em>al</em> que ama la violencia aborrece su ser.",
+          "tth": "יהוה <em>al</em> justificado examinará; y <em>al</em> condenado y <em>al</em> que ama la violencia aborrece su ser.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1057,7 +1058,7 @@
         },
         {
           "verse": 7,
-          "tth": "Porque justo es __יהוה__, las justicias ama; los rectos verán su rostro.",
+          "tth": "Porque justo es יהוה, las justicias ama; los rectos verán su rostro.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Para el vencedor; sobre la octava.Cántico de David."
@@ -1081,7 +1082,7 @@
         },
         {
           "verse": 3,
-          "tth": "Cortará __יהוה__ todos los labios suaves³⁸, la lengua habladora de grandezas;",
+          "tth": "Cortará יהוה todos los labios suaves³⁸, la lengua habladora de grandezas;",
           "footnotes": [
             {
               "marker": "³⁸",
@@ -1107,19 +1108,19 @@
         },
         {
           "verse": 5,
-          "tth": "Por la devastación de los afligidos, por el gemido de los necesitados, ahora me levantaré, dirá __יהוה__; pondré en salvación, apareceré por él.",
+          "tth": "Por la devastación de los afligidos, por el gemido de los necesitados, ahora me levantaré, dirá יהוה; pondré en salvación, apareceré por él.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 6,
-          "tth": "Los dichos de __יהוה__ <em>son</em> dichos puros, plata fundida en un crisol,",
+          "tth": "Los dichos de יהוה <em>son</em> dichos puros, plata fundida en un crisol,",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 7,
-          "tth": "Tú, __יהוה__, los guardarás; nos preservarás de esta generación para siempre.",
+          "tth": "Tú, יהוה, los guardarás; nos preservarás de esta generación para siempre.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1137,7 +1138,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "¿Hasta cuándo, __יהוה__, me olvidarás siempre? ¿Hasta cuándo esconderás tu rostro de mí?",
+          "tth": "¿Hasta cuándo, יהוה, me olvidarás siempre? ¿Hasta cuándo esconderás tu rostro de mí?",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1149,7 +1150,7 @@
         },
         {
           "verse": 3,
-          "tth": "Considera, respóndeme, __יהוה__ mi Elohim; ilumina mis ojos, no sea que duerma de muerte;",
+          "tth": "Considera, respóndeme, יהוה mi Elohim; ilumina mis ojos, no sea que duerma de muerte;",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1167,7 +1168,7 @@
         },
         {
           "verse": 6,
-          "tth": "Cantaré a __יהוה__, porque recompensó sobre mí.",
+          "tth": "Cantaré a יהוה, porque recompensó sobre mí.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Para el vencedor. De David."
@@ -1192,7 +1193,7 @@
         },
         {
           "verse": 2,
-          "tth": "__יהוה__ desde los cielos miró hacia abajo sobre los hijos de Adam, para ver si hay <em>alguien</em> prudente, que busque a Elohim.",
+          "tth": "יהוה desde los cielos miró hacia abajo sobre los hijos de Adam, para ver si hay <em>alguien</em> prudente, que busque a Elohim.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1204,7 +1205,7 @@
         },
         {
           "verse": 4,
-          "tth": "¿No conocen todos los hacedores de vacuidad, devoradores de mi pueblo <em>como si</em> comieran pan,<em>y a</em>__יהוה__ no llaman?",
+          "tth": "¿No conocen todos los hacedores de vacuidad, devoradores de mi pueblo <em>como si</em> comieran pan,<em>y a</em> יהוה no llaman?",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1216,13 +1217,13 @@
         },
         {
           "verse": 6,
-          "tth": "El consejo del afligido avergonzarán, por lo que __יהוה__ es su refugio.",
+          "tth": "El consejo del afligido avergonzarán, por lo que יהוה es su refugio.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 7,
-          "tth": "¡Quién dará de Tzión la salvación de Israel! Cuando retorne __יהוה__ el cautiverio de su pueblo, se regocijará Yaakov, se alegrará Israel.",
+          "tth": "¡Quién dará de Tzión la salvación de Israel! Cuando retorne יהוה el cautiverio de su pueblo, se regocijará Yaakov, se alegrará Israel.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Cántico de David."
@@ -1234,7 +1235,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "__יהוה__, ¿quién residirá en tu tienda? ¿Quién morará en el monte de tu santidad?",
+          "tth": "יהוה, ¿quién residirá en tu tienda? ¿Quién morará en el monte de tu santidad?",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1259,7 +1260,7 @@
         },
         {
           "verse": 4,
-          "tth": "Despreciado es en sus ojos el aborrecido, y a los temerosos de __יהוה__ honra.Juró para hacer mal, y no cambiará.",
+          "tth": "Despreciado es en sus ojos el aborrecido, y a los temerosos de יהוה honra.Juró para hacer mal, y no cambiará.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1297,7 +1298,7 @@
         },
         {
           "verse": 2,
-          "tth": "Dijiste a __יהוה__: Adonai eres Tú; mi bien no es sobre ti.",
+          "tth": "Dijiste a יהוה: Adonai eres Tú; mi bien no es sobre ti.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1322,7 +1323,7 @@
         },
         {
           "verse": 5,
-          "tth": "__יהוה__ es la porción de mi terreno y mi copa, Tú sostienes mi parcela⁴⁶.",
+          "tth": "יהוה es la porción de mi terreno y mi copa, Tú sostienes mi parcela⁴⁶.",
           "footnotes": [
             {
               "marker": "⁴⁶",
@@ -1341,13 +1342,13 @@
         },
         {
           "verse": 7,
-          "tth": "Bendeciré a __יהוה__, que me aconseja; ciertamente <em>en</em> las noches me disciplinan mis riñones.",
+          "tth": "Bendeciré a יהוה, que me aconseja; ciertamente <em>en</em> las noches me disciplinan mis riñones.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 8,
-          "tth": "He puesto <em>a</em> __יהוה__ delante de mí siempre; porque <em>está</em> a mi diestra, no seré sacudido.",
+          "tth": "He puesto <em>a</em> יהוה delante de mí siempre; porque <em>está</em> a mi diestra, no seré sacudido.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1384,7 +1385,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Escucha, __יהוה__, justicia; presta atención <em>a</em> mi grito; da oído <em>a</em> mi oración sin labios de engaño.",
+          "tth": "Escucha, יהוה, justicia; presta atención <em>a</em> mi grito; da oído <em>a</em> mi oración sin labios de engaño.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1470,19 +1471,19 @@
         },
         {
           "verse": 13,
-          "tth": "¡Levántate, __יהוה__! ¡Ponte al frente de su rostro! ¡Haz que se incline! Haz escapar mi vida del condenado con tu espada,",
+          "tth": "¡Levántate, יהוה! ¡Ponte al frente de su rostro! ¡Haz que se incline! Haz escapar mi vida del condenado con tu espada,",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 14,
-          "tth": "de los muertos, <em>con</em> tu mano, __יהוה__, de los muertos, del mundano,<em>que</em> su porción está en <em>esta</em> vida, y llena a tu protegido⁵⁰; el vientre de ellos, se sacian de hijos, y dejan su remanente a sus niños.",
+          "tth": "de los muertos, <em>con</em> tu mano, יהוה, de los muertos, del mundano,<em>que</em> su porción está en <em>esta</em> vida, y llena a tu protegido⁵⁰; el vientre de ellos, se sacian de hijos, y dejan su remanente a sus niños.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 15,
-          "tth": "Yo en justicia veré tu rostro, me saciaré cuando despierte <em>a</em> tu semejanza. <em>Para el vencedor. Del siervo de</em>__יהוה__<em>, de David, el cual habló a</em>__יהוה__<em>las palabras de esta canción en el día que lo rescató</em>__יהוה__<em>de la palma de todos sus enemigos, y de la mano de Shaúl, y dijo:</em>",
+          "tth": "Yo en justicia veré tu rostro, me saciaré cuando despierte <em>a</em> tu semejanza. <em>Para el vencedor. Del siervo de</em> יהוה <em>, de David, el cual habló a</em> יהוה <em>las palabras de esta canción en el día que lo rescató</em> יהוה <em>de la palma de todos sus enemigos, y de la mano de Shaúl, y dijo:</em>",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -1493,13 +1494,13 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Yo te amo, __יהוה__, mi fuerza.",
+          "tth": "Yo te amo, יהוה, mi fuerza.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 2,
-          "tth": "__יהוה__ es mi peña, mi castillo y mi escape; mi El⁵¹, mi Roca, me refugiaré en Él; mi escudo y el cuerno de mi salvación, mi altura segura.",
+          "tth": "יהוה es mi peña, mi castillo y mi escape; mi El⁵¹, mi Roca, me refugiaré en Él; mi escudo y el cuerno de mi salvación, mi altura segura.",
           "footnotes": [
             {
               "marker": "⁵¹",
@@ -1512,7 +1513,7 @@
         },
         {
           "verse": 3,
-          "tth": "Alabado es, llamaré <em>a</em> __יהוה__, y de mis enemigos seré salvado.",
+          "tth": "Alabado es, llamaré <em>a</em> יהוה, y de mis enemigos seré salvado.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1537,7 +1538,7 @@
         },
         {
           "verse": 6,
-          "tth": "En la estrechez mía llamaré <em>a</em> __יהוה__, y a mi Elohim gritaré por ayuda; escuchará desde su Hejal⁵³ mi voz, y mi grito de ayuda delante de Él llegará a sus oídos.",
+          "tth": "En la estrechez mía llamaré <em>a</em> יהוה, y a mi Elohim gritaré por ayuda; escuchará desde su Hejal⁵³ mi voz, y mi grito de ayuda delante de Él llegará a sus oídos.",
           "footnotes": [
             {
               "marker": "⁵³",
@@ -1586,7 +1587,7 @@
         },
         {
           "verse": 13,
-          "tth": "Y tronó en los cielos __יהוה__, y Elyón⁵⁴ dio su voz: granizo y carbones de fuego.",
+          "tth": "Y tronó en los cielos יהוה, y Elyón⁵⁴ dio su voz: granizo y carbones de fuego.",
           "footnotes": [
             {
               "marker": "⁵⁴",
@@ -1612,7 +1613,7 @@
         },
         {
           "verse": 15,
-          "tth": "Y fueron vistos los lechos de las aguas, y fueron descubiertos los cimientos del mundopor tu reprensión, __יהוה__, por la respiración del aliento de tu nariz.",
+          "tth": "Y fueron vistos los lechos de las aguas, y fueron descubiertos los cimientos del mundopor tu reprensión, יהוה, por la respiración del aliento de tu nariz.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1630,7 +1631,7 @@
         },
         {
           "verse": 18,
-          "tth": "Me confrontaron en el día de mi angustia, pero fue __יהוה__ por sostén para mí.",
+          "tth": "Me confrontaron en el día de mi angustia, pero fue יהוה por sostén para mí.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1642,13 +1643,13 @@
         },
         {
           "verse": 20,
-          "tth": "Me recompensará __יהוה__ conforme a mi justicia; conforme a la pureza de mis manos me devolverá.",
+          "tth": "Me recompensará יהוה conforme a mi justicia; conforme a la pureza de mis manos me devolverá.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 21,
-          "tth": "Porque he guardado los caminos de __יהוה__, y no he sido condenado de mi Elohim.",
+          "tth": "Porque he guardado los caminos de יהוה, y no he sido condenado de mi Elohim.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1666,7 +1667,7 @@
         },
         {
           "verse": 24,
-          "tth": "Y me devolvió __יהוה__ conforme a mi justicia, conforme a la pureza de mis manosdelante de sus ojos.",
+          "tth": "Y me devolvió יהוה conforme a mi justicia, conforme a la pureza de mis manosdelante de sus ojos.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1690,7 +1691,7 @@
         },
         {
           "verse": 28,
-          "tth": "Porque Tú harás brillar mi lámpara, __יהוה__; mi Elohim iluminará mi oscuridad.",
+          "tth": "Porque Tú harás brillar mi lámpara, יהוה; mi Elohim iluminará mi oscuridad.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1702,7 +1703,7 @@
         },
         {
           "verse": 30,
-          "tth": "El⁵⁶, es completo su camino; el dicho de __יהוה__ es refinado; escudo es Él a todos los que se refugian en Él.",
+          "tth": "El⁵⁶, es completo su camino; el dicho de יהוה es refinado; escudo es Él a todos los que se refugian en Él.",
           "footnotes": [
             {
               "marker": "⁵⁶",
@@ -1715,7 +1716,7 @@
         },
         {
           "verse": 31,
-          "tth": "Porque, ¿quién es Eloha⁵⁷ excepto __יהוה__? ¿Y quién es Roca salvo nuestro Elohim?",
+          "tth": "Porque, ¿quién es Eloha⁵⁷ excepto יהוה? ¿Y quién es Roca salvo nuestro Elohim?",
           "footnotes": [
             {
               "marker": "⁵⁷",
@@ -1782,7 +1783,7 @@
         },
         {
           "verse": 41,
-          "tth": "Gritaron por ayuda, y no hubo salvador, a __יהוה__, y no les respondió.",
+          "tth": "Gritaron por ayuda, y no hubo salvador, a יהוה, y no les respondió.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1819,7 +1820,7 @@
         },
         {
           "verse": 46,
-          "tth": "¡Vive __יהוה__! ¡Y bendita mi Roca! ¡Y exaltado será el Elohim de mi salvación!",
+          "tth": "¡Vive יהוה! ¡Y bendita mi Roca! ¡Y exaltado será el Elohim de mi salvación!",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1837,7 +1838,7 @@
         },
         {
           "verse": 49,
-          "tth": "Por eso te confesaré entre los gentiles, __יהוה__, y a tu Nombre cantaré melodías.",
+          "tth": "Por eso te confesaré entre los gentiles, יהוה, y a tu Nombre cantaré melodías.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1905,7 +1906,7 @@
         },
         {
           "verse": 7,
-          "tth": "La Torah de __יהוה__ es completa, hace volver el aliento⁶³; el testimonio de __יהוה__ es firme, hace sabio <em>al</em> simple;",
+          "tth": "La Torah de יהוה es completa, hace volver el aliento⁶³; el testimonio de יהוה es firme, hace sabio <em>al</em> simple;",
           "footnotes": [
             {
               "marker": "⁶³",
@@ -1918,13 +1919,13 @@
         },
         {
           "verse": 8,
-          "tth": "los estatutos de __יהוה__ son rectos, alegran el corazón; el mandamiento de __יהוה__ es puro, ilumina los ojos.",
+          "tth": "los estatutos de יהוה son rectos, alegran el corazón; el mandamiento de יהוה es puro, ilumina los ojos.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 9,
-          "tth": "el temor de __יהוה__ es limpio, permanece para siempre; los juicios de __יהוה__ son verdad, son justos juntamente;",
+          "tth": "el temor de יהוה es limpio, permanece para siempre; los juicios de יהוה son verdad, son justos juntamente;",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1961,7 +1962,7 @@
         },
         {
           "verse": 14,
-          "tth": "Serán para deleite los dichos de mi boca y la meditación de mi corazón delante de ti,__יהוה__, mi Roca y mi Redentor.",
+          "tth": "Serán para deleite los dichos de mi boca y la meditación de mi corazón delante de ti,יהוה, mi Roca y mi Redentor.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Para el vencedor. Cántico de David."
@@ -1973,7 +1974,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Te responderá __יהוה__ en el día de estrechez, te pondrá en alto el Nombre del Elohim de Yaakov.",
+          "tth": "Te responderá יהוה en el día de estrechez, te pondrá en alto el Nombre del Elohim de Yaakov.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2004,19 +2005,19 @@
         },
         {
           "verse": 5,
-          "tth": "Cantaremos con gozo por tu salvación, y en el Nombre de nuestro Elohim alzaremos bandera.Llenará __יהוה__ todas tus peticiones.",
+          "tth": "Cantaremos con gozo por tu salvación, y en el Nombre de nuestro Elohim alzaremos bandera.Llenará יהוה todas tus peticiones.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 6,
-          "tth": "Ahora sé que __יהוה__ salva <em>a</em> su Mesías, le responderá desde los cielos de su santidadcon las fuerzas de salvación de su diestra.",
+          "tth": "Ahora sé que יהוה salva <em>a</em> su Mesías, le responderá desde los cielos de su santidadcon las fuerzas de salvación de su diestra.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 7,
-          "tth": "Estos en carro, y estos en caballos; mas nosotros en el Nombre de __יהוה__ nuestro Elohim recordaremos.",
+          "tth": "Estos en carro, y estos en caballos; mas nosotros en el Nombre de יהוה nuestro Elohim recordaremos.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2028,7 +2029,7 @@
         },
         {
           "verse": 9,
-          "tth": "¡__יהוה__, salva! El Rey nos responderá en el día de nuestro llamado.",
+          "tth": "¡יהוה, salva! El Rey nos responderá en el día de nuestro llamado.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Para el vencedor. Cántico de David."
@@ -2040,7 +2041,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "__יהוה__, en tu fuerza se alegrará el rey, y en tu salvación, ¡cuán grandemente se regocijará!",
+          "tth": "יהוה, en tu fuerza se alegrará el rey, y en tu salvación, ¡cuán grandemente se regocijará!",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2097,7 +2098,7 @@
         },
         {
           "verse": 7,
-          "tth": "Porque el rey confía en __יהוה__, y en la bondad de Elyón⁶⁹ no será sacudido.",
+          "tth": "Porque el rey confía en יהוה, y en la bondad de Elyón⁶⁹ no será sacudido.",
           "footnotes": [
             {
               "marker": "⁶⁹",
@@ -2116,7 +2117,7 @@
         },
         {
           "verse": 9,
-          "tth": "Los pondrás como horno de fuego al tiempo de tu rostro;__יהוה__ en su nariz los tragará, y los consumirá el fuego.",
+          "tth": "Los pondrás como horno de fuego al tiempo de tu rostro;יהוה en su nariz los tragará, y los consumirá el fuego.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2140,7 +2141,7 @@
         },
         {
           "verse": 13,
-          "tth": "Enaltécete, __יהוה__, en tu fuerza; y cantaremos y entonaremos tu poder.",
+          "tth": "Enaltécete, יהוה, en tu fuerza; y cantaremos y entonaremos tu poder.",
           "footnotes": [
             {
               "marker": "⁷⁰",
@@ -2309,7 +2310,7 @@
         },
         {
           "verse": 19,
-          "tth": "Y Tú, __יהוה__, no te alejes; fuerza mía, apresúrate a ayudarme.",
+          "tth": "Y Tú, יהוה, no te alejes; fuerza mía, apresúrate a ayudarme.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3179,7 +3180,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "En ti, __יהוה__, me he refugiado; no seré avergonzado nunca, en tu justicia hazme escapar.",
+          "tth": "En ti, יהוה, me he refugiado; no seré avergonzado nunca, en tu justicia hazme escapar.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3203,7 +3204,7 @@
         },
         {
           "verse": 5,
-          "tth": "En tu mano encomendaré mi aliento; me redimiste, __יהוה__, El¹⁰³ de verdad.",
+          "tth": "En tu mano encomendaré mi aliento; me redimiste, יהוה, El¹⁰³ de verdad.",
           "footnotes": [
             {
               "marker": "¹⁰³",
@@ -3216,7 +3217,7 @@
         },
         {
           "verse": 6,
-          "tth": "He aborrecido <em>a</em> los que preservan vapores de vacuidad; y yo, hacia __יהוה__ he confiado.",
+          "tth": "He aborrecido <em>a</em> los que preservan vapores de vacuidad; y yo, hacia יהוה he confiado.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3234,7 +3235,7 @@
         },
         {
           "verse": 9,
-          "tth": "Inclínate en favor hacia mí, __יהוה__, porque tengo estrechez.Decayó por el sufrimiento mi ojo, mi ser y mi vientre.",
+          "tth": "Inclínate en favor hacia mí, יהוה, porque tengo estrechez.Decayó por el sufrimiento mi ojo, mi ser y mi vientre.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3264,7 +3265,7 @@
         },
         {
           "verse": 14,
-          "tth": "Pero yo en ti he confiado, __יהוה__, dije: Mi Elohim eres Tú.",
+          "tth": "Pero yo en ti he confiado, יהוה, dije: Mi Elohim eres Tú.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3282,7 +3283,7 @@
         },
         {
           "verse": 17,
-          "tth": "__יהוה__, no seré avergonzado, porque te he llamado. Serán avergonzados los malvados; serán enmudecidos hacia el Sheol.",
+          "tth": "יהוה, no seré avergonzado, porque te he llamado. Serán avergonzados los malvados; serán enmudecidos hacia el Sheol.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3319,7 +3320,7 @@
         },
         {
           "verse": 21,
-          "tth": "Bendito <em>es</em> __יהוה__, porque ha hecho distinguida su bondad para mí en ciudad fortificada.",
+          "tth": "Bendito <em>es</em> יהוה, porque ha hecho distinguida su bondad para mí en ciudad fortificada.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3331,13 +3332,13 @@
         },
         {
           "verse": 23,
-          "tth": "¡Amen a __יהוה__ todos sus benevolentes! <em>A</em> los firmes preserva __יהוה__, y retribuye sobre abundancia <em>al</em> hacedor de soberbia.",
+          "tth": "¡Amen a יהוה todos sus benevolentes! <em>A</em> los firmes preserva יהוה, y retribuye sobre abundancia <em>al</em> hacedor de soberbia.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 24,
-          "tth": "¡Fortalézcanse, y esfuércese su corazón, todos los que esperan a __יהוה__! <em>De David</em>; <em>Masquil¹⁰⁶.</em>",
+          "tth": "¡Fortalézcanse, y esfuércese su corazón, todos los que esperan a יהוה! <em>De David</em>; <em>Masquil¹⁰⁶.</em>",
           "footnotes": [
             {
               "marker": "¹⁰⁶",
@@ -3361,7 +3362,7 @@
         },
         {
           "verse": 2,
-          "tth": "¡Felicidades del hombre que no le diseñó __יהוה__ iniquidad, y <em>que</em> no hay en su espíritu engaño!",
+          "tth": "¡Felicidades del hombre que no le diseñó יהוה iniquidad, y <em>que</em> no hay en su espíritu engaño!",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3386,7 +3387,7 @@
         },
         {
           "verse": 5,
-          "tth": "Mi pecado te di a conocer, y mi iniquidad no oculté.Dije: Confesaré sobre mis transgresiones a __יהוה__; y Tú cargaste la iniquidad de mi pecado. <em>Selah.</em>",
+          "tth": "Mi pecado te di a conocer, y mi iniquidad no oculté.Dije: Confesaré sobre mis transgresiones a יהוה; y Tú cargaste la iniquidad de mi pecado. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3423,13 +3424,13 @@
         },
         {
           "verse": 10,
-          "tth": "Muchos son los dolores del condenado, pero el que confía en __יהוה__, benevolencia lo rodeará.",
+          "tth": "Muchos son los dolores del condenado, pero el que confía en יהוה, benevolencia lo rodeará.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 11,
-          "tth": "¡Alégrense en __יהוה__ y regocíjense, justos! ¡Y griten de alegría, todos los rectos de corazón!",
+          "tth": "¡Alégrense en יהוה y regocíjense, justos! ¡Y griten de alegría, todos los rectos de corazón!",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -3440,13 +3441,13 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "¡Griten de alegría, justos, en __יהוה__! Para los justos es apropiada la alabanza.",
+          "tth": "¡Griten de alegría, justos, en יהוה! Para los justos es apropiada la alabanza.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 2,
-          "tth": "¡Alaben a __יהוה__ con el arpa, con lira de diez <em>cuerdas</em> cántenle!",
+          "tth": "¡Alaben a יהוה con el arpa, con lira de diez <em>cuerdas</em> cántenle!",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3458,7 +3459,7 @@
         },
         {
           "verse": 4,
-          "tth": "Porque recta es la palabra de __יהוה__, y todas sus obras en fidelidad¹¹¹.",
+          "tth": "Porque recta es la palabra de יהוה, y todas sus obras en fidelidad¹¹¹.",
           "footnotes": [
             {
               "marker": "¹¹¹",
@@ -3471,13 +3472,13 @@
         },
         {
           "verse": 5,
-          "tth": "Él ama la justicia y el juicio, la bondad de __יהוה__ llena la tierra.",
+          "tth": "Él ama la justicia y el juicio, la bondad de יהוה llena la tierra.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 6,
-          "tth": "Por la palabra de __יהוה__ los cielos fueron hechos, y por el Rúaj¹¹² de su boca todo su ejército.",
+          "tth": "Por la palabra de יהוה los cielos fueron hechos, y por el Rúaj¹¹² de su boca todo su ejército.",
           "footnotes": [
             {
               "marker": "¹¹²",
@@ -3496,7 +3497,7 @@
         },
         {
           "verse": 8,
-          "tth": "Tengan temor de __יהוה__, toda la tierra, de Él tengan miedo todos los habitantes del mundo.",
+          "tth": "Tengan temor de יהוה, toda la tierra, de Él tengan miedo todos los habitantes del mundo.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3508,25 +3509,25 @@
         },
         {
           "verse": 10,
-          "tth": "__יהוה__ rompe el consejo de las naciones, estorba los pensamientos de los pueblos.",
+          "tth": "יהוה rompe el consejo de las naciones, estorba los pensamientos de los pueblos.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 11,
-          "tth": "El consejo de __יהוה__ para siempre permanecerá, los pensamientos de su corazón por generación y generación.",
+          "tth": "El consejo de יהוה para siempre permanecerá, los pensamientos de su corazón por generación y generación.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 12,
-          "tth": "¡Feliz la nación que __יהוה__ es su Elohim, el pueblo <em>que</em> Él escogió por herencia para sí!",
+          "tth": "¡Feliz la nación que יהוה es su Elohim, el pueblo <em>que</em> Él escogió por herencia para sí!",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 13,
-          "tth": "Desde los cielos mira __יהוה__; ve a todos los hijos de Adam.",
+          "tth": "Desde los cielos mira יהוה; ve a todos los hijos de Adam.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3556,7 +3557,7 @@
         },
         {
           "verse": 18,
-          "tth": "He aquí, el ojo de __יהוה__ es hacia sus temerosos, hacia los que esperan a su bondad,",
+          "tth": "He aquí, el ojo de יהוה es hacia sus temerosos, hacia los que esperan a su bondad,",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3568,7 +3569,7 @@
         },
         {
           "verse": 20,
-          "tth": "Nuestro ser¹¹³ espera a __יהוה__; nuestra ayuda y nuestro escudo es Él;",
+          "tth": "Nuestro ser¹¹³ espera a יהוה; nuestra ayuda y nuestro escudo es Él;",
           "footnotes": [
             {
               "marker": "¹¹³",
@@ -3587,7 +3588,7 @@
         },
         {
           "verse": 22,
-          "tth": "¡Será tu bondad, __יהוה__, sobre nosotros, como te hemos esperado!",
+          "tth": "¡Será tu bondad, יהוה, sobre nosotros, como te hemos esperado!",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "De David, cuando cambió su juicio delante de Abimélej, y lo echó y se fue."
@@ -3599,25 +3600,25 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Bendeciré a __יהוה__ en todo tiempo, continuamente su alabanza <em>estará</em> en mi boca.",
+          "tth": "Bendeciré a יהוה en todo tiempo, continuamente su alabanza <em>estará</em> en mi boca.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 2,
-          "tth": "En __יהוה__ se gloriará mi ser; escucharán los afligidos y se alegrarán.",
+          "tth": "En יהוה se gloriará mi ser; escucharán los afligidos y se alegrarán.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 3,
-          "tth": "¡Engrandezcan a __יהוה__ conmigo, y exaltemos su Nombre juntos!",
+          "tth": "¡Engrandezcan a יהוה conmigo, y exaltemos su Nombre juntos!",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 4,
-          "tth": "Busqué a __יהוה__ y me respondió, y de todos mis miedos me rescató.",
+          "tth": "Busqué a יהוה y me respondió, y de todos mis miedos me rescató.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3629,37 +3630,37 @@
         },
         {
           "verse": 6,
-          "tth": "Este afligido llamó, y __יהוה__ escuchó, y de todas sus estrecheces lo salvó.",
+          "tth": "Este afligido llamó, y יהוה escuchó, y de todas sus estrecheces lo salvó.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 7,
-          "tth": "Acampa el ángel de __יהוה__ alrededor de sus temerosos, y los rescata.",
+          "tth": "Acampa el ángel de יהוה alrededor de sus temerosos, y los rescata.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 8,
-          "tth": "¡Saboreen y vean que __יהוה__ es bueno! ¡Feliz el fuerte que se refugia en Él!",
+          "tth": "¡Saboreen y vean que יהוה es bueno! ¡Feliz el fuerte que se refugia en Él!",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 9,
-          "tth": "Teman a __יהוה__ sus apartados, porque no hay carencia para sus temerosos.",
+          "tth": "Teman a יהוה sus apartados, porque no hay carencia para sus temerosos.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 10,
-          "tth": "Los leoncillos pasan necesidad y tienen hambre, pero los que buscan <em>a</em> __יהוה__ no careceránde ningún bien.",
+          "tth": "Los leoncillos pasan necesidad y tienen hambre, pero los que buscan <em>a</em> יהוה no careceránde ningún bien.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 11,
-          "tth": "Vengan, hijos, escúchenme; el temor de __יהוה__ les enseñaré.",
+          "tth": "Vengan, hijos, escúchenme; el temor de יהוה les enseñaré.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3690,31 +3691,31 @@
         },
         {
           "verse": 15,
-          "tth": "Los ojos de __יהוה__ son hacia los justificados, y sus oídos hacia su grito de ayuda.",
+          "tth": "Los ojos de יהוה son hacia los justificados, y sus oídos hacia su grito de ayuda.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 16,
-          "tth": "El rostro de __יהוה__ es contra los hacedores del mal, para cortar de la tierra su memoria.",
+          "tth": "El rostro de יהוה es contra los hacedores del mal, para cortar de la tierra su memoria.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 17,
-          "tth": "Clamaron, y __יהוה__ escuchó, y de todas sus estrecheces los rescató.",
+          "tth": "Clamaron, y יהוה escuchó, y de todas sus estrecheces los rescató.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 18,
-          "tth": "Cercano <em>está</em> __יהוה__ a los quebrantados de corazón, y a los aplastados de ánimo Él salvará.",
+          "tth": "Cercano <em>está</em> יהוה a los quebrantados de corazón, y a los aplastados de ánimo Él salvará.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 19,
-          "tth": "Muchos son los males del justificado, pero de todos ellos lo rescatará __יהוה__.",
+          "tth": "Muchos son los males del justificado, pero de todos ellos lo rescatará יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3732,7 +3733,7 @@
         },
         {
           "verse": 22,
-          "tth": "Redime __יהוה__ el ser de sus siervos, y no serán culpables todos los que se refugian en Él. <em>De David.</em>",
+          "tth": "Redime יהוה el ser de sus siervos, y no serán culpables todos los que se refugian en Él. <em>De David.</em>",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -3743,7 +3744,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Pelea, __יהוה__, contra mis contendientes; lucha contra los que luchan contra mí.",
+          "tth": "Pelea, יהוה, contra mis contendientes; lucha contra los que luchan contra mí.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3767,13 +3768,13 @@
         },
         {
           "verse": 5,
-          "tth": "Serán como paja delante del viento, y el ángel de __יהוה__ los empuja.",
+          "tth": "Serán como paja delante del viento, y el ángel de יהוה los empuja.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 6,
-          "tth": "Será su camino oscuridad y resbaladizo, y el ángel de __יהוה__ los persigue.",
+          "tth": "Será su camino oscuridad y resbaladizo, y el ángel de יהוה los persigue.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3791,13 +3792,13 @@
         },
         {
           "verse": 9,
-          "tth": "Y mi ser se regocijará en __יהוה__, se gozará en su salvación.",
+          "tth": "Y mi ser se regocijará en יהוה, se gozará en su salvación.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 10,
-          "tth": "Todos mis huesos dirán: __יהוה__, ¿quién como Tú, que rescatas <em>al</em> afligido del <em>más</em> fuerte que él, y <em>al</em> afligido y necesitado del que lo saquea?",
+          "tth": "Todos mis huesos dirán: יהוה, ¿quién como Tú, que rescatas <em>al</em> afligido del <em>más</em> fuerte que él, y <em>al</em> afligido y necesitado del que lo saquea?",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3896,7 +3897,7 @@
         },
         {
           "verse": 22,
-          "tth": "Has visto, __יהוה__, no calles; Adonai, no te alejes de mí.",
+          "tth": "Has visto, יהוה, no calles; Adonai, no te alejes de mí.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3908,7 +3909,7 @@
         },
         {
           "verse": 24,
-          "tth": "Júzgame conforme a tu justicia, __יהוה__, Elohim mío, y no se alegrarán por mí.",
+          "tth": "Júzgame conforme a tu justicia, יהוה, Elohim mío, y no se alegrarán por mí.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3933,13 +3934,13 @@
         },
         {
           "verse": 27,
-          "tth": "¡Gritarán de júbilo y se alegrarán los que desean mi justicia!, y dirán siempre: ¡Se engrandecerá __יהוה__, que desea el shalom de su siervo!",
+          "tth": "¡Gritarán de júbilo y se alegrarán los que desean mi justicia!, y dirán siempre: ¡Se engrandecerá יהוה, que desea el shalom de su siervo!",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 28,
-          "tth": "Y mi lengua pronunciará tu justicia, todo el día tu alabanza. <em>Para el vencedor. Del siervo de</em>__יהוה__<em>, de David.</em>",
+          "tth": "Y mi lengua pronunciará tu justicia, todo el día tu alabanza. <em>Para el vencedor. Del siervo de</em> יהוה <em>, de David.</em>",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -3974,13 +3975,13 @@
         },
         {
           "verse": 5,
-          "tth": "__יהוה__, en los cielos <em>está</em> tu bondad, tu fidelidad hasta las nubes.",
+          "tth": "יהוה, en los cielos <em>está</em> tu bondad, tu fidelidad hasta las nubes.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 6,
-          "tth": "Tu justicia es como los montes de El¹²⁰; tus procesos legales <em>son</em> una gran profundidad.Al hombre y al animal salvas, __יהוה__.",
+          "tth": "Tu justicia es como los montes de El¹²⁰; tus procesos legales <em>son</em> una gran profundidad.Al hombre y al animal salvas, יהוה.",
           "footnotes": [
             {
               "marker": "¹²⁰",
@@ -4053,7 +4054,7 @@
         },
         {
           "verse": 3,
-          "tth": "Confía en __יהוה__ y haz el bien; mora en la tierra y pasta emunah¹²².",
+          "tth": "Confía en יהוה y haz el bien; mora en la tierra y pasta emunah¹²².",
           "footnotes": [
             {
               "marker": "¹²²",
@@ -4066,7 +4067,7 @@
         },
         {
           "verse": 4,
-          "tth": "Deléitate en __יהוה__, y Él te dará las peticiones de tu corazón.",
+          "tth": "Deléitate en יהוה, y Él te dará las peticiones de tu corazón.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4164,13 +4165,13 @@
         },
         {
           "verse": 17,
-          "tth": "Porque los brazos de los condenados serán rotos; pero sostiene <em>a</em> los justificados __יהוה__.",
+          "tth": "Porque los brazos de los condenados serán rotos; pero sostiene <em>a</em> los justificados יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 18,
-          "tth": "Conoce __יהוה__ los días de los íntegros, y su herencia para siempre será.",
+          "tth": "Conoce יהוה los días de los íntegros, y su herencia para siempre será.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4182,7 +4183,7 @@
         },
         {
           "verse": 20,
-          "tth": "Porque los condenados se perderán, y los enemigos de __יהוה__ <em>serán</em> como la grosura de carneros, se consumen en el humo, se consumen <em>.</em>",
+          "tth": "Porque los condenados se perderán, y los enemigos de יהוה <em>serán</em> como la grosura de carneros, se consumen en el humo, se consumen <em>.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4200,7 +4201,7 @@
         },
         {
           "verse": 23,
-          "tth": "Por __יהוה__ los pasos del hombre son enderezados¹²⁶, y <em>en</em> su camino Él se deleita.",
+          "tth": "Por יהוה los pasos del hombre son enderezados¹²⁶, y <em>en</em> su camino Él se deleita.",
           "footnotes": [
             {
               "marker": "¹²⁶",
@@ -4213,7 +4214,7 @@
         },
         {
           "verse": 24,
-          "tth": "Cuando caiga, no será arrojado, porque __יהוה__ sostiene su mano.",
+          "tth": "Cuando caiga, no será arrojado, porque יהוה sostiene su mano.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4237,7 +4238,7 @@
         },
         {
           "verse": 28,
-          "tth": "Porque __יהוה__ ama el proceso legal¹²⁷, y no abandonará a sus benevolentes, para siempre serán guardados; pero la simiente de los condenados será cortada.",
+          "tth": "Porque יהוה ama el proceso legal¹²⁷, y no abandonará a sus benevolentes, para siempre serán guardados; pero la simiente de los condenados será cortada.",
           "footnotes": [
             {
               "marker": "¹²⁷",
@@ -4274,13 +4275,13 @@
         },
         {
           "verse": 33,
-          "tth": "__יהוה__ no lo abandonará en su mano, ni dejará que lo condenen cuando sea juzgado.",
+          "tth": "יהוה no lo abandonará en su mano, ni dejará que lo condenen cuando sea juzgado.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 34,
-          "tth": "Espera a __יהוה__, y guarda su camino, y Él te exaltará para heredar la tierra; cuando sean cortados los condenados, <em>lo</em> verás.",
+          "tth": "Espera a יהוה, y guarda su camino, y Él te exaltará para heredar la tierra; cuando sean cortados los condenados, <em>lo</em> verás.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4330,13 +4331,13 @@
         },
         {
           "verse": 39,
-          "tth": "Y la liberación de los justos <em>es</em> de __יהוה__, Él es su fortaleza en tiempo de estrechez.",
+          "tth": "Y la liberación de los justos <em>es</em> de יהוה, Él es su fortaleza en tiempo de estrechez.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 40,
-          "tth": "Y los ayudará __יהוה__ y los hará escapar; los hará escapar de los condenados y los salvará, porque se refugiaron en Él.",
+          "tth": "Y los ayudará יהוה y los hará escapar; los hará escapar de los condenados y los salvará, porque se refugiaron en Él.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Cántico de David, para traer al recuerdo."
@@ -4348,7 +4349,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "__יהוה__, no me reprendas¹³¹ en tu rechazo, ni me disciplines en tu ardor.",
+          "tth": "יהוה, no me reprendas¹³¹ en tu rechazo, ni me disciplines en tu ardor.",
           "footnotes": [
             {
               "marker": "¹³¹",
@@ -4452,7 +4453,7 @@
         },
         {
           "verse": 15,
-          "tth": "Porque a ti, __יהוה__, <em>te</em> he esperado, Tú responderás, Adonai, Elohim mío.",
+          "tth": "Porque a ti, יהוה, <em>te</em> he esperado, Tú responderás, Adonai, Elohim mío.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4488,7 +4489,7 @@
         },
         {
           "verse": 21,
-          "tth": "¡No me abandones, __יהוה__!; Elohim mío, ¡no te alejes de mí!",
+          "tth": "¡No me abandones, יהוה!; Elohim mío, ¡no te alejes de mí!",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4524,7 +4525,7 @@
         },
         {
           "verse": 4,
-          "tth": "Hazme saber, __יהוה__, mi fin, y la medida de mis días, ¿cuál es?,<em>y</em> sabré cuán efímero¹³⁴ soy.",
+          "tth": "Hazme saber, יהוה, mi fin, y la medida de mis días, ¿cuál es?,<em>y</em> sabré cuán efímero¹³⁴ soy.",
           "footnotes": [
             {
               "marker": "¹³⁴",
@@ -4593,7 +4594,7 @@
         },
         {
           "verse": 12,
-          "tth": "Escucha mi tefilah¹³⁷, __יהוה__, y da oído a mi grito de ayuda; ante mis lágrimas no calles; porque extranjero soy yo junto a ti, forastero, como todos mis padres.",
+          "tth": "Escucha mi tefilah¹³⁷, יהוה, y da oído a mi grito de ayuda; ante mis lágrimas no calles; porque extranjero soy yo junto a ti, forastero, como todos mis padres.",
           "footnotes": [
             {
               "marker": "¹³⁷",
@@ -4617,7 +4618,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Pacientemente esperé <em>a</em> __יהוה__, y Él se inclinó a mí y escuchó mi grito de ayuda.",
+          "tth": "Pacientemente esperé <em>a</em> יהוה, y Él se inclinó a mí y escuchó mi grito de ayuda.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4629,19 +4630,19 @@
         },
         {
           "verse": 3,
-          "tth": "Y Él dio en mi boca un cántico nuevo, alabanza a nuestro Elohim; muchos <em>lo</em> verán y temerán, y confiarán en __יהוה__.",
+          "tth": "Y Él dio en mi boca un cántico nuevo, alabanza a nuestro Elohim; muchos <em>lo</em> verán y temerán, y confiarán en יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 4,
-          "tth": "¡Felicidades del varón que puso <em>en</em> __יהוה__ su confianza, y no se ha vuelto a los altivos ni <em>a</em> los que se desvían <em>a la</em> falsedad!",
+          "tth": "¡Felicidades del varón que puso <em>en</em> יהוה su confianza, y no se ha vuelto a los altivos ni <em>a</em> los que se desvían <em>a la</em> falsedad!",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 5,
-          "tth": "Muchas son las maravillas que Tú has hecho, __יהוה__ mi Elohim, y tus pensamientos hacia nosotros; nadie se compara contigo; <em>los</em> anunciaré y <em>los</em> hablaré, han sido numerosos <em>para</em> contar <em>los.</em>",
+          "tth": "Muchas son las maravillas que Tú has hecho, יהוה mi Elohim, y tus pensamientos hacia nosotros; nadie se compara contigo; <em>los</em> anunciaré y <em>los</em> hablaré, han sido numerosos <em>para</em> contar <em>los.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4672,7 +4673,7 @@
         },
         {
           "verse": 9,
-          "tth": "He llevado la buena noticia de justicia en la gran congregación; he aquí, mis labios no refrené,__יהוה__, Tú <em>lo</em> sabes.",
+          "tth": "He llevado la buena noticia de justicia en la gran congregación; he aquí, mis labios no refrené,יהוה, Tú <em>lo</em> sabes.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4684,7 +4685,7 @@
         },
         {
           "verse": 11,
-          "tth": "Tú, __יהוה__, no refrenes tus compasiones¹⁴⁰ de mí; tu bondad y tu verdad continuamente me vigilarán¹⁴¹ (O, preservarán).",
+          "tth": "Tú, יהוה, no refrenes tus compasiones¹⁴⁰ de mí; tu bondad y tu verdad continuamente me vigilarán¹⁴¹ (O, preservarán).",
           "footnotes": [
             {
               "marker": "¹⁴⁰",
@@ -4709,7 +4710,7 @@
         },
         {
           "verse": 13,
-          "tth": "Sé favorable, __יהוה__, a rescatarme; __יהוה__, apresúrate a ayudarme.",
+          "tth": "Sé favorable, יהוה, a rescatarme; יהוה, apresúrate a ayudarme.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4727,7 +4728,7 @@
         },
         {
           "verse": 16,
-          "tth": "Se gozarán y se alegrarán en ti todos los que te buscan, dirán continuamente: ¡Engrandecido será __יהוה__! los que aman tu liberación.",
+          "tth": "Se gozarán y se alegrarán en ti todos los que te buscan, dirán continuamente: ¡Engrandecido será יהוה! los que aman tu liberación.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4745,13 +4746,13 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Feliz es el que considera al pobre, en el día malo lo rescatará __יהוה__.",
+          "tth": "Feliz es el que considera al pobre, en el día malo lo rescatará יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 2,
-          "tth": "__יהוה__ lo guardará y hará que viva, será feliz¹⁴² en la tierra; y no lo dejarás a la voluntad de sus enemigos.",
+          "tth": "יהוה lo guardará y hará que viva, será feliz¹⁴² en la tierra; y no lo dejarás a la voluntad de sus enemigos.",
           "footnotes": [
             {
               "marker": "¹⁴²",
@@ -4764,13 +4765,13 @@
         },
         {
           "verse": 3,
-          "tth": "__יהוה__ lo sostendrá en el lecho de enfermedad; toda su cama diste vuelta en su enfermedad.",
+          "tth": "יהוה lo sostendrá en el lecho de enfermedad; toda su cama diste vuelta en su enfermedad.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 4,
-          "tth": "Yo dije: __יהוה__, inclínate con favor a mí; sana mi ser, porque he pecado contra ti.",
+          "tth": "Yo dije: יהוה, inclínate con favor a mí; sana mi ser, porque he pecado contra ti.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4826,7 +4827,7 @@
         },
         {
           "verse": 10,
-          "tth": "Pero Tú, __יהוה__, inclínate con favor a mí y levántame, y yo les retribuiré.",
+          "tth": "Pero Tú, יהוה, inclínate con favor a mí y levántame, y yo les retribuiré.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4844,7 +4845,7 @@
         },
         {
           "verse": 13,
-          "tth": "¡Bendito __יהוה__, Elohim de Israel, desde el olam¹⁴⁶ hasta el olam! Amén y amén. __LIBRO SEGUNDO__",
+          "tth": "¡Bendito יהוה, Elohim de Israel, desde el olam¹⁴⁶ hasta el olam! Amén y amén.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Para el vencedor. Masquil de los hijos de Koraj."
@@ -4947,7 +4948,8 @@
           "footnotes": [],
           "hebrew_terms": []
         }
-      ]
+      ],
+      "book_division": "LIBRO SEGUNDO"
     },
     {
       "chapter": 43,
@@ -5364,13 +5366,13 @@
         },
         {
           "verse": 7,
-          "tth": "__יהוה__ Tzebaot <em>está</em> con nosotros; nuestro alto refugio, Elohim de Yaakov. <em>Selah.</em>",
+          "tth": "יהוה Tzebaot <em>está</em> con nosotros; nuestro alto refugio, Elohim de Yaakov. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 8,
-          "tth": "¡Vengan! Contemplen las obras de __יהוה__, que puso desolaciones en la tierra;",
+          "tth": "¡Vengan! Contemplen las obras de יהוה, que puso desolaciones en la tierra;",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5395,7 +5397,7 @@
         },
         {
           "verse": 11,
-          "tth": "__יהוה__ Tzebaot <em>está</em> con nosotros; nuestro alto refugio, Elohim de Yaakov.",
+          "tth": "יהוה Tzebaot <em>está</em> con nosotros; nuestro alto refugio, Elohim de Yaakov.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Selah. Para el vencedor. De los hijos de Koraj. Cántico."
@@ -5413,7 +5415,7 @@
         },
         {
           "verse": 2,
-          "tth": "Porque __יהוה__ Elyón¹⁶³ es temible; Rey grande sobre toda la tierra.",
+          "tth": "Porque יהוה Elyón¹⁶³ es temible; Rey grande sobre toda la tierra.",
           "footnotes": [
             {
               "marker": "¹⁶³",
@@ -5445,7 +5447,7 @@
         },
         {
           "verse": 5,
-          "tth": "Ha ascendido Elohim con t’ruáh¹⁶⁵, __יהוה__, con voz de shofar¹⁶⁶.",
+          "tth": "Ha ascendido Elohim con t’ruáh¹⁶⁵, יהוה, con voz de shofar¹⁶⁶.",
           "footnotes": [
             {
               "marker": "¹⁶⁵",
@@ -5501,7 +5503,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Grande es __יהוה__, y alabado grandemente en la ciudad de nuestro Elohim, el monte de su santidad.",
+          "tth": "Grande es יהוה, y alabado grandemente en la ciudad de nuestro Elohim, el monte de su santidad.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5543,7 +5545,7 @@
         },
         {
           "verse": 8,
-          "tth": "Como <em>lo</em> hemos oído, así <em>lo</em> hemos visto en la ciudad de __יהוה__ Tzebaot, en la ciudad de nuestro Elohim.Elohim la afirmará hasta siempre. <em>Selah</em>¹⁶⁸<em>.</em>",
+          "tth": "Como <em>lo</em> hemos oído, así <em>lo</em> hemos visto en la ciudad de יהוה Tzebaot, en la ciudad de nuestro Elohim.Elohim la afirmará hasta siempre. <em>Selah</em>¹⁶⁸<em>.</em>",
           "footnotes": [
             {
               "marker": "¹⁶⁸",
@@ -5779,7 +5781,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "El Poderoso¹⁷⁸, Elohim, __יהוה__, ha hablado, y llamó <em>a</em> la tierra desde el amanecer del sol hasta su puesta.",
+          "tth": "El Poderoso¹⁷⁸, Elohim, יהוה, ha hablado, y llamó <em>a</em> la tierra desde el amanecer del sol hasta su puesta.",
           "footnotes": [
             {
               "marker": "¹⁷⁸",
@@ -6272,7 +6274,7 @@
         },
         {
           "verse": 6,
-          "tth": "Con voluntariedad sacrificaré a ti; alabaré tu Nombre, __יהוה__, porque es bueno.",
+          "tth": "Con voluntariedad sacrificaré a ti; alabaré tu Nombre, יהוה, porque es bueno.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -6435,7 +6437,7 @@
         },
         {
           "verse": 16,
-          "tth": "<em>Y</em> yo, a Elohim llamaré, y __יהוה__ me salvará.",
+          "tth": "<em>Y</em> yo, a Elohim llamaré, y יהוה me salvará.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -6492,7 +6494,7 @@
         },
         {
           "verse": 22,
-          "tth": "Echa sobre __יהוה__ <em>todo</em> lo que te es dado, y Él te sustentará; Él nunca dará tambaleo al justo.",
+          "tth": "Echa sobre יהוה <em>todo</em> lo que te es dado, y Él te sustentará; Él nunca dará tambaleo al justo.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -6577,7 +6579,7 @@
         },
         {
           "verse": 10,
-          "tth": "En Elohim, ¡alabaré <em>su</em> palabra!, en __יהוה__, ¡alabaré <em>su</em> palabra!",
+          "tth": "En Elohim, ¡alabaré <em>su</em> palabra!, en יהוה, ¡alabaré <em>su</em> palabra!",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -6723,7 +6725,7 @@
         },
         {
           "verse": 6,
-          "tth": "Elohim, destruye sus dientes en su boca; rompe los colmillos de los leoncillos, __יהוה__.",
+          "tth": "Elohim, destruye sus dientes en su boca; rompe los colmillos de los leoncillos, יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -6777,7 +6779,7 @@
         },
         {
           "verse": 3,
-          "tth": "Porque, he aquí, acecharon mi vida; se reunieron contra mí los fuertes, no <em>por</em> transgresión mía ni <em>por</em> pecado mío, __יהוה__.",
+          "tth": "Porque, he aquí, acecharon mi vida; se reunieron contra mí los fuertes, no <em>por</em> transgresión mía ni <em>por</em> pecado mío, יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -6789,7 +6791,7 @@
         },
         {
           "verse": 5,
-          "tth": "Y Tú, __יהוה__, Elohim Tzebaot, Elohim de Israel, despierta para visitar todas las naciones; no tengas piedad de ningún traidor de vacuidad. <em>Selah</em>²¹⁴<em>.</em>",
+          "tth": "Y Tú, יהוה, Elohim Tzebaot, Elohim de Israel, despierta para visitar todas las naciones; no tengas piedad de ningún traidor de vacuidad. <em>Selah</em>²¹⁴<em>.</em>",
           "footnotes": [
             {
               "marker": "²¹⁴",
@@ -6814,7 +6816,7 @@
         },
         {
           "verse": 8,
-          "tth": "Pero Tú, __יהוה__, te reirás de ellos, te burlarás de todas las naciones.",
+          "tth": "Pero Tú, יהוה, te reirás de ellos, te burlarás de todas las naciones.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8234,7 +8236,7 @@
         },
         {
           "verse": 20,
-          "tth": "Han acabado las oraciones de David, hijo de Ishai. __LIBRO TERCERO__",
+          "tth": "Han acabado las oraciones de David, hijo de Ishai.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Cántico de Asaf."
@@ -8413,7 +8415,8 @@
           "hebrew_terms": [],
           "subtitle": "Masquil de Asaf."
         }
-      ]
+      ],
+      "book_division": "LIBRO TERCERO"
     },
     {
       "chapter": 74,
@@ -9850,7 +9853,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Te reconciliaste, __יהוה__,",
+          "tth": "Te reconciliaste, יהוה,",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -10513,7 +10516,7 @@
         },
         {
           "verse": 52,
-          "tth": "¡Bendito <em>sea</em> יהוה para siempre! Amén y amén. __LIBRO CUARTO__",
+          "tth": "¡Bendito <em>sea</em> יהוה para siempre! Amén y amén.",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -10624,7 +10627,8 @@
           "footnotes": [],
           "hebrew_terms": []
         }
-      ]
+      ],
+      "book_division": "LIBRO CUARTO"
     },
     {
       "chapter": 91,
@@ -12527,7 +12531,7 @@
         },
         {
           "verse": 48,
-          "tth": "¡Bendito יהוה, Elohim de Israel, desde tiempo antiguo hasta tiempo futuro! Y dijo todo el pueblo: ¡Amén! ¡Alaben a Yah (heb.: <em>HaleluYah</em>)! __LIBRO QUINTO__",
+          "tth": "¡Bendito יהוה, Elohim de Israel, desde tiempo antiguo hasta tiempo futuro! Y dijo todo el pueblo: ¡Amén! ¡Alaben a Yah (heb.: <em>HaleluYah</em>)!",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -12794,7 +12798,8 @@
           "footnotes": [],
           "hebrew_terms": []
         }
-      ]
+      ],
+      "book_division": "LIBRO QUINTO"
     },
     {
       "chapter": 108,
@@ -13479,7 +13484,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Amaré, por lo cual, escuchará __יהוה__ la voz de mis súplicas.",
+          "tth": "Amaré, por lo cual, escuchará יהוה la voz de mis súplicas.",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/vaikra.json
+++ b/data/tth_2/json/vaikra.json
@@ -1018,7 +1018,7 @@
         },
         {
           "verse": 18,
-          "tth": "Todo varón entre los hijos de Aharón puede comerla; será estatuto olam³⁶ para sus generaciones, de las ofrendas encendidas de __יהוה__. Todo el que las toque, será consagrado”.",
+          "tth": "Todo varón entre los hijos de Aharón puede comerla; será estatuto olam³⁶ para sus generaciones, de las ofrendas encendidas de יהוה. Todo el que las toque, será consagrado”.",
           "footnotes": [
             {
               "marker": "³⁶",
@@ -1031,13 +1031,13 @@
         },
         {
           "verse": 19,
-          "tth": "Y habló __יהוה__ a Moshéh, diciendo:",
+          "tth": "Y habló יהוה a Moshéh, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 20,
-          "tth": "Este es el korbán³⁷ de Aharón y sus hijos que deberán acercar a __יהוה__ en el día de la unción de ellos: la décima parte de un efáh³⁸ de harina fina, una ofrenda de grano constante, su mitad por la mañana y su mitad por la tarde.",
+          "tth": "Este es el korbán³⁷ de Aharón y sus hijos que deberán acercar a יהוה en el día de la unción de ellos: la décima parte de un efáh³⁸ de harina fina, una ofrenda de grano constante, su mitad por la mañana y su mitad por la tarde.",
           "footnotes": [
             {
               "marker": "³⁷",
@@ -1056,13 +1056,13 @@
         },
         {
           "verse": 21,
-          "tth": "En una sartén con aceite se hará, y <em>cuando</em> esté mezclado la traerás. Y el horneado de la ofrenda de grano de las piezas de pan acercarás, <em>como</em> olor calmante para __יהוה__.",
+          "tth": "En una sartén con aceite se hará, y <em>cuando</em> esté mezclado la traerás. Y el horneado de la ofrenda de grano de las piezas de pan acercarás, <em>como</em> olor calmante para יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 22,
-          "tth": "Y el sacerdote, el ungido en su lugar de entre sus hijos, la hará. Es estatuto olam, para __יהוה__ será completamente quemada.",
+          "tth": "Y el sacerdote, el ungido en su lugar de entre sus hijos, la hará. Es estatuto olam, para יהוה será completamente quemada.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1074,13 +1074,13 @@
         },
         {
           "verse": 24,
-          "tth": "Y habló __יהוה__ a Moshéh, diciendo:",
+          "tth": "Y habló יהוה a Moshéh, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 25,
-          "tth": "Habla a Aharón y a sus hijos, diciendo: “Esta es la Torah de la ofrenda por el pecado³⁹: en el lugar el cual será sacrificada la ofrenda ascendida, será sacrificada la ofrenda por el pecado, delante de __יהוה__; santidad de santidades es esto.",
+          "tth": "Habla a Aharón y a sus hijos, diciendo: “Esta es la Torah de la ofrenda por el pecado³⁹: en el lugar el cual será sacrificada la ofrenda ascendida, será sacrificada la ofrenda por el pecado, delante de יהוה; santidad de santidades es esto.",
           "footnotes": [
             {
               "marker": "³⁹",
@@ -1166,7 +1166,7 @@
         },
         {
           "verse": 5,
-          "tth": "Y los quemará el sacerdote <em>sobre</em> el altar <em>como</em> ofrenda de fuego⁴² para __יהוה__; ofrenda de culpa es.",
+          "tth": "Y los quemará el sacerdote <em>sobre</em> el altar <em>como</em> ofrenda de fuego⁴² para יהוה; ofrenda de culpa es.",
           "footnotes": [
             {
               "marker": "⁴²",
@@ -1216,7 +1216,7 @@
         },
         {
           "verse": 11,
-          "tth": "Y esta es la Torah del sacrificio de las retribuciones que será acercado a __יהוה__.",
+          "tth": "Y esta es la Torah del sacrificio de las retribuciones que será acercado a יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1241,7 +1241,7 @@
         },
         {
           "verse": 14,
-          "tth": "Y acercará de ello un <em>pan</em> de cada korbán⁴⁵ <em>como</em> terumáh⁴⁶ a __יהוה__; para el sacerdote que tire la sangre de las retribuciones⁴⁷, para él será.",
+          "tth": "Y acercará de ello un <em>pan</em> de cada korbán⁴⁵ <em>como</em> terumáh⁴⁶ a יהוה; para el sacerdote que tire la sangre de las retribuciones⁴⁷, para él será.",
           "footnotes": [
             {
               "marker": "⁴⁵",
@@ -1296,13 +1296,13 @@
         },
         {
           "verse": 20,
-          "tth": "Pero la persona que coma la carne del sacrificio de las retribuciones, que es para __יהוה__, y su impureza <em>está</em> en él, será cortada esa persona de su pueblo.",
+          "tth": "Pero la persona que coma la carne del sacrificio de las retribuciones, que es para יהוה, y su impureza <em>está</em> en él, será cortada esa persona de su pueblo.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 21,
-          "tth": "Y la persona que toque en cualquier cosa impura⁴⁸, <em>ya sea</em> en impureza de hombre, o en un animal impuro, o en cualquier abominación impura, y coma de la carne del sacrificio de las retribuciones que es para __יהוה__, será cortada esa persona de su pueblo”.",
+          "tth": "Y la persona que toque en cualquier cosa impura⁴⁸, <em>ya sea</em> en impureza de hombre, o en un animal impuro, o en cualquier abominación impura, y coma de la carne del sacrificio de las retribuciones que es para יהוה, será cortada esa persona de su pueblo”.",
           "footnotes": [
             {
               "marker": "⁴⁸",
@@ -1315,7 +1315,7 @@
         },
         {
           "verse": 22,
-          "tth": "Y habló __יהוה__ a Moshéh, diciendo:",
+          "tth": "Y habló יהוה a Moshéh, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1333,7 +1333,7 @@
         },
         {
           "verse": 25,
-          "tth": "Porque todo el que coma la grasa de un animal del cual se acerca una ofrenda de fuego para __יהוה__, será cortada la persona que coma de su pueblo.",
+          "tth": "Porque todo el que coma la grasa de un animal del cual se acerca una ofrenda de fuego para יהוה, será cortada la persona que coma de su pueblo.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1351,19 +1351,19 @@
         },
         {
           "verse": 28,
-          "tth": "Y habló __יהוה__ a Moshéh, diciendo:",
+          "tth": "Y habló יהוה a Moshéh, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 29,
-          "tth": "Habla a los hijos de Israel, diciendo: “El que acerque un sacrificio de sus retribuciones para __יהוה__, traerá su korbán a __יהוה__ del sacrificio de sus retribuciones.",
+          "tth": "Habla a los hijos de Israel, diciendo: “El que acerque un sacrificio de sus retribuciones para יהוה, traerá su korbán a יהוה del sacrificio de sus retribuciones.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 30,
-          "tth": "Sus manos traerán ofrendas de fuego de __יהוה__. La grasa con el seno traerá; el seno para mecerlo <em>como</em> ofrenda mecida⁴⁹ delante de __יהוה__.",
+          "tth": "Sus manos traerán ofrendas de fuego de יהוה. La grasa con el seno traerá; el seno para mecerlo <em>como</em> ofrenda mecida⁴⁹ delante de יהוה.",
           "footnotes": [
             {
               "marker": "⁴⁹",
@@ -1407,13 +1407,13 @@
         },
         {
           "verse": 35,
-          "tth": "Esta es la unción de Aharón y la unción de sus hijos de las ofrendas de fuego de __יהוה__, en el día que los acercó <em>Moshéh</em> para ser sacerdote para __יהוה__,",
+          "tth": "Esta es la unción de Aharón y la unción de sus hijos de las ofrendas de fuego de יהוה, en el día que los acercó <em>Moshéh</em> para ser sacerdote para יהוה,",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 36,
-          "tth": "la cual había ordenado __יהוה__ para dar a ellos en el día que los ungió de <em>parte de</em> los hijos de Israel, <em>como</em> estatuto olam para sus generaciones.",
+          "tth": "la cual había ordenado יהוה para dar a ellos en el día que los ungió de <em>parte de</em> los hijos de Israel, <em>como</em> estatuto olam para sus generaciones.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1432,7 +1432,7 @@
         },
         {
           "verse": 38,
-          "tth": "que ordenó __יהוה__ a Moshéh en el monte Sinay, en el día que mandó a los hijos de Israel a acercar sus ofrendas a __יהוה__, en el desierto de Sinay.",
+          "tth": "que ordenó יהוה a Moshéh en el monte Sinay, en el día que mandó a los hijos de Israel a acercar sus ofrendas a יהוה, en el desierto de Sinay.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Consagración de Aharón y de sus hijos"
@@ -1444,7 +1444,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y habló __יהוה__ a Moshéh, diciendo:",
+          "tth": "Y habló יהוה a Moshéh, diciendo:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1469,13 +1469,13 @@
         },
         {
           "verse": 4,
-          "tth": "E hizo Moshéh como le ordenó __יהוה__, y fue reunida la congregación a la entrada de la Tienda del Mo’ed.",
+          "tth": "E hizo Moshéh como le ordenó יהוה, y fue reunida la congregación a la entrada de la Tienda del Mo’ed.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 5,
-          "tth": "Y dijo Moshéh a la congregación: Esta es la palabra que ha ordenado __יהוה__ para hacer.",
+          "tth": "Y dijo Moshéh a la congregación: Esta es la palabra que ha ordenado יהוה para hacer.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1622,7 +1622,7 @@
         },
         {
           "verse": 26,
-          "tth": "Y de la cesta de los panes sin levadura⁵⁶ que <em>estaba</em> delante de __יהוה__, tomó una hogaza sin levadura, una hogaza de pan <em>con</em> aceite, y un pan delgado, y <em>las</em> puso sobre las grosuras y sobre la pata derecha.",
+          "tth": "Y de la cesta de los panes sin levadura⁵⁶ que <em>estaba</em> delante de יהוה, tomó una hogaza sin levadura, una hogaza de pan <em>con</em> aceite, y un pan delgado, y <em>las</em> puso sobre las grosuras y sobre la pata derecha.",
           "footnotes": [
             {
               "marker": "⁵⁶",
@@ -1635,7 +1635,7 @@
         },
         {
           "verse": 27,
-          "tth": "Y <em>lo</em> puso todo sobre las palmas de Aharón y sobre las palmas de sus hijos, y las meció <em>como</em> ofrenda mecida⁵⁷ delante de __יהוה__.",
+          "tth": "Y <em>lo</em> puso todo sobre las palmas de Aharón y sobre las palmas de sus hijos, y las meció <em>como</em> ofrenda mecida⁵⁷ delante de יהוה.",
           "footnotes": [
             {
               "marker": "⁵⁷",
@@ -1648,7 +1648,7 @@
         },
         {
           "verse": 28,
-          "tth": "Y las tomó Moshéh desde encima de sus palmas, y <em>lo</em> quemó <em>en</em> el altar sobre la ofrenda ascendida. Eran ofrendas de plenitudes, para olor calmante, una ofrenda de fuego⁵⁸ es, para __יהוה__.",
+          "tth": "Y las tomó Moshéh desde encima de sus palmas, y <em>lo</em> quemó <em>en</em> el altar sobre la ofrenda ascendida. Eran ofrendas de plenitudes, para olor calmante, una ofrenda de fuego⁵⁸ es, para יהוה.",
           "footnotes": [
             {
               "marker": "⁵⁸",
@@ -1661,7 +1661,7 @@
         },
         {
           "verse": 29,
-          "tth": "Y tomó Moshéh el seno y lo meció <em>como</em> ofrenda mecida delante de __יהוה__; del carnero de las plenitudes para Moshéh era, para porción, como había mandado __יהוה__ a Moshéh.",
+          "tth": "Y tomó Moshéh el seno y lo meció <em>como</em> ofrenda mecida delante de יהוה; del carnero de las plenitudes para Moshéh era, para porción, como había mandado יהוה a Moshéh.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1691,13 +1691,13 @@
         },
         {
           "verse": 34,
-          "tth": "Conforme se ha hecho en este día ha ordenado __יהוה__ a hacer, para hacer reconciliación por ustedes.",
+          "tth": "Conforme se ha hecho en este día ha ordenado יהוה a hacer, para hacer reconciliación por ustedes.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 35,
-          "tth": "Y <em>a</em> la entrada de la Tienda del Mo’ed permanecerán, día y noche <em>por</em> siete días, y guarden la guardia de __יהוה__, y no morirán, porque así se me ha ordenado.",
+          "tth": "Y <em>a</em> la entrada de la Tienda del Mo’ed permanecerán, día y noche <em>por</em> siete días, y guarden la guardia de יהוה, y no morirán, porque así se me ha ordenado.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1721,7 +1721,7 @@
         },
         {
           "verse": 2,
-          "tth": "Y dijo a Aharón: Toma para ti un ternero hijo del ganado para ofrenda por el pecado⁵⁹, y un carnero para ofrenda ascendida⁶⁰, completos, y acérca <em>los</em> delante de __יהוה__.",
+          "tth": "Y dijo a Aharón: Toma para ti un ternero hijo del ganado para ofrenda por el pecado⁵⁹, y un carnero para ofrenda ascendida⁶⁰, completos, y acérca <em>los</em> delante de יהוה.",
           "footnotes": [
             {
               "marker": "⁵⁹",
@@ -1746,7 +1746,7 @@
         },
         {
           "verse": 4,
-          "tth": "y un buey y un carnero para retribuciones⁶¹, para sacrificar delante de __יהוה__, y una ofrenda de grano⁶² mezclada con aceite, porque hoy __יהוה__ aparecerá a ustedes”.",
+          "tth": "y un buey y un carnero para retribuciones⁶¹, para sacrificar delante de יהוה, y una ofrenda de grano⁶² mezclada con aceite, porque hoy יהוה aparecerá a ustedes”.",
           "footnotes": [
             {
               "marker": "⁶¹",
@@ -1765,7 +1765,7 @@
         },
         {
           "verse": 5,
-          "tth": "Y tomaron lo que había mandado Moshéh hacia el frente de la Tienda del Mo’ed⁶³, y se acercó toda la congregación y permaneció de pie delante de __יהוה__.",
+          "tth": "Y tomaron lo que había mandado Moshéh hacia el frente de la Tienda del Mo’ed⁶³, y se acercó toda la congregación y permaneció de pie delante de יהוה.",
           "footnotes": [
             {
               "marker": "⁶³",
@@ -1784,7 +1784,7 @@
         },
         {
           "verse": 7,
-          "tth": "Y dijo Moshéh a Aharón: Acércate al altar y haz tu ofrenda por el pecado y tu ofrenda ascendida, y puedas hacer reconciliación a favor de ti y a favor del pueblo; y haz el korbán⁶⁴ del pueblo, y puedas hacer reconciliación a favor de ellos, como ha ordenado __יהוה__.",
+          "tth": "Y dijo Moshéh a Aharón: Acércate al altar y haz tu ofrenda por el pecado y tu ofrenda ascendida, y puedas hacer reconciliación a favor de ti y a favor del pueblo; y haz el korbán⁶⁴ del pueblo, y puedas hacer reconciliación a favor de ellos, como ha ordenado יהוה.",
           "footnotes": [
             {
               "marker": "⁶⁴",
@@ -1809,7 +1809,7 @@
         },
         {
           "verse": 10,
-          "tth": "Y la grasa, y los riñones, y el lóbulo del hígado de la ofrenda por el pecado quemó <em>en</em> el altar, como había ordenado __יהוה__ a Moshéh.",
+          "tth": "Y la grasa, y los riñones, y el lóbulo del hígado de la ofrenda por el pecado quemó <em>en</em> el altar, como había ordenado יהוה a Moshéh.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1882,7 +1882,7 @@
         },
         {
           "verse": 21,
-          "tth": "Pero los senos y el muslo derecho meció Aharón <em>como</em> ofrenda mecida⁶⁶ delante de __יהוה__, como había ordenado Moshéh.",
+          "tth": "Pero los senos y el muslo derecho meció Aharón <em>como</em> ofrenda mecida⁶⁶ delante de יהוה, como había ordenado Moshéh.",
           "footnotes": [
             {
               "marker": "⁶⁶",
@@ -1901,13 +1901,13 @@
         },
         {
           "verse": 23,
-          "tth": "Y entraron Moshéh y Aharón a la Tienda del Mo’ed, y salieron y bendijeron al pueblo, y apareció la gloria de __יהוה__ a todo el pueblo.",
+          "tth": "Y entraron Moshéh y Aharón a la Tienda del Mo’ed, y salieron y bendijeron al pueblo, y apareció la gloria de יהוה a todo el pueblo.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 24,
-          "tth": "Y salió fuego de delante de __יהוה__ y consumió sobre el altar la ofrenda ascendida y las grosuras. Y vio todo el pueblo y cantaron de alegría, y cayeron sobre sus rostros.",
+          "tth": "Y salió fuego de delante de יהוה y consumió sobre el altar la ofrenda ascendida y las grosuras. Y vio todo el pueblo y cantaron de alegría, y cayeron sobre sus rostros.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Nadab y Avihu"
@@ -1919,19 +1919,19 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y tomaron los hijos de Aharón, Nadab y Avihu, cada uno su incensario, y pusieron en ellos fuego, y pusieron sobre ellos incienso, y acercaron delante de __יהוה__ fuego extraño, el cual no les había ordenado.",
+          "tth": "Y tomaron los hijos de Aharón, Nadab y Avihu, cada uno su incensario, y pusieron en ellos fuego, y pusieron sobre ellos incienso, y acercaron delante de יהוה fuego extraño, el cual no les había ordenado.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 2,
-          "tth": "Y salió fuego de delante de __יהוה__ y los consumió, y murieron delante de __יהוה__.",
+          "tth": "Y salió fuego de delante de יהוה y los consumió, y murieron delante de יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 3,
-          "tth": "Y dijo Moshéh a Aharón: Esto es lo que habló __יהוה__, diciendo: “Por los que se acercan a Mí seré santificado, y sobre los rostros de todo el pueblo seré honrado”. Y guardó silencio Aharón.",
+          "tth": "Y dijo Moshéh a Aharón: Esto es lo que habló יהוה, diciendo: “Por los que se acercan a Mí seré santificado, y sobre los rostros de todo el pueblo seré honrado”. Y guardó silencio Aharón.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2125,7 +2125,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y habló __יהוה__ a Moshéh y a Aharón, diciendo a ellos:",
+          "tth": "Y habló יהוה a Moshéh y a Aharón, diciendo a ellos:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2643,7 +2643,7 @@
         },
         {
           "verse": 44,
-          "tth": "Porque Yo soy __יהוה__, su Elohim. Conságrense y sean kedoshim¹¹⁹, porque Kadosh¹²⁰ soy Yo. Y no impurifiquen sus vidas con cualquier animal pequeño¹²¹ que se arrastra sobre la tierra.",
+          "tth": "Porque Yo soy יהוה, su Elohim. Conságrense y sean kedoshim¹¹⁹, porque Kadosh¹²⁰ soy Yo. Y no impurifiquen sus vidas con cualquier animal pequeño¹²¹ que se arrastra sobre la tierra.",
           "footnotes": [
             {
               "marker": "¹¹⁹",
@@ -2668,7 +2668,7 @@
         },
         {
           "verse": 45,
-          "tth": "Porque Yo soy __יהוה__, quien los ha hecho subir de la tierra de Mitzráim para ser para ustedes por Elohim, y serán kedoshim, porque Kadosh soy Yo”.",
+          "tth": "Porque Yo soy יהוה, quien los ha hecho subir de la tierra de Mitzráim para ser para ustedes por Elohim, y serán kedoshim, porque Kadosh soy Yo”.",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/zejariah.json
+++ b/data/tth_2/json/zejariah.json
@@ -938,31 +938,31 @@
         },
         {
           "verse": 19,
-          "tth": "Así ha dicho __יהוה__ Tzebaot: “El ayuno del cuarto <em>mes</em>, el ayuno del quinto, el ayuno del séptimo y el ayuno del décimo serán para la casa de Iehudáh por gozo y por alegría y por tiempos señalados buenos. Y la verdad y el shalom amen”.",
+          "tth": "Así ha dicho יהוה Tzebaot: “El ayuno del cuarto <em>mes</em>, el ayuno del quinto, el ayuno del séptimo y el ayuno del décimo serán para la casa de Iehudáh por gozo y por alegría y por tiempos señalados buenos. Y la verdad y el shalom amen”.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 20,
-          "tth": "Así ha dicho __יהוה__ Tzebaot: “Aún <em>será</em> que vendrán pueblos y habitantes de muchas ciudades;",
+          "tth": "Así ha dicho יהוה Tzebaot: “Aún <em>será</em> que vendrán pueblos y habitantes de muchas ciudades;",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 21,
-          "tth": "E irán los habitantes de una a otra, diciendo: ‘Andando, andaremos para rogar al rostro de __יהוה__ y para buscar a __יהוה__ Tzebaot. Iré yo también’.",
+          "tth": "E irán los habitantes de una a otra, diciendo: ‘Andando, andaremos para rogar al rostro de יהוה y para buscar a יהוה Tzebaot. Iré yo también’.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 22,
-          "tth": "Y vendrán muchos pueblos y naciones poderosas para buscar a __יהוה__ Tzebaot en Yerushaláim y para rogar al rostro de __יהוה__”.",
+          "tth": "Y vendrán muchos pueblos y naciones poderosas para buscar a יהוה Tzebaot en Yerushaláim y para rogar al rostro de יהוה”.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 23,
-          "tth": "Así ha dicho __יהוה__ Tzebaot: “En aquellos días <em>será</em> que tomarán fuerte diez hombres de toda lengua de las naciones, y tomarán fuerte el borde²⁸ <em>del vestido</em> de un hombre iehudí²⁹, diciendo: ‘Iremos con ustedes, porque escuchamos <em>que</em> Elohim <em>está</em> con ustedes’ ”.",
+          "tth": "Así ha dicho יהוה Tzebaot: “En aquellos días <em>será</em> que tomarán fuerte diez hombres de toda lengua de las naciones, y tomarán fuerte el borde²⁸ <em>del vestido</em> de un hombre iehudí²⁹, diciendo: ‘Iremos con ustedes, porque escuchamos <em>que</em> Elohim <em>está</em> con ustedes’ ”.",
           "footnotes": [
             {
               "marker": "²⁸",
@@ -986,7 +986,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Carga de la palabra de __יהוה__ en la tierra de Jadraj y Damések, su lugar de descanso",
+          "tth": "Carga de la palabra de יהוה en la tierra de Jadraj y Damések, su lugar de descanso",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1110,19 +1110,19 @@
         },
         {
           "verse": 14,
-          "tth": "Y __יהוה__ sobre ellos será visto, y saldrá como el relámpago su flecha; y Adonai __יהוה__ con el shofar soplará, e irá por las tempestades del sur.",
+          "tth": "Y יהוה sobre ellos será visto, y saldrá como el relámpago su flecha; y Adonai יהוה con el shofar soplará, e irá por las tempestades del sur.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 15,
-          "tth": "__יהוה__ Tzebaot protegerá sobre ellos, y consumirán y pisotearán las piedras de honda,",
+          "tth": "יהוה Tzebaot protegerá sobre ellos, y consumirán y pisotearán las piedras de honda,",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 16,
-          "tth": "Y los salvará __יהוה__ su Elohim en aquel día como rebaño de su pueblo; porque <em>como</em> piedras de una corona se levantan³⁷ sobre su tierra.",
+          "tth": "Y los salvará יהוה su Elohim en aquel día como rebaño de su pueblo; porque <em>como</em> piedras de una corona se levantan³⁷ sobre su tierra.",
           "footnotes": [
             {
               "marker": "³⁷",
@@ -1147,7 +1147,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Pidan de __יהוה__ lluvia en el tiempo de lluvia tardía,__יהוה__ hace los relámpagos³⁹; y lluvia de aguacero <em>les</em> dará a ellos, a <em>cada</em> hombre, hierba en el campo.",
+          "tth": "Pidan de יהוה lluvia en el tiempo de lluvia tardía,יהוה hace los relámpagos³⁹; y lluvia de aguacero <em>les</em> dará a ellos, a <em>cada</em> hombre, hierba en el campo.",
           "footnotes": [
             {
               "marker": "³⁹",
@@ -1179,7 +1179,7 @@
         },
         {
           "verse": 3,
-          "tth": "Sobre los pastores se calentó mi nariz, y sobre los machos cabríos visitaré; porque ha visitado __יהוה__ Tzebaot a su rebaño, a la casa de Iehudáh, y los puso como caballo de su esplendor en la batalla.",
+          "tth": "Sobre los pastores se calentó mi nariz, y sobre los machos cabríos visitaré; porque ha visitado יהוה Tzebaot a su rebaño, a la casa de Iehudáh, y los puso como caballo de su esplendor en la batalla.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1197,13 +1197,13 @@
         },
         {
           "verse": 6,
-          "tth": "Y fortaleceré a la casa de Iehudáh, y a la casa de Iosef salvaré, y los haré volver porque los he amado, y serán como no rechazados, porque Yo <em>soy</em> __יהוה__ su Elohim, y les responderé.",
+          "tth": "Y fortaleceré a la casa de Iehudáh, y a la casa de Iosef salvaré, y los haré volver porque los he amado, y serán como no rechazados, porque Yo <em>soy</em> יהוה su Elohim, y les responderé.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 7,
-          "tth": "Y serán como poderoso <em>los de</em> Efráim, y se alegrará su corazón como el vino; y sus hijos lo verán y se alegrarán, ¡se regocijará su corazón en __יהוה__!",
+          "tth": "Y serán como poderoso <em>los de</em> Efráim, y se alegrará su corazón como el vino; y sus hijos lo verán y se alegrarán, ¡se regocijará su corazón en יהוה!",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1233,7 +1233,7 @@
         },
         {
           "verse": 12,
-          "tth": "Y los fortaleceré en __יהוה__, y en su Nombre andarán –declaración de __יהוה__.",
+          "tth": "Y los fortaleceré en יהוה, y en su Nombre andarán –declaración de יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -1263,19 +1263,19 @@
         },
         {
           "verse": 4,
-          "tth": "Así ha dicho __יהוה__ mi Elohim: ¡Apacienta al rebaño de la matanza!",
+          "tth": "Así ha dicho יהוה mi Elohim: ¡Apacienta al rebaño de la matanza!",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 5,
-          "tth": "Los que las compran las matan y no son culpables, y el que las vende dice: ¡Bendito __יהוה__, me he enriquecido! Y sus pastores no tienen compasión por ellas.",
+          "tth": "Los que las compran las matan y no son culpables, y el que las vende dice: ¡Bendito יהוה, me he enriquecido! Y sus pastores no tienen compasión por ellas.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 6,
-          "tth": "Pues no me compadeceré más por los habitantes de la tierra –declaración de __יהוה__–, y he aquí, Yo haré que se encuentre el hombre <em>cada</em> uno en mano de su compañero y en mano de su rey; y machacarán la tierra, y no <em>los</em> rescataré de su mano.",
+          "tth": "Pues no me compadeceré más por los habitantes de la tierra –declaración de יהוה–, y he aquí, Yo haré que se encuentre el hombre <em>cada</em> uno en mano de su compañero y en mano de su rey; y machacarán la tierra, y no <em>los</em> rescataré de su mano.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1350,7 +1350,7 @@
         },
         {
           "verse": 11,
-          "tth": "Y fue roto en aquel día; y supieron así los pobres del rebaño⁵⁰ que me observaban que palabra de __יהוה__ <em>era</em> ella.",
+          "tth": "Y fue roto en aquel día; y supieron así los pobres del rebaño⁵⁰ que me observaban que palabra de יהוה <em>era</em> ella.",
           "footnotes": [
             {
               "marker": "⁵⁰",
@@ -1369,7 +1369,7 @@
         },
         {
           "verse": 13,
-          "tth": "Y me dijo __יהוה__: Échalo al alfarero⁵¹ –magnífico el precio <em>con</em> que fui apreciado por ellos. Y tomé las treinta <em>piezas de</em> plata, y lo eché <em>en</em> la casa de __יהוה__ al alfarero.",
+          "tth": "Y me dijo יהוה: Échalo al alfarero⁵¹ –magnífico el precio <em>con</em> que fui apreciado por ellos. Y tomé las treinta <em>piezas de</em> plata, y lo eché <em>en</em> la casa de יהוה al alfarero.",
           "footnotes": [
             {
               "marker": "⁵¹",
@@ -1388,7 +1388,7 @@
         },
         {
           "verse": 15,
-          "tth": "Y me dijo __יהוה__: Aún toma para ti instrumentos de un pastor tonto.",
+          "tth": "Y me dijo יהוה: Aún toma para ti instrumentos de un pastor tonto.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1411,7 +1411,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Carga, palabra de __יהוה__ sobre Israel.Declaración de __יהוה__, que extiende los cielos y funda la tierra, y forma el ánimo del hombre en medio de él:",
+          "tth": "Carga, palabra de יהוה sobre Israel.Declaración de יהוה, que extiende los cielos y funda la tierra, y forma el ánimo del hombre en medio de él:",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1429,13 +1429,13 @@
         },
         {
           "verse": 4,
-          "tth": "En aquel día –declaración de __יהוה__– golpearé todo caballo con desconcierto y su jinete con locura. Y sobre la casa de Iehudáh abriré mis ojos, y todo caballo de los pueblos golpearé con ceguera.",
+          "tth": "En aquel día –declaración de יהוה– golpearé todo caballo con desconcierto y su jinete con locura. Y sobre la casa de Iehudáh abriré mis ojos, y todo caballo de los pueblos golpearé con ceguera.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 5,
-          "tth": "Y dirán los jefes de Iehudáh en su corazón: “Fortaleza para mí <em>son</em> los habitantes de Yerushaláim por __יהוה__ Tzebaot su Elohim”.",
+          "tth": "Y dirán los jefes de Iehudáh en su corazón: “Fortaleza para mí <em>son</em> los habitantes de Yerushaláim por יהוה Tzebaot su Elohim”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1447,13 +1447,13 @@
         },
         {
           "verse": 7,
-          "tth": "Y salvará __יהוה__ a las tiendas de Iehudáh primero, a fin de que no se engrandezca el esplendor de la casa de David y el esplendor de los habitantes de Yerushaláim sobre Iehudáh.",
+          "tth": "Y salvará יהוה a las tiendas de Iehudáh primero, a fin de que no se engrandezca el esplendor de la casa de David y el esplendor de los habitantes de Yerushaláim sobre Iehudáh.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 8,
-          "tth": "En aquel día protegerá __יהוה__ por el bien de los habitantes de Yerushaláim, y será el que tropieza entre ellos en aquel día como David, y la casa de David como Elohim⁵², como el ángel de __יהוה__ delante de ellos.",
+          "tth": "En aquel día protegerá יהוה por el bien de los habitantes de Yerushaláim, y será el que tropieza entre ellos en aquel día como David, y la casa de David como Elohim⁵², como el ángel de יהוה delante de ellos.",
           "footnotes": [
             {
               "marker": "⁵²",
@@ -1536,7 +1536,7 @@
         },
         {
           "verse": 2,
-          "tth": "Y será en aquel día –declaración de __יהוה__ Tzebaot– cortaré los nombres de las imágenes de la tierra, y no serán recordados más; y también a los profetas y al ánimo de impureza⁵⁶ haré pasar de la tierra.",
+          "tth": "Y será en aquel día –declaración de יהוה Tzebaot– cortaré los nombres de las imágenes de la tierra, y no serán recordados más; y también a los profetas y al ánimo de impureza⁵⁶ haré pasar de la tierra.",
           "footnotes": [
             {
               "marker": "⁵⁶",
@@ -1549,7 +1549,7 @@
         },
         {
           "verse": 3,
-          "tth": "Y será <em>que</em> cuando profetice un hombre todavía, le dirán su padre y su madre, sus engendrantes: ¡No vivirás, porque mentira has hablado en Nombre de __יהוה__! Y lo traspasarán su padre y su madre, sus engendrantes, en su profetizar.",
+          "tth": "Y será <em>que</em> cuando profetice un hombre todavía, le dirán su padre y su madre, sus engendrantes: ¡No vivirás, porque mentira has hablado en Nombre de יהוה! Y lo traspasarán su padre y su madre, sus engendrantes, en su profetizar.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1573,13 +1573,13 @@
         },
         {
           "verse": 7,
-          "tth": "¡Espada, despierta contra mi pastor, y contra el varón amigo mío! –declaración de __יהוה__ Tzebaot. ¡Hiere al pastor!, y se dispersarán las ovejas, y haré volver mi mano sobre los pequeños.",
+          "tth": "¡Espada, despierta contra mi pastor, y contra el varón amigo mío! –declaración de יהוה Tzebaot. ¡Hiere al pastor!, y se dispersarán las ovejas, y haré volver mi mano sobre los pequeños.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 8,
-          "tth": "Y será en toda la tierra –declaración de __יהוה__–<em>que</em> dos partes⁵⁷ en ella serán cortadas, expirarán; pero la tercera será dejada en ella.",
+          "tth": "Y será en toda la tierra –declaración de יהוה–<em>que</em> dos partes⁵⁷ en ella serán cortadas, expirarán; pero la tercera será dejada en ella.",
           "footnotes": [
             {
               "marker": "⁵⁷",
@@ -1592,7 +1592,7 @@
         },
         {
           "verse": 9,
-          "tth": "Y haré entrar a la tercera en el fuego, y los refinaré conforme al refinar de la plata, y los probaré conforme al probar del oro.Él llamará en mi Nombre, y Yo le responderé; diré: “Mi pueblo es él”, y él dirá: “__יהוה__ es mi Elohim”. <em>El reino de</em>__יהוה__",
+          "tth": "Y haré entrar a la tercera en el fuego, y los refinaré conforme al refinar de la plata, y los probaré conforme al probar del oro.Él llamará en mi Nombre, y Yo le responderé; diré: “Mi pueblo es él”, y él dirá: “יהוה es mi Elohim”. <em>El reino de</em> יהוה",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -1603,7 +1603,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "He aquí, el día de __יהוה__ viene, y será repartido tu botín en medio de ti.",
+          "tth": "He aquí, el día de יהוה viene, y será repartido tu botín en medio de ti.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1615,7 +1615,7 @@
         },
         {
           "verse": 3,
-          "tth": "Y saldrá __יהוה__ y luchará contra aquellas naciones, como el día de su pelea, en el día de batalla.",
+          "tth": "Y saldrá יהוה y luchará contra aquellas naciones, como el día de su pelea, en el día de batalla.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1640,7 +1640,7 @@
         },
         {
           "verse": 5,
-          "tth": "Y ustedes huirán al valle de mis montes, porque alcanzará el valle de los montes hasta Atzal; y huirán como huyeron a causa del temblor en los días de Uziyah, rey de Iehudáh. Y vendrá __יהוה__ mi Elohim y todos los kedoshim⁶⁰ con Él⁶¹.",
+          "tth": "Y ustedes huirán al valle de mis montes, porque alcanzará el valle de los montes hasta Atzal; y huirán como huyeron a causa del temblor en los días de Uziyah, rey de Iehudáh. Y vendrá יהוה mi Elohim y todos los kedoshim⁶⁰ con Él⁶¹.",
           "footnotes": [
             {
               "marker": "⁶⁰",
@@ -1672,7 +1672,7 @@
         },
         {
           "verse": 7,
-          "tth": "Y será día único, él será conocido de __יהוה__, ni día ni noche; y será por el tiempo de la tarde <em>que</em> habrá luz.",
+          "tth": "Y será día único, él será conocido de יהוה, ni día ni noche; y será por el tiempo de la tarde <em>que</em> habrá luz.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1684,7 +1684,7 @@
         },
         {
           "verse": 9,
-          "tth": "Y será __יהוה__ por Rey sobre toda la tierra; en aquel día será __יהוה__ uno, y su Nombre uno.",
+          "tth": "Y será יהוה por Rey sobre toda la tierra; en aquel día será יהוה uno, y su Nombre uno.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1702,13 +1702,13 @@
         },
         {
           "verse": 12,
-          "tth": "Y esta será la plaga <em>con</em> que golpeará __יהוה__ a todos los pueblos que se han reunido en guerra contra Yerushaláim: se pudrirá su carne y él estará parado sobre sus pies, y sus ojos se pudrirán en sus cuencas, y su lengua se pudrirá en la boca de ellos.",
+          "tth": "Y esta será la plaga <em>con</em> que golpeará יהוה a todos los pueblos que se han reunido en guerra contra Yerushaláim: se pudrirá su carne y él estará parado sobre sus pies, y sus ojos se pudrirán en sus cuencas, y su lengua se pudrirá en la boca de ellos.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 13,
-          "tth": "Y será en aquel día <em>que</em> habrá gran desconcierto de __יהוה__, y agarrarán <em>cada</em> hombre la mano de su compañero y subirá su mano sobre la mano de su compañero.",
+          "tth": "Y será en aquel día <em>que</em> habrá gran desconcierto de יהוה, y agarrarán <em>cada</em> hombre la mano de su compañero y subirá su mano sobre la mano de su compañero.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1733,19 +1733,19 @@
         },
         {
           "verse": 16,
-          "tth": "Y será <em>que</em> todo el que quede de todas las naciones que vinieron contra Yerushaláim subirán de año en año para postrarse al Rey, __יהוה__ Tzebaot, y para celebrar la fiesta de Sucot.",
+          "tth": "Y será <em>que</em> todo el que quede de todas las naciones que vinieron contra Yerushaláim subirán de año en año para postrarse al Rey, יהוה Tzebaot, y para celebrar la fiesta de Sucot.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 17,
-          "tth": "Y será <em>que</em> el que no suba de las familias de la tierra a Yerushaláim para postrarse al Rey, __יהוה__ Tzebaot, no habrá sobre ellos lluvia.",
+          "tth": "Y será <em>que</em> el que no suba de las familias de la tierra a Yerushaláim para postrarse al Rey, יהוה Tzebaot, no habrá sobre ellos lluvia.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 18,
-          "tth": "Y si la familia de Mitzráim no sube ni viene, no <em>habrá</em> sobre ellos <em>lluvia</em>; será la plaga <em>con</em> que golpeará __יהוה__ a las naciones que no suban a celebrar la fiesta de Sucot.",
+          "tth": "Y si la familia de Mitzráim no sube ni viene, no <em>habrá</em> sobre ellos <em>lluvia</em>; será la plaga <em>con</em> que golpeará יהוה a las naciones que no suban a celebrar la fiesta de Sucot.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1757,13 +1757,13 @@
         },
         {
           "verse": 20,
-          "tth": "En aquel día estará sobre las campanillas de los caballos: Santidad a __יהוה__. Y serán las ollas en la casa de __יהוה__ como los tazones delante del altar.",
+          "tth": "En aquel día estará sobre las campanillas de los caballos: Santidad a יהוה. Y serán las ollas en la casa de יהוה como los tazones delante del altar.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 21,
-          "tth": "Y será toda olla en Yerushaláim y en Iehudáh santidad a __יהוה__ Tzebaot; y vendrán todos los que sacrifiquen y tomarán de ellas y cocerán en ellas; y no habrá más mercader⁶⁴ en la casa de __יהוה__ Tzebaot en aquel día.",
+          "tth": "Y será toda olla en Yerushaláim y en Iehudáh santidad a יהוה Tzebaot; y vendrán todos los que sacrifiquen y tomarán de ellas y cocerán en ellas; y no habrá más mercader⁶⁴ en la casa de יהוה Tzebaot en aquel día.",
           "footnotes": [
             {
               "marker": "⁶⁴",

--- a/data/tth_2/markdown/bereshit.md
+++ b/data/tth_2/markdown/bereshit.md
@@ -868,8 +868,7 @@ y como la arena que es sobre la orilla del mar,
 **9** Y lo enterraron Itzjak e Ishmael sus hijos en la cueva de Majpelah, en el campo de Efrón, hijo de Tzojar el jití, el cual es sobre la faz de Mamré,
 **10** el campo que compró Abraham de los hijos de Jet, allí fue enterrado Abraham, y Sarah su mujer.
 **11** Y sucedió *que* después de la muerte de Abra­ham, bendijo Elohim a Itzjak su hijo, y habi­taba Itzjak junto a Beer Lajay Roi.
-**12** Y
-**1** estas son las generaciones de Ishmael, hijo de Abraham, quien dio a luz Hagar la mitzrit, sierva de Sarah, a Abraham.
+**12** Y estas son las generaciones de Ishmael, hijo de Abraham, quien dio a luz Hagar la mitzrit, sierva de Sarah, a Abraham.
 **13** Y estos *son* los nombres de los hijos de Ishmael, por sus nombres por sus genera­cio­nes: El primogénito de Ishmael, Nevaiot, y Kedar, Adbeel, Mivsán,
 **14** Mishma, Dumah, Masá,
 **15** Jadar, Teimá, Ietur, Nafish, y Kedemah.

--- a/scripts/tth_2/docx_to_md.py
+++ b/scripts/tth_2/docx_to_md.py
@@ -70,8 +70,10 @@ class TTH2DocxConverter:
             content = match.group(2).strip()
 
             # Remove back references [↑](#footnote-ref-1)
-            content = re.sub(r'\s*\[↑\]\s*\(#footnote-ref-\d+\)\s*$', '', content)
-            content = re.sub(r'\s*\[.*?\]\s*\(#footnote-ref-\d+\)\s*\d*\.?\s*$', '', content)
+            content = re.sub(
+                r'\s*\[↑\]\s*\(#footnote-ref-\d+\)\s*$', '', content)
+            content = re.sub(
+                r'\s*\[.*?\]\s*\(#footnote-ref-\d+\)\s*\d*\.?\s*$', '', content)
 
             # Clean up any remaining HTML
             content = re.sub(r'<[^>]+>', '', content)
@@ -92,7 +94,8 @@ class TTH2DocxConverter:
         for line in lines:
             if re.match(r'\[\^\d+\]:', line):
                 # Remove any remaining back references at end of footnote lines
-                line = re.sub(r'\s*\[.*?\]\(#footnote-ref-\d+\)\s*\d*\.?\s*$', '', line)
+                line = re.sub(
+                    r'\s*\[.*?\]\(#footnote-ref-\d+\)\s*\d*\.?\s*$', '', line)
             cleaned_lines.append(line)
 
         return '\n'.join(cleaned_lines)
@@ -104,8 +107,10 @@ class TTH2DocxConverter:
         # Convert __número__ to **número** (standard verse format)
         text = re.sub(r'__\s*(\d+)\s*__', r'**\1**', text)
 
-        # Convert __ __ (empty verse marker) to **1** (first verse)
-        text = re.sub(r'__\s*__', r'**1**', text)
+        # Convert line-leading empty verse markers to **1** only when they
+        # appear as standalone markers at the start of a line.
+        # This avoids corrupting mid-verse artifacts like "Y__ __...".
+        text = re.sub(r'(?m)^__\s*__\s*', r'**1** ', text)
 
         # Convert any remaining __número__ format
         text = re.sub(r'__(\d+)__', r'**\1**', text)
@@ -144,7 +149,8 @@ class TTH2DocxConverter:
             line = re.sub(r'\\([.;:,!?])', r'\1', line)
 
             # Fix spacing around verse markers
-            line = re.sub(r'\*\*(\d+)\*\*([A-Za-zÁÉÍÓÚáéíóúñÑ\u0590-\u05FF])', r'**\1** \2', line)
+            line = re.sub(
+                r'\*\*(\d+)\*\*([A-Za-zÁÉÍÓÚáéíóúñÑ\u0590-\u05FF])', r'**\1** \2', line)
 
             cleaned_lines.append(line)
 
@@ -247,7 +253,8 @@ class TTH2DocxConverter:
             Tuple of (output_file_path, warning_messages)
         """
         if not MAMMOTH_AVAILABLE:
-            raise RuntimeError("Mammoth library is not available. Install it with: pip install mammoth")
+            raise RuntimeError(
+                "Mammoth library is not available. Install it with: pip install mammoth")
 
         # Validate input file
         if not os.path.exists(input_file):

--- a/scripts/tth_2/format_validator.py
+++ b/scripts/tth_2/format_validator.py
@@ -10,6 +10,7 @@ Checks:
 2. Disallowed escaped punctuation/brackets (\\!, \\., \\[, \\])
 3. Unbalanced <em> tags
 4. Basic footnote marker consistency in verse text
+5. Non-increasing verse numbering inside each chapter
 """
 
 import json
@@ -17,11 +18,13 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
-DEFAULT_JSON_DIR = Path(__file__).parent.parent.parent / "data" / "tth_2" / "json"
+DEFAULT_JSON_DIR = Path(__file__).parent.parent.parent / \
+    "data" / "tth_2" / "json"
 
 DISALLOWED_ESCAPES_RE = re.compile(r'\\([!\.\[\]])')
 MARKDOWN_ITALICS_RE = re.compile(r'\*[^*]+\*')
 EM_NESTING_RE = re.compile(r'<em>\s*<em>|</em>\s*</em>')
+DIVINE_NAME_WRAPPED_RE = re.compile(r'__[^_\n]*יהוה[^_\n]*__')
 
 
 class TTHFormatValidator:
@@ -39,7 +42,8 @@ class TTHFormatValidator:
             issues.append(f"{label}: contains markdown italics markers")
 
         if DISALLOWED_ESCAPES_RE.search(text):
-            issues.append(f"{label}: contains disallowed escaped punctuation/brackets")
+            issues.append(
+                f"{label}: contains disallowed escaped punctuation/brackets")
 
         if text.count('<em>') != text.count('</em>'):
             issues.append(f"{label}: unbalanced <em> tags")
@@ -49,6 +53,10 @@ class TTHFormatValidator:
 
         if '## Footnotes' in text:
             issues.append(f"{label}: embedded footnotes section leakage")
+
+        if DIVINE_NAME_WRAPPED_RE.search(text):
+            issues.append(
+                f"{label}: contains wrapped divine-name token (__יהוה__)")
 
         return issues
 
@@ -67,16 +75,28 @@ class TTHFormatValidator:
             'nested_em_tags': 0,
             'embedded_footnotes_sections': 0,
             'footnote_marker_mismatches': 0,
+            'verse_sequence_issues': 0,
+            'wrapped_divine_name_tokens': 0,
         }
 
         for chapter in data.get('chapters', []):
             chapter_num = chapter.get('chapter', 0)
+            previous_verse_num = None
             for verse in chapter.get('verses', []):
                 verse_num = verse.get('verse', 0)
                 stats['verses_checked'] += 1
 
+                if isinstance(verse_num, int):
+                    if previous_verse_num is not None and verse_num <= previous_verse_num:
+                        stats['verse_sequence_issues'] += 1
+                        issues.append(
+                            f"Ch {chapter_num}:{verse_num} verse sequence regression after {previous_verse_num}"
+                        )
+                    previous_verse_num = verse_num
+
                 tth_text = verse.get('tth', '')
-                verse_issues = self._validate_text(tth_text, f"Ch {chapter_num}:{verse_num} verse text")
+                verse_issues = self._validate_text(
+                    tth_text, f"Ch {chapter_num}:{verse_num} verse text")
                 for issue in verse_issues:
                     issues.append(issue)
 
@@ -90,6 +110,8 @@ class TTHFormatValidator:
                     stats['nested_em_tags'] += 1
                 if '## Footnotes' in tth_text:
                     stats['embedded_footnotes_sections'] += 1
+                if DIVINE_NAME_WRAPPED_RE.search(tth_text):
+                    stats['wrapped_divine_name_tokens'] += 1
 
                 for footnote in verse.get('footnotes', []):
                     stats['footnotes_checked'] += 1
@@ -111,6 +133,8 @@ class TTHFormatValidator:
                         stats['nested_em_tags'] += 1
                     if '## Footnotes' in explanation:
                         stats['embedded_footnotes_sections'] += 1
+                    if DIVINE_NAME_WRAPPED_RE.search(explanation):
+                        stats['wrapped_divine_name_tokens'] += 1
 
                     marker = footnote.get('marker', '')
                     if marker and marker not in tth_text:
@@ -151,8 +175,13 @@ def print_book_report(book_key: str, is_valid: bool, issues: List[str], stats: D
     print(f"   - escaped special chars:    {stats['escaped_special_chars']}")
     print(f"   - unbalanced <em> tags:     {stats['unbalanced_em_tags']}")
     print(f"   - nested <em> tags:         {stats['nested_em_tags']}")
-    print(f"   - embedded footnotes text:  {stats['embedded_footnotes_sections']}")
-    print(f"   - marker mismatches:        {stats['footnote_marker_mismatches']}")
+    print(
+        f"   - embedded footnotes text:  {stats['embedded_footnotes_sections']}")
+    print(
+        f"   - marker mismatches:        {stats['footnote_marker_mismatches']}")
+    print(f"   - verse sequence issues:    {stats['verse_sequence_issues']}")
+    print(
+        f"   - wrapped divine names:     {stats['wrapped_divine_name_tokens']}")
 
     for issue in issues[:8]:
         print(f"   - {issue}")

--- a/scripts/tth_2/json_postprocess.py
+++ b/scripts/tth_2/json_postprocess.py
@@ -61,6 +61,11 @@ class TTHJsonPostProcessor:
         'יהוה',
     }
 
+    TEHILIM_BOOK_DIVISION_RE = re.compile(
+        r'__\s*(LIBRO\s+(?:PRIMERO|SEGUNDO|TERCERO|CUARTO|QUINTO))\s*__',
+        flags=re.IGNORECASE,
+    )
+
     def __init__(self, verbose: bool = False):
         self.verbose = verbose
         self.stats = {
@@ -79,9 +84,32 @@ class TTHJsonPostProcessor:
             'subtitle_segments_skipped_phrase': 0,
             'subtitle_invalid_removed': 0,
             'divine_name_normalized': 0,
+            'divine_name_markdown_wrappers_removed': 0,
+            'book_divisions_extracted': 0,
             'verses_processed': 0,
             'files_processed': 0,
         }
+
+    def extract_tehilim_book_division_marker(self, text: str) -> Tuple[str, str]:
+        """
+        Extract Tehilim book division labels from verse text.
+
+        Returns:
+            (cleaned_text, book_division_label)
+        """
+        if not text:
+            return text, ''
+
+        match = self.TEHILIM_BOOK_DIVISION_RE.search(text)
+        if not match:
+            return text, ''
+
+        book_division = match.group(1).upper().strip()
+        cleaned = (text[:match.start()] + text[match.end():]).strip()
+        cleaned = re.sub(r'\s{2,}', ' ', cleaned)
+        cleaned = re.sub(r'\s+([,.;:!?])', r'\1', cleaned)
+        self.stats['book_divisions_extracted'] += 1
+        return cleaned, book_division
 
     def normalize_divine_name_forms(self, text: str) -> str:
         """Normalize Latin divine-name spellings to the Hebrew form יהוה."""
@@ -95,6 +123,33 @@ class TTHJsonPostProcessor:
         if matches:
             self.stats['divine_name_normalized'] += len(matches)
         return pattern.sub('יהוה', text)
+
+    def remove_markdown_wrappers_from_divine_name(self, text: str) -> str:
+        """
+        Remove markdown-style double-underscore wrappers from standalone
+        divine-name tokens, while preserving inner punctuation/content.
+
+        Examples:
+        - __יהוה__ -> יהוה
+        - __יהוה__, -> יהוה,
+        - __"יהוה"__ -> "יהוה"
+        """
+        if not text or '__' not in text:
+            return text
+
+        def unwrap_if_divine_name(match):
+            inner = match.group(1)
+            token = inner.strip()
+            token = re.sub(r'^[,.;:!?"\'“”‘’()\[\]{}]+', '', token)
+            token = re.sub(r'[,.;:!?"\'“”‘’()\[\]{}]+$', '', token)
+            token = re.sub(r'^[0-9⁰¹²³⁴⁵⁶⁷⁸⁹]+\s*', '', token)
+            normalized = _strip_hebrew_diacritics(token)
+            if normalized in self.DIVINE_NAME_BASE_FORMS:
+                self.stats['divine_name_markdown_wrappers_removed'] += 1
+                return inner.strip()
+            return match.group(0)
+
+        return re.sub(r'__([^_\n]+?)__', unwrap_if_divine_name, text)
 
     def starts_with_lowercase_latin(self, content: str) -> bool:
         """Return True when the first Latin letter in content is lowercase."""
@@ -574,38 +629,41 @@ class TTHJsonPostProcessor:
         # Step 6: Normalize leftover markdown bold wrappers
         result = self.normalize_double_asterisk_markup(result)
 
-        # Step 7: Convert single-word italics FIRST (*word* → <em>word</em>)
+        # Step 7: Remove markdown wrappers from divine name tokens
+        result = self.remove_markdown_wrappers_from_divine_name(result)
+
+        # Step 8: Convert single-word italics FIRST (*word* → <em>word</em>)
         # This handles cases like escribírte*las* correctly
         result = self.convert_single_word_italics(result)
 
-        # Step 8: Fix orphan asterisks (word* *next patterns)
+        # Step 9: Fix orphan asterisks (word* *next patterns)
         result = self.fix_orphan_asterisks(result)
 
-        # Step 9: Strip stray asterisks around existing <em> tags
+        # Step 10: Strip stray asterisks around existing <em> tags
         result = self.strip_asterisks_around_em(result)
 
-        # Step 10: Normalize any remaining broken italic patterns
+        # Step 11: Normalize any remaining broken italic patterns
         result = self.normalize_broken_italics(result)
 
-        # Step 11: Convert any remaining *...* to <em>...</em>
+        # Step 12: Convert any remaining *...* to <em>...</em>
         result = self.convert_italics_to_em(result)
 
-        # Step 12: Remove orphan markdown stars left after conversion
+        # Step 13: Remove orphan markdown stars left after conversion
         result = self.remove_orphan_asterisks(result)
 
-        # Step 13: Fix spacing around <em> tags
+        # Step 14: Fix spacing around <em> tags
         result = self.fix_em_spacing(result)
 
-        # Step 14: Flatten accidental nested <em> tags
+        # Step 15: Flatten accidental nested <em> tags
         result = self.flatten_nested_em_tags(result)
 
-        # Step 15: Keep divine name unitalicized even if source markers wrapped it
+        # Step 16: Keep divine name unitalicized even if source markers wrapped it
         result = self.remove_em_from_divine_name(result)
 
-        # Step 16: Normalize Latin divine-name forms to Hebrew
+        # Step 17: Normalize Latin divine-name forms to Hebrew
         result = self.normalize_divine_name_forms(result)
 
-        # Step 17: Clean up any remaining issues
+        # Step 18: Clean up any remaining issues
         result = re.sub(r'  +', ' ', result)  # Double spaces
         result = result.strip()
 
@@ -679,10 +737,28 @@ class TTHJsonPostProcessor:
 
             # Process all verses in all chapters
             if 'chapters' in data:
-                for chapter in data['chapters']:
+                is_tehilim = file_path.stem == 'tehilim'
+                pending_book_division = ''
+
+                for chapter_index, chapter in enumerate(data['chapters']):
+                    if is_tehilim:
+                        if chapter_index == 0 and not chapter.get('book_division'):
+                            chapter['book_division'] = 'LIBRO PRIMERO'
+                        if pending_book_division:
+                            chapter['book_division'] = pending_book_division
+                            pending_book_division = ''
+
                     if 'verses' in chapter:
                         for i, verse in enumerate(chapter['verses']):
                             chapter['verses'][i] = self.process_verse(verse)
+
+                            if is_tehilim and chapter['verses'][i].get('tth'):
+                                cleaned_tth, division = self.extract_tehilim_book_division_marker(
+                                    chapter['verses'][i]['tth']
+                                )
+                                if division:
+                                    chapter['verses'][i]['tth'] = cleaned_tth
+                                    pending_book_division = division
 
             # Calculate changes for this file
             file_stats = {
@@ -769,6 +845,8 @@ class TTHJsonPostProcessor:
             f"  Invalid subtitles:    {self.stats['subtitle_invalid_removed']}")
         print(
             f"  Divine names norm.:   {self.stats['divine_name_normalized']}")
+        print(
+            f"  Book divisions moved: {self.stats['book_divisions_extracted']}")
         print(f"  Underscore artifacts: {self.stats['underscore_artifacts']}")
 
 

--- a/scripts/tth_2/md_to_json.py
+++ b/scripts/tth_2/md_to_json.py
@@ -421,6 +421,7 @@ class TTH2MdToJson:
 
         current_chapter = None
         current_verses = []
+        current_last_verse_num: Optional[int] = None
         total_chapters_expected = self.book_info.get('chapters', 0)
         skipping_inline_footnote_blob = False
 
@@ -458,6 +459,7 @@ class TTH2MdToJson:
 
                 current_chapter = int(chapter_match.group(1))
                 current_verses = []
+                current_last_verse_num = None
                 i += 1
                 continue
 
@@ -482,6 +484,13 @@ class TTH2MdToJson:
                         cleaned_text, footnotes = self.extract_footnotes(
                             cleaned_text)
 
+                        if current_last_verse_num is not None and split_verse_num <= current_last_verse_num:
+                            raise ValueError(
+                                f"Verse sequence regression in {self.book_key} chapter {current_chapter}: "
+                                f"got verse {split_verse_num} after {current_last_verse_num}. "
+                                f"Offending line: {line}"
+                            )
+
                         verse_entry = {
                             'verse': split_verse_num,
                             'tth': cleaned_text,
@@ -490,6 +499,7 @@ class TTH2MdToJson:
                         }
 
                         current_verses.append(verse_entry)
+                        current_last_verse_num = split_verse_num
                     i += 1
                     continue
 
@@ -506,6 +516,13 @@ class TTH2MdToJson:
                     verse_text = self.clean_text_preserve_comments(verse_text)
                     verse_text, footnotes = self.extract_footnotes(verse_text)
 
+                    if current_last_verse_num is not None and verse_num <= current_last_verse_num:
+                        raise ValueError(
+                            f"Verse sequence regression in {self.book_key} chapter {current_chapter}: "
+                            f"got verse {verse_num} after {current_last_verse_num}. "
+                            f"Offending line: {line}"
+                        )
+
                     verse_entry = {
                         'verse': verse_num,
                         'tth': verse_text,
@@ -514,6 +531,7 @@ class TTH2MdToJson:
                     }
 
                     current_verses.append(verse_entry)
+                    current_last_verse_num = verse_num
                     i += 1
                     continue
 


### PR DESCRIPTION
- add postprocess normalization to remove markdown wrappers around divine-name tokens while preserving surrounding punctuation and handling numeric-prefixed edge cases
- move Tehilim LIBRO markers out of verse text into chapter-level book_division fields (LIBRO PRIMERO through LIBRO QUINTO)
- extend format validation to detect wrapped divine-name artifacts and verse sequence regressions inside chapters
- tighten DOCX-to-markdown empty-verse handling so only line-leading standalone markers are converted, avoiding mid-verse corruption
- add markdown-to-JSON verse ordering guardrails that raise on non-increasing verse numbers during parsing
- regenerate affected TTH_2 artifacts across markdown/json outputs to align with the updated processing pipeline