### PR TITLE
fix: harden tth2 verse-sequence pipeline and regenerate corpus

### DIFF
--- a/data/tth_2/json/bamidbar.json
+++ b/data/tth_2/json/bamidbar.json
@@ -7,7 +7,7 @@
     "spanish_name": "Números",
     "section": "torah",
     "total_chapters": 36,
-    "total_verses": 1303
+    "total_verses": 1287
   },
   "chapters": [
     {
@@ -136,13 +136,7 @@
         },
         {
           "verse": 18,
-          "tth": "y a toda la congregación reunieron en el <em>día</em> uno del mes segundo. Y su nacimiento",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "por sus familias, por las casas de sus padres, con el número de nombres, de edad de veinte años y arriba, por sus cabezas.",
+          "tth": "y a toda la congregación reunieron en el <em>día</em> uno del mes segundo. Y su nacimiento por sus familias, por las casas de sus padres, con el número de nombres, de edad de veinte años y arriba, por sus cabezas.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1464,13 +1458,7 @@
         },
         {
           "verse": 10,
-          "tth": "Y <em>cada</em> hombre,",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "sus santidades para él serán; lo que un hombre da al sacerdote, para él será.",
+          "tth": "Y <em>cada</em> hombre, sus santidades para él serán; lo que un hombre da al sacerdote, para él será.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Sobre los celos"
@@ -4504,13 +4492,7 @@
         },
         {
           "verse": 3,
-          "tth": "Y se reunieron sobre Moshéh y sobre Aharón, y les dijeron:",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "¡<em>Es</em> mucho para ustedes! Porque, toda la congregación, todos ellos son santos, y en medio de ellos <em>está</em> יהוה. ¿Por qué se levantan sobre la asamblea de יהוה?",
+          "tth": "Y se reunieron sobre Moshéh y sobre Aharón, y les dijeron: ¡<em>Es</em> mucho para ustedes! Porque, toda la congregación, todos ellos son santos, y en medio de ellos <em>está</em> יהוה. ¿Por qué se levantan sobre la asamblea de יהוה?",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4808,13 +4790,7 @@
         },
         {
           "verse": 49,
-          "tth": "Y fueron los muertos por la plaga",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "catorce mil setecientos, aparte de los muertos por el asunto de Koraj.",
+          "tth": "Y fueron los muertos por la plaga catorce mil setecientos, aparte de los muertos por el asunto de Koraj.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5702,13 +5678,7 @@
         },
         {
           "verse": 15,
-          "tth": "y la cascada de los arroyos que se esparce hasta el descanso de Ar, y se apoya por la frontera",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "de Moab.",
+          "tth": "y la cascada de los arroyos que se esparce hasta el descanso de Ar, y se apoya por la frontera de Moab.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -6268,13 +6238,7 @@
         },
         {
           "verse": 19,
-          "tth": "No es hombre El para que",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "mienta, e hijo de hombre para que se vuelva atrás. ¿Él dijo, y no lo hará?, ¿ha hablado, y no lo levantará?",
+          "tth": "No es hombre El para que mienta, e hijo de hombre para que se vuelva atrás. ¿Él dijo, y no lo hará?, ¿ha hablado, y no lo levantará?",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -6388,13 +6352,7 @@
         },
         {
           "verse": 6,
-          "tth": "Como arroyos que se esparcen, como jardines junto al río,",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "como cedros junto a las aguas.",
+          "tth": "Como arroyos que se esparcen, como jardines junto al río, como cedros junto a las aguas.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -6466,13 +6424,7 @@
         },
         {
           "verse": 18,
-          "tth": "Y será Edom una posesión,",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "Seir, sus enemigos.E Israel, hacedor de valor.",
+          "tth": "Y será Edom una posesión, Seir, sus enemigos.E Israel, hacedor de valor.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -6490,20 +6442,7 @@
         },
         {
           "verse": 21,
-          "tth": "Y vio al keiní, y tomó su parábola, y dijo: Olam¹⁷³ es tu asentamiento, y puesto en roca <em>está</em>",
-          "footnotes": [
-            {
-              "marker": "¹⁷³",
-              "number": "173",
-              "word": "Olam",
-              "explanation": "Tiempo oculto, solo conocido por Elohim. Así también en cap. 25:13."
-            }
-          ],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "tu nido.",
+          "tth": "Y vio al keiní, y tomó su parábola, y dijo: Olam¹⁷³ es tu asentamiento, y puesto en roca <em>está</em> tu nido.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7633,13 +7572,7 @@
         },
         {
           "verse": 11,
-          "tth": "<em>y</em>",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "un peludo de las cabras <em>para</em> ofrenda por el pecado, además de la ofrenda por el pecado de las reconciliaciones²⁰² y la ofrenda ascendida de la continuidad y su ofrenda de grano, y sus ofrendas derramadas.",
+          "tth": "<em>y</em> un peludo de las cabras <em>para</em> ofrenda por el pecado, además de la ofrenda por el pecado de las reconciliaciones²⁰² y la ofrenda ascendida de la continuidad y su ofrenda de grano, y sus ofrendas derramadas.",
           "footnotes": [
             {
               "marker": "²⁰²",
@@ -8588,13 +8521,7 @@
         },
         {
           "verse": 39,
-          "tth": "Y fueron los hijos de Majir, hijo de Menasheh a Guilad, y capturaron y tomaron posesión del emorí que <em>habitaba</em>",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "en ella.",
+          "tth": "Y fueron los hijos de Majir, hijo de Menasheh a Guilad, y capturaron y tomaron posesión del emorí que <em>habitaba</em> en ella.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8855,13 +8782,7 @@
         },
         {
           "verse": 36,
-          "tth": "Y viajaron de",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "Etzión Gaber y acamparon en el desierto de Tzin, esto es Kádesh.",
+          "tth": "Y viajaron de Etzión Gaber y acamparon en el desierto de Tzin, esto es Kádesh.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8927,19 +8848,7 @@
         },
         {
           "verse": 47,
-          "tth": "Y viajaron de",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "Almón Diblataimah",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "y acamparon en Harei Haabarím, delante de Nebó.",
+          "tth": "Y viajaron de Almón Diblataimah y acamparon en Harei Haabarím, delante de Nebó.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -9128,13 +9037,7 @@
         },
         {
           "verse": 17,
-          "tth": "Estos son los nombres",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "de los hombres que heredarán para ustedes la tierra: Eleazar el sacerdote y Yehoshúa, hijo de Nun.",
+          "tth": "Estos son los nombres de los hombres que heredarán para ustedes la tierra: Eleazar el sacerdote y Yehoshúa, hijo de Nun.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -9543,13 +9446,7 @@
         },
         {
           "verse": 12,
-          "tth": "De las familias de los hijos de Menasheh, hijo de Iosef, fueron por mujeres, y fue su herencia",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "a la tribu de la familia de su padre.",
+          "tth": "De las familias de los hijos de Menasheh, hijo de Iosef, fueron por mujeres, y fue su herencia a la tribu de la familia de su padre.",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/bereshit.json
+++ b/data/tth_2/json/bereshit.json
@@ -7,7 +7,7 @@
     "spanish_name": "Génesis",
     "section": "torah",
     "total_chapters": 52,
-    "total_verses": 1548
+    "total_verses": 1533
   },
   "chapters": [
     {
@@ -592,13 +592,7 @@
         },
         {
           "verse": 8,
-          "tth": "Y escucharon la voz de יהוה Elohim que caminaba en el jardín al viento del día;",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "y se escondieron el hombre y su mujer del rostro de יהוה Elohim en medio del árbol del jardín.",
+          "tth": "Y escucharon la voz de יהוה Elohim que caminaba en el jardín al viento del día; y se escondieron el hombre y su mujer del rostro de יהוה Elohim en medio del árbol del jardín.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2041,13 +2035,7 @@
         },
         {
           "verse": 7,
-          "tth": "Da <em>acá</em>, descendamos y confundamos allí su lenguaje, que",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "no escuche un hombre el lenguaje de su compañero.",
+          "tth": "Da <em>acá</em>, descendamos y confundamos allí su lenguaje, que no escuche un hombre el lenguaje de su compañero.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2181,13 +2169,7 @@
         },
         {
           "verse": 29,
-          "tth": "Y tomaron Abram y Najor para ellos mujeres. El nombre <em>de</em>",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "la mujer de Abram era Sarai. Y el nombre <em>de</em> la mujer de Najor era Milcáh, hija de Harán, padre de Milcáh, y padre de Iscáh.",
+          "tth": "Y tomaron Abram y Najor para ellos mujeres. El nombre <em>de</em> la mujer de Abram era Sarai. Y el nombre <em>de</em> la mujer de Najor era Milcáh, hija de Harán, padre de Milcáh, y padre de Iscáh.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2663,13 +2645,7 @@
         },
         {
           "verse": 23,
-          "tth": "que",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "si desde un hilo hasta una cuerda de sandalia, si tomaría de cualquier <em>cosa</em> que es tuya, no digas: “Yo enriquecí a Abram”.",
+          "tth": "que si desde un hilo hasta una cuerda de sandalia, si tomaría de cualquier <em>cosa</em> que es tuya, no digas: “Yo enriquecí a Abram”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3509,13 +3485,7 @@
         },
         {
           "verse": 10,
-          "tth": "Pero enviaron los hombres",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "sus manos y trajeron a Lot hacia ellos a la casa, y la puerta cerraron.",
+          "tth": "Pero enviaron los hombres sus manos y trajeron a Lot hacia ellos a la casa, y la puerta cerraron.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5905,13 +5875,7 @@
         },
         {
           "verse": 21,
-          "tth": "Y dijo Yaakov a Labán: Da <em>me</em>",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "a mi mujer, porque se cumplieron mis días, y pueda entrar a ella.",
+          "tth": "Y dijo Yaakov a Labán: Da <em>me</em> a mi mujer, porque se cumplieron mis días, y pueda entrar a ella.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7251,13 +7215,7 @@
         },
         {
           "verse": 12,
-          "tth": "Multipliquen sobre mí mucho el precio de la novia, y regalo daré tal como me digan, pero den para mí",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "a la joven por mujer.",
+          "tth": "Multipliquen sobre mí mucho el precio de la novia, y regalo daré tal como me digan, pero den para mí a la joven por mujer.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8262,13 +8220,7 @@
         },
         {
           "verse": 18,
-          "tth": "Y él dijo: ¿Qué garantía <em>tengo</em> que darte a ti?",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "Y ella dijo: Tu sello, tu cuerda y tu bastón que <em>tienes</em> en tu mano. Y <em>los</em> dio a ella, y entró a ella, y ella concibió para él.",
+          "tth": "Y él dijo: ¿Qué garantía <em>tengo</em> que darte a ti? Y ella dijo: Tu sello, tu cuerda y tu bastón que <em>tienes</em> en tu mano. Y <em>los</em> dio a ella, y entró a ella, y ella concibió para él.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8342,13 +8294,7 @@
         },
         {
           "verse": 28,
-          "tth": "Y sucedió",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "que <em>, cuando daba a luz, él puso <em>su</em> mano, y <em>la</em> tomó la partera y ató en su mano</em> un hilo escarlata, diciendo: Este salió primero.",
+          "tth": "Y sucedió que <em>, cuando daba a luz, él puso <em>su</em> mano, y <em>la</em> tomó la partera y ató en su mano</em> un hilo escarlata, diciendo: Este salió primero.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8616,13 +8562,7 @@
         },
         {
           "verse": 11,
-          "tth": "Y la copa de Faraón <em>estaba</em> en mi mano; y tomé las uvas",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "y las exprimí¹⁹⁸ en la copa de Faraón, y puse la copa en la palma de Faraón.",
+          "tth": "Y la copa de Faraón <em>estaba</em> en mi mano; y tomé las uvas y las exprimí¹⁹⁸ en la copa de Faraón, y puse la copa en la palma de Faraón.",
           "footnotes": [
             {
               "marker": "¹⁹⁸",
@@ -8679,13 +8619,7 @@
         },
         {
           "verse": 17,
-          "tth": "Y en la canasta superior",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "había de toda comida <em>para</em> Faraón hecha para hornear, y las aves los comían de la canasta de sobre mi cabeza.",
+          "tth": "Y en la canasta superior había de toda comida <em>para</em> Faraón hecha para hornear, y las aves los comían de la canasta de sobre mi cabeza.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8909,13 +8843,7 @@
         },
         {
           "verse": 27,
-          "tth": "Y las siete vacas flacas y malas que subieron después de ellas, siete años <em>son</em> ellas,",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "y las siete espigas vacías arruinadas <em>por el</em> viento del este, serán siete años de hambre.",
+          "tth": "Y las siete vacas flacas y malas que subieron después de ellas, siete años <em>son</em> ellas, y las siete espigas vacías arruinadas <em>por el</em> viento del este, serán siete años de hambre.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -10275,13 +10203,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y vino Iosef y contó a Faraón, y dijo: Mi padre y mis hermanos, y sus rebaños y sus ganados, y todo lo que",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "ellos tienen, han venido de la tierra de Kenáan, y he aquí están en la tierra de Goshén.",
+          "tth": "Y vino Iosef y contó a Faraón, y dijo: Mi padre y mis hermanos, y sus rebaños y sus ganados, y todo lo que ellos tienen, han venido de la tierra de Kenáan, y he aquí están en la tierra de Goshén.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -10317,13 +10239,7 @@
         },
         {
           "verse": 7,
-          "tth": "Y",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "trajo Iosef a Yaakov su padre y lo paró delante de Faraón, y bendijo Yaakov a Faraón.",
+          "tth": "Y trajo Iosef a Yaakov su padre y lo paró delante de Faraón, y bendijo Yaakov a Faraón.",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/devarim.json
+++ b/data/tth_2/json/devarim.json
@@ -7,7 +7,7 @@
     "spanish_name": "Deuteronomio",
     "section": "torah",
     "total_chapters": 34,
-    "total_verses": 967
+    "total_verses": 956
   },
   "chapters": [
     {
@@ -1813,13 +1813,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Cuando te haya hecho entrar יהוה tu Elohim",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "a la tierra la cual tú entrarás allí para heredarla, y haya expulsado muchas naciones de delante de ti: el jití, el girgashí, el emorí, el kenaaní, el perizí, el jiví y el iebusí, siete naciones <em>más</em> numerosas y tremendas que tú,",
+          "tth": "Cuando te haya hecho entrar יהוה tu Elohim a la tierra la cual tú entrarás allí para heredarla, y haya expulsado muchas naciones de delante de ti: el jití, el girgashí, el emorí, el kenaaní, el perizí, el jiví y el iebusí, siete naciones <em>más</em> numerosas y tremendas que tú,",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1919,13 +1913,7 @@
         },
         {
           "verse": 11,
-          "tth": "Y guardarás los mandamientos, los decretos y los procesos legales",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "que yo te ordeno hoy, para hacerlos.",
+          "tth": "Y guardarás los mandamientos, los decretos y los procesos legales que yo te ordeno hoy, para hacerlos.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Bendiciones de la obediencia"
@@ -3188,19 +3176,7 @@
         },
         {
           "verse": 18,
-          "tth": "porque escucharás a la voz de יהוה para guardar todos sus mandamientos que yo te ordeno",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "hoy, para hacer",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "lo recto en los ojos de יהוה tu Elohim.",
+          "tth": "porque escucharás a la voz de יהוה para guardar todos sus mandamientos que yo te ordeno hoy, para hacer lo recto en los ojos de יהוה tu Elohim.",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -3224,26 +3200,7 @@
         },
         {
           "verse": 2,
-          "tth": "Porque pueblo kadosh¹¹⁴ <em>eres</em> tú",
-          "footnotes": [
-            {
-              "marker": "¹¹⁴",
-              "number": "114",
-              "word": "kadosh",
-              "explanation": "Santo, apartado, distinguido. Así también en vers. 21."
-            }
-          ],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "para יהוה tu Elohim; y te ha escogido יהוה",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "para ser a Él por pueblo, una adquisición¹¹⁵ de <em>entre</em> todos los pueblos que <em>están</em> sobre la faz de la tierra.",
+          "tth": "Porque pueblo kadosh¹¹⁴ <em>eres</em> tú para יהוה tu Elohim; y te ha escogido יהוה para ser a Él por pueblo, una adquisición¹¹⁵ de <em>entre</em> todos los pueblos que <em>están</em> sobre la faz de la tierra.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Animales puros e impuros"
@@ -3469,13 +3426,7 @@
         },
         {
           "verse": 17,
-          "tth": "y",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "la <em>kaat</em>¹³⁷, la <em>rajamáh</em>¹³⁸ y el <em>shálaj</em>¹³⁹,",
+          "tth": "y la <em>kaat</em>¹³⁷, la <em>rajamáh</em>¹³⁸ y el <em>shálaj</em>¹³⁹,",
           "footnotes": [
             {
               "marker": "¹³⁷",
@@ -4435,13 +4386,7 @@
         },
         {
           "verse": 3,
-          "tth": "y <em>les</em> dirá a ellos: “¡Escucha Israel, ustedes se acercan",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "hoy a la guerra sobre sus enemigos; no se ablandará su corazón, no temerán y no se apresurarán, y no temblarán debido a sus rostros!",
+          "tth": "y <em>les</em> dirá a ellos: “¡Escucha Israel, ustedes se acercan hoy a la guerra sobre sus enemigos; no se ablandará su corazón, no temerán y no se apresurarán, y no temblarán debido a sus rostros!",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4978,13 +4923,7 @@
         },
         {
           "verse": 4,
-          "tth": "por cosa que no fueron al encuentro de ustedes con pan y con agua en el camino, en su salida",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "de Mitzráim, y que contrataron contra ti a Bilam, hijo de Beor, de Petor, Aram Naharáim, para hacerte excluido.",
+          "tth": "por cosa que no fueron al encuentro de ustedes con pan y con agua en el camino, en su salida de Mitzráim, y que contrataron contra ti a Bilam, hijo de Beor, de Petor, Aram Naharáim, para hacerte excluido.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5115,13 +5054,7 @@
         },
         {
           "verse": 20,
-          "tth": "A un extranjero harás interés, pero a tu hermano",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "no harás interés, a fin de que te bendiga יהוה en todo extender de tu mano sobre la tierra, la cual tú entrarás allí para heredarla.",
+          "tth": "A un extranjero harás interés, pero a tu hermano no harás interés, a fin de que te bendiga יהוה en todo extender de tu mano sobre la tierra, la cual tú entrarás allí para heredarla.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -6433,13 +6366,7 @@
         },
         {
           "verse": 25,
-          "tth": "Y dirán: “Porque abandonaron el pacto de יהוה, Elohim de sus padres, el cual hizo con ellos",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "cuando los sacó de la tierra de Mitzráim.",
+          "tth": "Y dirán: “Porque abandonaron el pacto de יהוה, Elohim de sus padres, el cual hizo con ellos cuando los sacó de la tierra de Mitzráim.",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/hoshea.json
+++ b/data/tth_2/json/hoshea.json
@@ -7,7 +7,7 @@
     "spanish_name": "Oseas",
     "section": "neviim",
     "total_chapters": 24,
-    "total_verses": 660
+    "total_verses": 658
   },
   "chapters": [
     {
@@ -349,13 +349,7 @@
         },
         {
           "verse": 24,
-          "tth": "Y dijeron a Yehoshúa: Ciertamente ha dado יהוה",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "en nuestras manos toda la tierra, y además, se han derretido todos los habitantes de la tierra debido a nuestros rostros.",
+          "tth": "Y dijeron a Yehoshúa: Ciertamente ha dado יהוה en nuestras manos toda la tierra, y además, se han derretido todos los habitantes de la tierra debido a nuestros rostros.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "El paso del Iardén"
@@ -2624,20 +2618,7 @@
         },
         {
           "verse": 2,
-          "tth": "por goral⁸⁰",
-          "footnotes": [
-            {
-              "marker": "⁸⁰",
-              "number": "80",
-              "word": "goral",
-              "explanation": "Piedrecita lanzada para tomar decisiones y designar tierras."
-            }
-          ],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "fue su herencia, conforme había ordenado יהוה, por mano de Moshéh, a las nueve tribus y a la media tribu.",
+          "tth": "por goral⁸⁰ fue su herencia, conforme había ordenado יהוה, por mano de Moshéh, a las nueve tribus y a la media tribu.",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/iehoshua.json
+++ b/data/tth_2/json/iehoshua.json
@@ -7,7 +7,7 @@
     "spanish_name": "Josué",
     "section": "neviim",
     "total_chapters": 24,
-    "total_verses": 660
+    "total_verses": 658
   },
   "chapters": [
     {
@@ -349,13 +349,7 @@
         },
         {
           "verse": 24,
-          "tth": "Y dijeron a Yehoshúa: Ciertamente ha dado יהוה",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "en nuestras manos toda la tierra, y además, se han derretido todos los habitantes de la tierra debido a nuestros rostros.",
+          "tth": "Y dijeron a Yehoshúa: Ciertamente ha dado יהוה en nuestras manos toda la tierra, y además, se han derretido todos los habitantes de la tierra debido a nuestros rostros.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "El paso del Iardén"
@@ -2624,20 +2618,7 @@
         },
         {
           "verse": 2,
-          "tth": "por goral⁸⁰",
-          "footnotes": [
-            {
-              "marker": "⁸⁰",
-              "number": "80",
-              "word": "goral",
-              "explanation": "Piedrecita lanzada para tomar decisiones y designar tierras."
-            }
-          ],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "fue su herencia, conforme había ordenado יהוה, por mano de Moshéh, a las nueve tribus y a la media tribu.",
+          "tth": "por goral⁸⁰ fue su herencia, conforme había ordenado יהוה, por mano de Moshéh, a las nueve tribus y a la media tribu.",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/iejezkel.json
+++ b/data/tth_2/json/iejezkel.json
@@ -7,7 +7,7 @@
     "spanish_name": "Ezequiel",
     "section": "neviim",
     "total_chapters": 48,
-    "total_verses": 1273
+    "total_verses": 1272
   },
   "chapters": [
     {
@@ -2886,13 +2886,7 @@
         },
         {
           "verse": 24,
-          "tth": "Y sabrán todos los árboles del campo que Yo soy יהוה; hago bajo al árbol elevado y elevo al árbol bajo; seco al árbol fresco y hago florecer al",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "árbol seco. Yo, יהוה, he hablado y he hecho. La persona que peque morirá",
+          "tth": "Y sabrán todos los árboles del campo que Yo soy יהוה; hago bajo al árbol elevado y elevo al árbol bajo; seco al árbol fresco y hago florecer al árbol seco. Yo, יהוה, he hablado y he hecho. La persona que peque morirá",
           "footnotes": [],
           "hebrew_terms": []
         }

--- a/data/tth_2/json/ionah.json
+++ b/data/tth_2/json/ionah.json
@@ -7,7 +7,7 @@
     "spanish_name": "Jonás",
     "section": "neviim",
     "total_chapters": 4,
-    "total_verses": 48
+    "total_verses": 47
   },
   "chapters": [
     {
@@ -377,20 +377,7 @@
         },
         {
           "verse": 6,
-          "tth": "Y dispuso יהוה Elohim un ricino¹⁵ y subió por encima de Yonáh para ser sombra sobre su cabeza y lo librara de su mal. Y se alegró Yonáh por el ricino con gran alegría.7",
-          "footnotes": [
-            {
-              "marker": "¹⁵",
-              "number": "15",
-              "word": "ricino",
-              "explanation": "En la versión gr.: una calabacera."
-            }
-          ],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "Pero dispuso Elohim un gusano al subir el amanecer del día siguiente, e hirió al ricino, y se secó.",
+          "tth": "Y dispuso יהוה Elohim un ricino¹⁵ y subió por encima de Yonáh para ser sombra sobre su cabeza y lo librara de su mal. Y se alegró Yonáh por el ricino con gran alegría.7 Pero dispuso Elohim un gusano al subir el amanecer del día siguiente, e hirió al ricino, y se secó.",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/irmeiahu.json
+++ b/data/tth_2/json/irmeiahu.json
@@ -7,7 +7,7 @@
     "spanish_name": "Jeremías",
     "section": "neviim",
     "total_chapters": 52,
-    "total_verses": 1365
+    "total_verses": 1364
   },
   "chapters": [
     {
@@ -986,13 +986,7 @@
         },
         {
           "verse": 14,
-          "tth": "Por eso, así dijo יהוה, Elohei Tzebaot: Porque han hablado ustedes esta palabra, heme aquí, pondré mis palabras en tu boca por fuego,",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "maderas, y los consumirá.",
+          "tth": "Por eso, así dijo יהוה, Elohei Tzebaot: Porque han hablado ustedes esta palabra, heme aquí, pondré mis palabras en tu boca por fuego, maderas, y los consumirá.",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/lukas.json
+++ b/data/tth_2/json/lukas.json
@@ -7,7 +7,7 @@
     "spanish_name": "Lucas",
     "section": "besorah",
     "total_chapters": 46,
-    "total_verses": 2029
+    "total_verses": 2026
   },
   "chapters": [
     {
@@ -6624,13 +6624,7 @@
         },
         {
           "verse": 5,
-          "tth": "ciertamente,",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "porque esta viuda me ha cansado, la defenderé²⁶⁴, para que no venga siempre ni me apresure”.",
+          "tth": "ciertamente, porque esta viuda me ha cansado, la defenderé²⁶⁴, para que no venga siempre ni me apresure”.",
           "footnotes": [
             {
               "marker": "²⁶⁴",
@@ -7755,20 +7749,7 @@
         },
         {
           "verse": 4,
-          "tth": "porque todos estos de sus sobras echaron para las ofrendas³⁰⁶ a Elohim,",
-          "footnotes": [
-            {
-              "marker": "³⁰⁶",
-              "number": "306",
-              "word": "ofrendas",
-              "explanation": "Lit.: acercamientos. Heb.: korbanot. Así también en vers. 5."
-            }
-          ],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "pero esta, de su escasez, echó toda posesión que ella tenía. Profecía de la destrucción del Santuario",
+          "tth": "porque todos estos de sus sobras echaron para las ofrendas³⁰⁶ a Elohim, pero esta, de su escasez, echó toda posesión que ella tenía. Profecía de la destrucción del Santuario",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8509,13 +8490,7 @@
         },
         {
           "verse": 67,
-          "tth": "diciendo:",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "Si Tú eres el Mesías, dínoslo. Y les dijo: Si les digo, no creerán;",
+          "tth": "diciendo: Si Tú eres el Mesías, dínoslo. Y les dijo: Si les digo, no creerán;",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/malaji.json
+++ b/data/tth_2/json/malaji.json
@@ -419,7 +419,7 @@
         },
         {
           "verse": 18,
-          "tth": "Y volverán y verán entre el justificado y el condenado, entre el siervo de Elohim y el que no le sirve. <em>El gran día de</em> יהוה",
+          "tth": "Y volverán y verán entre el justificado y el condenado, entre el siervo de Elohim y el que no le sirve. <em>El gran día de</em>__יהוה__",
           "footnotes": [],
           "hebrew_terms": []
         }

--- a/data/tth_2/json/markos.json
+++ b/data/tth_2/json/markos.json
@@ -7,7 +7,7 @@
     "spanish_name": "Marcos",
     "section": "besorah",
     "total_chapters": 16,
-    "total_verses": 679
+    "total_verses": 678
   },
   "chapters": [
     {
@@ -691,13 +691,7 @@
         },
         {
           "verse": 7,
-          "tth": "Y",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "se apartó Yeshúa con sus discípulos hacia el mar, y mucha gente venía detrás de Él desde Galil, desde Iehudáh,",
+          "tth": "Y se apartó Yeshúa con sus discípulos hacia el mar, y mucha gente venía detrás de Él desde Galil, desde Iehudáh,",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/melajim_alef.json
+++ b/data/tth_2/json/melajim_alef.json
@@ -7,7 +7,7 @@
     "spanish_name": "1 Reyes",
     "section": "neviim",
     "total_chapters": 22,
-    "total_verses": 818
+    "total_verses": 816
   },
   "chapters": [
     {
@@ -2991,15 +2991,10 @@
         },
         {
           "verse": 10,
-          "tth": "y le había ordenado sobre esta cosa, para no ir tras de otros dioses, pero no guardó lo que había ordenado יהוה. Elohim",
+          "tth": "y le había ordenado sobre esta cosa, para no ir tras de otros dioses, pero no guardó lo que había ordenado יהוה.",
           "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "levanta adversarios a Shelomóh",
-          "footnotes": [],
-          "hebrew_terms": []
+          "hebrew_terms": [],
+          "subtitle": "Elohim levanta adversarios a Shelomóh"
         },
         {
           "verse": 11,
@@ -3616,13 +3611,7 @@
         },
         {
           "verse": 24,
-          "tth": "Y se fue, y lo encontró un león en el camino y lo mató; y estuvo su cadáver tirado en el camino, y el asno parado junto a él, y el león parado",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "junto al cadáver.",
+          "tth": "Y se fue, y lo encontró un león en el camino y lo mató; y estuvo su cadáver tirado en el camino, y el asno parado junto a él, y el león parado junto al cadáver.",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/micah.json
+++ b/data/tth_2/json/micah.json
@@ -7,7 +7,7 @@
     "spanish_name": "Miqueas",
     "section": "neviim",
     "total_chapters": 7,
-    "total_verses": 106
+    "total_verses": 105
   },
   "chapters": [
     {
@@ -279,13 +279,7 @@
         },
         {
           "verse": 11,
-          "tth": "Si un hombre anda",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "en viento y falsedad, miente: “Destilaré para ti de vino y de bebida embriagante”, sería uno que destila de este pueblo.",
+          "tth": "Si un hombre anda en viento y falsedad, miente: “Destilaré para ti de vino y de bebida embriagante”, sería uno que destila de este pueblo.",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/shemot.json
+++ b/data/tth_2/json/shemot.json
@@ -7,7 +7,7 @@
     "spanish_name": "Éxodo",
     "section": "torah",
     "total_chapters": 40,
-    "total_verses": 1217
+    "total_verses": 1210
   },
   "chapters": [
     {
@@ -516,13 +516,7 @@
         },
         {
           "verse": 13,
-          "tth": "Y dijo Moshéh a Elohim: He aquí, yo voy a los hijos de Israel, y les diré: “El Elohim de sus padres",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "me ha enviado a ustedes”. Y ellos me dirán: “¿Cuál es su nombre? ”, ¿qué les diré?",
+          "tth": "Y dijo Moshéh a Elohim: He aquí, yo voy a los hijos de Israel, y les diré: “El Elohim de sus padres me ha enviado a ustedes”. Y ellos me dirán: “¿Cuál es su nombre? ”, ¿qué les diré?",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1599,13 +1593,7 @@
         },
         {
           "verse": 32,
-          "tth": "Pero permaneció pesado Faraón su corazón también esta vez, y no envió al pueblo.",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "Quinta plaga: peste en el ganado",
+          "tth": "Pero permaneció pesado Faraón su corazón también esta vez, y no envió al pueblo. Quinta plaga: peste en el ganado",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -1800,13 +1788,7 @@
         },
         {
           "verse": 29,
-          "tth": "Y le dijo Moshéh: Cuando salga de la ciudad extenderé mis palmas a יהוה; las voces cesarán y el granizo no estará más, para que sepas que de יהוה",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "es la tierra.",
+          "tth": "Y le dijo Moshéh: Cuando salga de la ciudad extenderé mis palmas a יהוה; las voces cesarán y el granizo no estará más, para que sepas que de יהוה es la tierra.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2954,20 +2936,7 @@
         },
         {
           "verse": 8,
-          "tth": "Y en el aliento de tus narices se acumularon las aguas, se pararon como un pilar de agua las corrientes⁷⁰;",
-          "footnotes": [
-            {
-              "marker": "⁷⁰",
-              "number": "70",
-              "word": "corrientes",
-              "explanation": "Lit.: destilaciones."
-            }
-          ],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "se congelaron los abismos en el corazón del mar.",
+          "tth": "Y en el aliento de tus narices se acumularon las aguas, se pararon como un pilar de agua las corrientes⁷⁰; se congelaron los abismos en el corazón del mar.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3183,13 +3152,7 @@
         },
         {
           "verse": 7,
-          "tth": "Y <em>por</em>",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "la mañana verán la gloria de יהוה, por <em>que</em> Él escucha sus murmuraciones sobre יהוה; pero nosotros, ¿qué <em>somos</em> para que se quejen sobre nosotros?",
+          "tth": "Y <em>por</em> la mañana verán la gloria de יהוה, por <em>que</em> Él escucha sus murmuraciones sobre יהוה; pero nosotros, ¿qué <em>somos</em> para que se quejen sobre nosotros?",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3578,13 +3541,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y escuchó Itró, sacerdote",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "de Midián, suegro de Moshéh, todo lo que había hecho Elohim por Moshéh y por Israel su pueblo, porque sacó יהוה a Israel de Mitzráim.",
+          "tth": "Y escuchó Itró, sacerdote de Midián, suegro de Moshéh, todo lo que había hecho Elohim por Moshéh y por Israel su pueblo, porque sacó יהוה a Israel de Mitzráim.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4794,13 +4751,7 @@
         },
         {
           "verse": 4,
-          "tth": "Cuando te encuentres un buey",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "de tu enemigo o su asno perdido, devolviendo, lo devolverás a él.",
+          "tth": "Cuando te encuentres un buey de tu enemigo o su asno perdido, devolviendo, lo devolverás a él.",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/shemuel_alef.json
+++ b/data/tth_2/json/shemuel_alef.json
@@ -7,7 +7,7 @@
     "spanish_name": "1 Samuel",
     "section": "neviim",
     "total_chapters": 31,
-    "total_verses": 812
+    "total_verses": 810
   },
   "chapters": [
     {
@@ -34,20 +34,7 @@
         },
         {
           "verse": 3,
-          "tth": "Y subía este hombre de su ciudad cada año² para inclinarse y para sacrificar para יהוה",
-          "footnotes": [
-            {
-              "marker": "²",
-              "number": "2",
-              "word": "año",
-              "explanation": "Lit.: de días a días."
-            }
-          ],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "Tzebaot en Shiloh. Y allí <em>estaban</em> los dos hijos de Elí, Jofní y Pinjas, sacerdotes de יהוה.",
+          "tth": "Y subía este hombre de su ciudad cada año² para inclinarse y para sacrificar para יהוה Tzebaot en Shiloh. Y allí <em>estaban</em> los dos hijos de Elí, Jofní y Pinjas, sacerdotes de יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -662,13 +649,7 @@
         },
         {
           "verse": 15,
-          "tth": "Y se acostó Shemuel hasta la mañana; y abrió las puertas de la casa de יהוה; y Shemuel",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "tenía miedo de dar a conocer la visión a Elí.",
+          "tth": "Y se acostó Shemuel hasta la mañana; y abrió las puertas de la casa de יהוה; y Shemuel tenía miedo de dar a conocer la visión a Elí.",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/shoftim.json
+++ b/data/tth_2/json/shoftim.json
@@ -7,7 +7,7 @@
     "spanish_name": "Jueces",
     "section": "neviim",
     "total_chapters": 21,
-    "total_verses": 618
+    "total_verses": 616
   },
   "chapters": [
     {
@@ -998,13 +998,7 @@
         },
         {
           "verse": 11,
-          "tth": "Del sonido de los que dividen entre los abrevaderos,",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "de sus campesinos en Israel.Entonces descendió a las puertas el pueblo de יהוה.",
+          "tth": "Del sonido de los que dividen entre los abrevaderos, de sus campesinos en Israel.Entonces descendió a las puertas el pueblo de יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3006,13 +3000,7 @@
         },
         {
           "verse": 22,
-          "tth": "Y dijo Manóaj a su mujer: ¡Muriendo, moriremos!",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "Porque <em>a</em> Elohim hemos visto.",
+          "tth": "Y dijo Manóaj a su mujer: ¡Muriendo, moriremos! Porque <em>a</em> Elohim hemos visto.",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/tehilim.json
+++ b/data/tth_2/json/tehilim.json
@@ -7,7 +7,7 @@
     "spanish_name": "Salmos",
     "section": "ketuvim",
     "total_chapters": 150,
-    "total_verses": 2461
+    "total_verses": 2460
   },
   "chapters": [
     {
@@ -473,7 +473,7 @@
         },
         {
           "verse": 10,
-          "tth": "Se avergonzarán y se aterrarán mucho todos mis enemigos; volverán y se avergonzarán de repente. <em>Shigaión¹⁸ de David, que cantó a</em> יהוה <em>sobre las palabras de Cush, benieminí¹⁹.</em>",
+          "tth": "Se avergonzarán y se aterrarán mucho todos mis enemigos; volverán y se avergonzarán de repente. <em>Shigaión¹⁸ de David, que cantó a</em>__יהוה__<em>sobre las palabras de Cush, benieminí¹⁹.</em>",
           "footnotes": [
             {
               "marker": "¹⁹",
@@ -1483,7 +1483,7 @@
         },
         {
           "verse": 15,
-          "tth": "Yo en justicia veré tu rostro, me saciaré cuando despierte <em>a</em> tu semejanza. <em>Para el vencedor. Del siervo de</em> יהוה <em>, de David, el cual habló a</em> יהוה <em>las palabras de esta canción en el día que lo rescató</em> יהוה <em>de la palma de todos sus enemigos, y de la mano de Shaúl, y dijo:</em>",
+          "tth": "Yo en justicia veré tu rostro, me saciaré cuando despierte <em>a</em> tu semejanza. <em>Para el vencedor. Del siervo de</em>__יהוה__<em>, de David, el cual habló a</em>__יהוה__<em>las palabras de esta canción en el día que lo rescató</em>__יהוה__<em>de la palma de todos sus enemigos, y de la mano de Shaúl, y dijo:</em>",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -3940,7 +3940,7 @@
         },
         {
           "verse": 28,
-          "tth": "Y mi lengua pronunciará tu justicia, todo el día tu alabanza. <em>Para el vencedor. Del siervo de</em> יהוה <em>, de David.</em>",
+          "tth": "Y mi lengua pronunciará tu justicia, todo el día tu alabanza. <em>Para el vencedor. Del siervo de</em>__יהוה__<em>, de David.</em>",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -9853,13 +9853,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Te reconciliaste, יהוה,",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "con tu tierra, has hecho volver el cautiverio de Yaakov.",
+          "tth": "Te reconciliaste, יהוה, con tu tierra, has hecho volver el cautiverio de Yaakov.",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/vaikra.json
+++ b/data/tth_2/json/vaikra.json
@@ -7,7 +7,7 @@
     "spanish_name": "Levítico",
     "section": "torah",
     "total_chapters": 28,
-    "total_verses": 866
+    "total_verses": 858
   },
   "chapters": [
     {
@@ -638,13 +638,7 @@
         },
         {
           "verse": 30,
-          "tth": "Y tomará el sacerdote de su sangre con su dedo, y <em>la</em> pondrá sobre los cuernos del altar",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "de la ofrenda ascendida, y toda la sangre <em>restante</em> derramará en la base del altar.",
+          "tth": "Y tomará el sacerdote de su sangre con su dedo, y <em>la</em> pondrá sobre los cuernos del altar de la ofrenda ascendida, y toda la sangre <em>restante</em> derramará en la base del altar.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -857,13 +851,7 @@
         },
         {
           "verse": 4,
-          "tth": "y",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "será, cuando peque y sea culpable, regresará lo robado que robó, o la explotación <em>con</em> que oprimió, o el depósito que fue depositado con él, o la cosa perdida que ha encontrado,",
+          "tth": "y será, cuando peque y sea culpable, regresará lo robado que robó, o la explotación <em>con</em> que oprimió, o el depósito que fue depositado con él, o la cosa perdida que ha encontrado,",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2920,13 +2908,7 @@
         },
         {
           "verse": 19,
-          "tth": "y haya en lugar de la ebullición una hinchazón",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "blanca, o una mancha blanca rojiza, se mostrará al sacerdote;",
+          "tth": "y haya en lugar de la ebullición una hinchazón blanca, o una mancha blanca rojiza, se mostrará al sacerdote;",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4330,13 +4312,7 @@
         },
         {
           "verse": 5,
-          "tth": "Con el fin de que puedan traer los hijos de Israel sus sacrificios que ellos sacrificaban sobre la faz del campo, y los traigan a יהוה",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "a la entrada de la Tienda del Mo’ed, al sacerdote, y los sacrifiquen <em>como</em> sacrificios de retribución¹⁸⁸ para יהוה.",
+          "tth": "Con el fin de que puedan traer los hijos de Israel sus sacrificios que ellos sacrificaban sobre la faz del campo, y los traigan a יהוה a la entrada de la Tienda del Mo’ed, al sacerdote, y los sacrifiquen <em>como</em> sacrificios de retribución¹⁸⁸ para יהוה.",
           "footnotes": [
             {
               "marker": "¹⁸⁸",
@@ -5109,13 +5085,7 @@
         },
         {
           "verse": 15,
-          "tth": "Y el hombre que dé su acostar con un animal, muriendo, morirá; y el animal",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "matarán.",
+          "tth": "Y el hombre que dé su acostar con un animal, muriendo, morirá; y el animal matarán.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5994,13 +5964,7 @@
         },
         {
           "verse": 27,
-          "tth": "Sin embargo, en el décimo <em>día</em> del mes",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "séptimo, este es el día de las reconciliaciones²⁶¹; una convocación de santidad será para ustedes, y afligirán sus gargantas²⁶², y acercarán una ofrenda de fuego a יהוה.",
+          "tth": "Sin embargo, en el décimo <em>día</em> del mes séptimo, este es el día de las reconciliaciones²⁶¹; una convocación de santidad será para ustedes, y afligirán sus gargantas²⁶², y acercarán una ofrenda de fuego a יהוה.",
           "footnotes": [
             {
               "marker": "²⁶¹",
@@ -7053,19 +7017,7 @@
         },
         {
           "verse": 40,
-          "tth": "Y si arrojan su iniquidad y la iniquidad de sus padres, por sus infidelidades",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "con las cuales",
-          "footnotes": [],
-          "hebrew_terms": []
-        },
-        {
-          "verse": 1,
-          "tth": "fueron infieles contra Mí, y también que hayan andado conmigo con frialdad,",
+          "tth": "Y si arrojan su iniquidad y la iniquidad de sus padres, por sus infidelidades con las cuales fueron infieles contra Mí, y también que hayan andado conmigo con frialdad,",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/zejariah.json
+++ b/data/tth_2/json/zejariah.json
@@ -1592,7 +1592,7 @@
         },
         {
           "verse": 9,
-          "tth": "Y haré entrar a la tercera en el fuego, y los refinaré conforme al refinar de la plata, y los probaré conforme al probar del oro.Él llamará en mi Nombre, y Yo le responderé; diré: “Mi pueblo es él”, y él dirá: “יהוה es mi Elohim”. <em>El reino de</em> יהוה",
+          "tth": "Y haré entrar a la tercera en el fuego, y los refinaré conforme al refinar de la plata, y los probaré conforme al probar del oro.Él llamará en mi Nombre, y Yo le responderé; diré: “Mi pueblo es él”, y él dirá: “יהוה es mi Elohim”. <em>El reino de</em>__יהוה__",
           "footnotes": [],
           "hebrew_terms": []
         }

--- a/data/tth_2/markdown/bamidbar.md
+++ b/data/tth_2/markdown/bamidbar.md
@@ -22,7 +22,7 @@ __BEMIDBAR \(NÚMEROS\)__במדבר
 **16** Estos son los llamados de la congregación, jefes de las tribus de sus padres; cabezas de miles de Israel *fueron* ellos.
 **17** Y tomaron Moshéh y Aharón a estos hom­bres que fueron designados por nombres;
 **18** y a toda la congregación reunieron en el *día* uno del mes segundo. Y su naci­miento
-**1** por sus familias, por las casas de sus padres, con el número de nombres, de edad de veinte años y arriba, por sus cabezas.
+por sus familias, por las casas de sus padres, con el número de nombres, de edad de veinte años y arriba, por sus cabezas.
 **19** Como había ordenado יהוה a Moshéh, los encargó en el desierto de Sinay.
 **20** Y fueron los hijos de Reubén, primogénito de Israel, sus genealogías, por sus familias, por la casa de sus padres, con el número de nom­bres, por sus cabezas, todo varón de edad de veinte años y arriba, todo el que sale *al* ejército;
 **21** los encargados de ellos, por la tribu de Reubén, *fueron *cuarenta y seis mil quinientos.
@@ -232,7 +232,7 @@ __BEMIDBAR \(NÚMEROS\)__במדבר
 **8** Pero si no hay para el hombre redentor para restituir la culpa, la culpa restituida es a יהוה, para el sacerdote, además del carnero de las reconciliaciones, con el cual se hace reconcilia­ción por él.
 **9** Y toda terumáh[^883] para todas las santidades de los hijos de Israel que acercan al sacerdote, para él será.
 **10** Y *cada* hombre,
-**1** sus santidades para él se­rán; lo que un hombre da al sacerdote, para él será.
+sus santidades para él se­rán; lo que un hombre da al sacerdote, para él será.
 
 *Sobre los celos*
 
@@ -722,7 +722,7 @@ __BEMIDBAR \(NÚMEROS\)__במדבר
 **1** Y tomó *hombres* Koraj, hijo de Itzhar, hijo de Kehat, hijo de Levi, y Datán y Abiram, hi­jos de Eliab, y On, hijo de Pelet, hijos de Reu­bén,
 **2** y se levantaron delante de Moshéh, y unos hombres de los hijos de Israel, doscientos cin­cuenta jefes de la congregación, llamados de la hora señalada, hombres de nombre.
 **3** Y se reunieron sobre Moshéh y sobre Aha­rón, y les dijeron:
-**1**¡*Es* mucho para ustedes! Porque, toda la congregación, todos ellos son san­tos, y en medio de ellos *está* יהוה. ¿Por qué se levantan sobre la asamblea de יהוה?
+¡*Es* mucho para ustedes! Porque, toda la congregación, todos ellos son san­tos, y en medio de ellos *está* יהוה. ¿Por qué se levantan sobre la asamblea de יהוה?
 **4** Y escuchó Moshéh, y cayó sobre su rostro;
 **5** y habló a Koraj y a todo su grupo, diciendo: *A* la mañana dará a conocer יהוה el que es de Él y el que es kadosh, y *lo* acercará a Él; y al que elija con Él, *lo *acercará hacia Él.
 **6** Esto hagan: Tomen para ustedes incensarios; Koraj y todo su grupo,
@@ -772,7 +772,7 @@ __BEMIDBAR \(NÚMEROS\)__במדבר
 **47** Y *lo* tomó Aharón como había hablado Mo­shéh, y corrió hacia el medio de la asamblea, y he aquí, había comenzado el golpe en el pue­blo. Y puso el incienso e hizo reconciliación por el pueblo.
 **48** Y se paró entre los muertos y los vi­vos, y se detuvo la plaga.
 **49** Y fueron los muertos por la plaga
-**1** catorce mil setecientos, aparte de los muertos por el a­sunto de Koraj.
+catorce mil setecientos, aparte de los muertos por el a­sunto de Koraj.
 **50** Y regresó Aharón a Moshéh a la entrada de la Tienda del Mo’ed, y la plaga se había dete­nido.
 
 **17**
@@ -921,7 +921,7 @@ __BEMIDBAR \(NÚMEROS\)__במדבר
 **14** Por eso dice en el Rollo de las Lu­chas de יהוה:
 
 **15** y la cascada de los arroyos que se esparce hasta el descanso de Ar, y se apoya por la fron­tera
-**1** de Moab.
+de Moab.
 
 **16** Y desde allí a Beer; este *es* el pozo[^1010] *en* el cual dijo יהוה a Moshéh: Junta al pueblo y *les *daré a ellos agua.
 **17** Entonces cantó Israel esta canción:
@@ -1022,7 +1022,7 @@ con el decreto, con sus báculos.
 **18** Y tomó su parábola, y dijo:
 
 **19** No es hombre El para que
-**1** mienta, e hijo de hombre* *para que* *se vuelva atrás. ¿Él dijo, y no lo hará?, ¿ha hablado, y no lo le­vantará?
+mienta, e hijo de hombre* *para que* *se vuelva atrás. ¿Él dijo, y no lo hará?, ¿ha hablado, y no lo le­vantará?
 **20** He aquí, de bendecir he recibido; Él bendijo, y no lo puedo retornar.
 **21** No ha visto iniquidad en Yaakov,
  y no vio carga pesada en Israel, יהוה su Elohim *está* con él,
@@ -1046,7 +1046,7 @@ con el decreto, con sus báculos.
 Declaración de Bilam, hijo de Beor, y declaración del fuerte abierto de ojos;**4** declaración del oyente de los dichos de El,
 **5**¡Cuán buenas son tus tiendas, Yaakov; tus asentamientos, Israel!
 **6** Como arroyos que se esparcen, como jardi­nes junto al río,
-**1** como cedros junto a las aguas.
+como cedros junto a las aguas.
 **7** Fluirá agua de su balde, y su simiente *estará* en muchas aguas; y se elevará* más* que Agag su rey, y se levanta­rá su reino.
 **8** El lo saca de Mitzráim; como cuernos de búfalo es para él.Consumirá las naciones, sus opresores,
  y sus huesos romperá, y *con *sus flechas* los* herirá.**9** Se agacha, se acuesta como el león y como leona, ¿quién lo levantará? El que te bendice *es* bendito, y el que te excluye, excluido.
@@ -1062,11 +1062,11 @@ Declaración de Bilam, hijo de Beor, y declaración del fuerte de ojos abiertos.
  y el que conoce el conocimiento de Elyón,
 visión del Shadai ve, caído, pero descubiertos los ojos. **17** Lo veo, pero no ahora; lo contemplo, pero no cerca;andará una estrella de Yaakov, y se levantará una vara de Israel,
  aplastará las esquinas de Moab y destruirá todos los hijos de Shet.**18** Y será Edom una posesión,
-**1** Seir, sus enemigos.E Israel, hacedor de valor.
+Seir, sus enemigos.E Israel, hacedor de valor.
 **19** Y dominará desde Yaakov, y hará perder el sobreviviente de la ciudad.
 **20** Y vio a Amalek, y tomó su parábola, y dijo:Primera de las naciones *fue* Amalek, pero su postrer *será* hasta perdición.
 **21** Y vio al keiní, y tomó su parábola, y dijo: Olam[^1023] es tu asentamiento, y puesto en ro­ca *está*
-**1** tu nido.
+tu nido.
 **22** Sino que será para quemar Káin; ¿hasta cuándo Ashur te capturará?
 **23** Y tomó su parábola, y dijo: ¡Oy! ¿Quién vivirá debido a que lo pondrá El?
 **24** Y las naves de la mano de Kitim *vendrán*,
@@ -1247,7 +1247,7 @@ visión del Shadai ve, caído, pero descubiertos los ojos. **17** Lo veo, pero n
 **9** y su ofrenda de grano, harina fina mezclada con aceite, tres décimas para el toro, dos dé­cimas para el carnero uno;
 **10** una décima, una décima para el cordero u­no, por los siete corderos;
 **11** *y*
-**1** un peludo de las cabras *para* ofrenda por el pecado, además de la ofrenda por el pecado de las reconciliaciones[^1052] y la ofrenda ascendida de la con­tinuidad y su ofrenda de grano, y sus ofrendas de­rramadas.
+un peludo de las cabras *para* ofrenda por el pecado, además de la ofrenda por el pecado de las reconciliaciones[^1052] y la ofrenda ascendida de la con­tinuidad y su ofrenda de grano, y sus ofrendas de­rramadas.
 **12** Y en el décimo quinto día del mes séptimo, convocación de santidad habrá para ustedes; cualquier trabajo de servicio no harán, y cele­brarán fiesta a __יהוה__ siete días.
 **13** Y acercarán una ofrenda ascendida, ofrenda de fue­go, olor calmante a __יהוה__: trece toros hijos de ganado, dos carneros, catorce corderos hijos de un año, completos serán;
 **14** y su ofrenda de grano, harina fina mezclada con aceite, tres décimas para el toro uno, por los trece toros, dos décimas para el carnero uno, por los dos carneros;
@@ -1404,7 +1404,7 @@ visión del Shadai ve, caído, pero descubiertos los ojos. **17** Lo veo, pero n
 **37** y los hijos de Reubén edificaron a Jesh­bón, a Elealé[^1067], y a Kiriatáim,
 **38** a Nebó y a Baal Meón, cambiaron *su* nom­bre, y a Sibmáh; y llamaron con *otros *nombres a los nombres de las ciudades que edificaron.
 **39** Y fueron los hijos de Majir, hijo de Menasheh a Guilad, y capturaron y tomaron posesión del emorí que *habitaba*
-**1** en ella.
+en ella.
 **40** Y dio Moshéh Guilad a Majir, hijo de Menasheh, y él habitó en ella.
 **41** Y Iair, hijo de Menasheh, fue y capturó sus tiendas, y las llamó Javot Iair[^1068].
 **42** Y Nobaj fue y capturó a Kenat y a sus al­deas[^1069], y llamó a esta Nobaj, en su nombre.
@@ -1449,7 +1449,7 @@ visión del Shadai ve, caído, pero descubiertos los ojos. **17** Lo veo, pero n
 **34** Y viajaron de Iotbatah y acamparon en A­bro­náh.
 **35** Y viajaron de A­bro­náh y acamparon en Etzión Gaber.
 **36** Y viajaron de
-**1** Etzión Gaber y acamparon en el desierto de Tzin, esto es Kádesh.
+Etzión Gaber y acamparon en el desierto de Tzin, esto es Kádesh.
 **37** Y viajaron de Kádesh y acamparon en Hor, la montaña, en el extremo de tierra de Edom.
 **38** Y subió Aharón el sacerdote a Hor, la montaña, por boca de יהוה, y murió allí, en el año cua­renta por la salida de los hijos de Israel de la tierra de Mitzráim, en el mes quinto, en el *día* uno del mes.
 **39** Y Aharón *tenía* la edad de ciento veintitrés años cuando murió en Hor, la montaña.
@@ -1461,8 +1461,8 @@ visión del Shadai ve, caído, pero descubiertos los ojos. **17** Lo veo, pero n
 **45** Y viajaron de Iyeím y acamparon en Dibón Gad.
 **46** Y viajaron de Dibón Gad y acamparon en Almón Diblataimah.
 **47** Y viajaron de
-**1** Almón Diblataimah
-**1** y acam­pa­ron en Harei Haabarím, delante de Nebó.
+Almón Diblataimah
+y acam­pa­ron en Harei Haabarím, delante de Nebó.
 **48** Y viajaron de Harei Haabarím y acamparon en las llanuras de Moab, por el Iardén, Ierijó.
 **49** Y acamparon junto al Iardén, desde Bet Haieshimot hasta Abel Hashitim, en las lla­nuras de Moab.
 **50** Y habló יהוה a Moshéh, en las llanuras de Moab, junto al Iardén, Ierijó, diciendo:
@@ -1494,7 +1494,7 @@ visión del Shadai ve, caído, pero descubiertos los ojos. **17** Lo veo, pero n
 **15** Las dos tribus y la media tribu han tomado su herencia de *este* lado del Iardén[^1075], Ierijó, ha­cia el este, hacia el amane­cer.
 **16** Y habló __יהוה__ a Moshéh, diciendo:
 **17** Estos son los nombres
-**1** de los hombres que heredarán para ustedes la tierra: Eleazar el sacerdote y Yehoshúa, hijo de Nun.
+de los hombres que heredarán para ustedes la tierra: Eleazar el sacerdote y Yehoshúa, hijo de Nun.
 **18** Y un jefe, un jefe de *cada* tribu tomarás pa­ra heredar la tierra.
 **19** Y estos son los nombres de los hombres: de la tribu de Iehudáh, Caleb, hijo de Iefunéh.
 **20** Y de la tribu de los hijos de Shimeón, She­muel, hijo de Amihud.
@@ -1563,7 +1563,7 @@ visión del Shadai ve, caído, pero descubiertos los ojos. **17** Lo veo, pero n
 **10** Conforme ordenó __יהוה__ a Moshéh, así hi­cieron las hijas de Tzelofjad.
 **11** Y eran Majláh, Tirtzah, Jogláh, Milcáh y Noah, las hijas de Tzelofjad, a los hijos de sus tíos por mujeres.
 **12** De las familias de los hijos de Menasheh, hijo de Iosef, fueron por mujeres, y fue su he­rencia
-**1** a la tribu de la familia de su padre.
+a la tribu de la familia de su padre.
 **13** Estos son los mandamientos y los procesos legales que ordenó __יהוה__ por mano de Moshéh a los hijos de Israel, en las llanuras de Moab, por el Iardén[^1084], Ierijó.
 
 

--- a/data/tth_2/markdown/bereshit.md
+++ b/data/tth_2/markdown/bereshit.md
@@ -86,7 +86,7 @@
 **7** Y fueron abiertos los ojos de los dos, y co­nocieron que *estaban* desnudos ellos; y co­sieron hojas de higo e hicie­ron para sí fa­jas.
 
 **8** Y escucharon la voz de יהוה Elohim que caminaba en el jardín al viento del día;
-**1** y se escondieron el hombre y su mujer del rostro de יהוה Elohim en medio del árbol del jar­dín.
+y se escondieron el hombre y su mujer del rostro de יהוה Elohim en medio del árbol del jar­dín.
 **9** Y llamó יהוה Elohim al hombre, y le dijo: ¿Dónde estás?
 **10** Y él dijo: Tu voz escuché en el jardín, y te­mí porque *estaba* desnudo yo, y me escondí.
 **11** Y Él dijo: ¿Quién te dio a conocer que *esta­bas* des­nu­do tú? ¿Del árbol que te mandé a no comer de él, comiste?
@@ -356,7 +356,7 @@
 **5** Y descendió יהוה para ver la ciudad y la torre que edificaron los hijos del hombre.
 **6** Y dijo יהוה: He aquí el pueblo es uno, y su lenguaje[^53] una para todos. Y esto han comen­zado a hacer, y ahora, ¿no se deberá refrenar de ellos todo lo que traman hacer?
 **7** Da *acá*, descendamos y confundamos allí su lenguaje, que
-**1** no escuche un hombre el lenguaje de su compañero.
+no escuche un hombre el lenguaje de su compañero.
 **8** Y los dispersó יהוה desde allí sobre la faz de toda la tierra. Y cesaron de edificar la ciu­dad.
 **9** Por eso fue llamado su nombre Babel[^54], porque allí confundió[^55] יהוה el lenguaje de toda la tierra; y de allí los dis­persó יהוה sobre la faz de toda la tierra.
 
@@ -385,7 +385,7 @@
 **27** Y estas son las generaciones de Téraj. Téraj engendró a Abram, a Najor y a Harán. Y Harán engendró a Lot.
 **28** Y murió Jarán a la faz de Téraj su padre, en la tierra de su naci­miento, en Ur de los casdim.
 **29** Y tomaron Abram y Najor para ellos mu­jeres. El nombre *de*
-**1** la mujer de Abram era Sa­rai. Y el nombre *de* la mujer de Najor era Mil­cáh, hija de Harán, padre de Milcáh, y padre de Iscáh.
+la mujer de Abram era Sa­rai. Y el nombre *de* la mujer de Najor era Mil­cáh, hija de Harán, padre de Milcáh, y padre de Iscáh.
 **30** Y era Sarai estéril, no tenía ella niño.
 **31** Y tomó Téraj a Abram, su hijo, y a Lot hijo de Jarán, hijo de su hijo, y a Sarai su nuera, mujer de Abram, su hijo. Y salieron con ellos de Ur de los casdim[^56], para ir a la tierra de Kenáan. Y fueron a Jarán, y habita­ron allí.
 **32** Y fueron los días de Téraj doscientos cinco años, y murió Téraj en Jarán.
@@ -478,7 +478,7 @@
 **21** Y dijo el rey de Sedom a Abram: Dame las personas, pero los bienes tóma*los* para ti.
 **22** Y dijo Abram al rey de Sedom: He elevado mi mano a יהוה, El Elyón, creador de los cielos y la tierra,
 **23** que*
-**1** si desde un hilo hasta una cuerda de sandalia, si tomaría de cualquier *cosa* que es tuya, no digas: “Yo enriquecí a Abram”.
+si desde un hilo hasta una cuerda de sandalia, si tomaría de cualquier *cosa* que es tuya, no digas: “Yo enriquecí a Abram”.
 **24** Nada *será* para mí, sólo lo que comieron los jóvenes, y la porción de los hombres que fue­ron conmigo: Aner, Eshcol, y Mamré; ellos to­marán su porción.
 
 *Elohim establece su pacto con Abram*
@@ -625,7 +625,7 @@ a fin de que traiga יהוה sobre Abraham lo que habló sobre él.
 **8** He aquí ahora tengo dos hijas, las cuales no conocieron varón, las sacaré, por favor, a uste­des, y hagan a ellas como sea bueno en sus o­jos; solamente a estos hombres no hagan na­da, porque han venido en la sombra de mi te­cho.
 **9** Y ellos dijeron: ¡Ven más acá! Y dijeron: Este[^92] vino para residir, y ya está juzgando[^93]. Ahora seremos más malos a ti que a ellos. Y presionaron contra el hombre, contra Lot, mucho, y se acer­caron para romper la puerta.
 **10** Pero enviaron los hombres
-**1** sus manos y trajeron a Lot hacia ellos a la casa, y la puerta cerraron.
+sus manos y trajeron a Lot hacia ellos a la casa, y la puerta cerraron.
 **11** Y a los hombres que *estaban* en la entrada de la casa golpearon con ceguera, desde el pequeño y hasta el grande, y se cansaban por *tratar de* encontrar la entrada.
 **12** Y dijeron los hombres a Lot: ¿A quién más tienes aquí? A *tu* yerno, y tus hijos y tus hijas, y todos los cuales tienes en la ciudad, saca del lugar.
 **13** Porque destruiremos nosotros este lugar, porque grande es el grito de ellos al rostro de יהוה, y nos ha enviado יהוה para des­truir­la.
@@ -1042,7 +1042,7 @@ hasta que haya hecho lo que te he hablado.
 **19** Y dijo Labán: Bueno *es* dártela a ti que dársela a otro hombre, permanece conmigo.
 **20** Y sirvió Yaakov por Rajel siete años, y fueron en sus ojos como pocos días, por su amor a ella.
 **21** Y dijo Yaakov a Labán: Da*me*
-**1** a mi mujer, porque se cumplieron mis días, y pueda entrar a ella.
+a mi mujer, porque se cumplieron mis días, y pueda entrar a ella.
 **22** Y juntó Labán a todos los hombres del lugar, e hizo un banquete.
 **23** Y sucedió *que *por la tarde, tomó a Leah su hija y la trajo a Yaakov, y él entró a ella.
 **24** Y dio Labán para ella a Zilpah su sierva, a Leah su hija *como* sierva.
@@ -1260,7 +1260,7 @@ hasta que haya hecho lo que te he hablado.
 **10** Y con nosotros habitarán, y la tierra *estará* delante de ustedes. Habiten y comercien, y to­men *propiedades* en ella.
 **11** Y dijo Shejem a su padre y a los hermanos de ella: Encuentre favor en sus ojos, lo que me digan daré.
 **12** Multipliquen sobre mí mucho el precio de la novia, y regalo daré tal como me digan, pero den para mí
-**1** a la joven por mujer.
+a la joven por mujer.
 **13** Pero respondieron los hijos de Yaakov a Shejem y a Jamor con engaño, y *les* hablaron, porque él había profanado a Dinah su hermana.
 **14** Y les dijeron: No podemos hacer esta cosa, dar a nuestra hermana a un hombre que es incircunciso, porque una vergüenza *sería *eso* *para nosotros.
 **15** Pero en esto acordaremos: Si se hacen como nosotros, sea circuncidado a ti todo va­rón.
@@ -1435,7 +1435,7 @@ Estos son los hijos de Yaakov que le na­cieron en Padán Aram.
 **16** Y se desvió hacia ella al camino, y dijo: Ven, por favor, déjame entrar a ti. Porque no sabía que su nuera era ella. Y ella dijo: ¿Qué me darás por entrar a mí?
 **17** Y él dijo: Yo enviaré una cabra joven del rebaño. Y ella dijo: Si *me* das una garantía hasta que lo envíes.
 **18** Y él dijo: ¿Qué garantía *tengo* que darte a ti?
-**1** Y ella dijo: Tu sello, tu cuerda y tu bastón que *tienes* en tu mano. Y *los* dio a ella, y entró a ella, y ella concibió para él.
+Y ella dijo: Tu sello, tu cuerda y tu bastón que *tienes* en tu mano. Y *los* dio a ella, y entró a ella, y ella concibió para él.
 **19** Y ella se levantó y se fue, y se quitó su velo de sobre ella, y se puso las ves­tiduras de su viudez.
 **20** Y envió Iehudáh la cabra joven por mano de su amigo el adulamí, para adquirir la ga­rantía de mano de la mujer, pero no la halló.
 **21** Y preguntó a los hombres del lugar de ella, diciendo: ¿Dónde *está* la ramera del templo[^191]?, ella *estaba* en Eynáim, junto al camino. Y ellos dijeron: No ha habido aquí *ninguna* ramera del templo.
@@ -1446,7 +1446,7 @@ Estos son los hijos de Yaakov que le na­cieron en Padán Aram.
 **26** Y *los* reconoció Iehudáh, y dijo: Ella es *más* justa que yo, por causa de que no le di a Sheláh, mi hijo. Y no volvió más a conocerla[^192].
 **27** Y sucedió* que* en el tiempo del parto, he aquí, *había* gemelos en su vientre.
 **28** Y sucedió
-**1** que*, cuando daba a luz, él puso *su* mano, y *la* tomó la partera y ató en su mano *un hilo* escar­lata, diciendo: Este salió pri­mero.
+que*, cuando daba a luz, él puso *su* mano, y *la* tomó la partera y ató en su mano *un hilo* escar­lata, diciendo: Este salió pri­mero.
 **29** Y sucedió *que* cuando regresó su mano, he aquí, salió su hermano. Y ella dijo: ¡Qué brecha[^193] has abierto sobre ti! Y llamaron su nombre Péretz[^194].
 **30** Y después salió su hermano, el cual *tenía* sobre su mano *el hilo* escarlata. Y llamaron su nombre Zaraj[^195].
 
@@ -1493,14 +1493,14 @@ Estos son los hijos de Yaakov que le na­cieron en Padán Aram.
 **9** Y contó el jefe de los coperos su sueño a Iosef, y le dijo: En mi sueño* había* una vid delante de mí,
 **10** y en la vid *había* tres brotes. Y ella, cuando florecía, ascendían sus flores, y maduraron en sus racimos uvas.
 **11** Y la copa de Faraón *estaba* en mi mano; y tomé las uvas
-**1** y las exprimí[^200] en la copa de Faraón, y puse la copa en la palma de Faraón.
+y las exprimí[^200] en la copa de Faraón, y puse la copa en la palma de Faraón.
 **12** Y le dijo Iosef: Esta es su interpretación: Los tres brotes, ellos *son* tres días.
 **13** En aún tres días levantará Faraón tu cabeza, y te devolverá a tu puesto, y darás la copa de Faraón en su mano como tenías de­recho antes cuando eras su copero.
 **14** Pero acuérdate de mí contigo mismo cuando él sea bueno para ti, y haz por favor con­migo bondad[^201], y hazle memoria de mí a Faraón, y sácame de esta casa.
 **15** Porque ciertamente fui robado de la tierra de los ivrim[^202], y además, aquí no he hecho nada para que me pongan en el hoyo.
 **16** Y vio el jefe de los panaderos que era buena la interpretación, y dijo a Iosef: También yo *vi* en mi sueño, he aquí, tres canastas de pan blanco sobre mi cabeza.
 **17** Y en la canasta superior
-**1** había* de toda comida *para* Faraón hecha para hornear, y las aves los comían de la canasta de sobre mi cabeza.
+había* de toda comida *para* Faraón hecha para hornear, y las aves los comían de la canasta de sobre mi cabeza.
 **18** Y respondió Iosef, y dijo: Esta es su interpretación: Las tres canastas, ellas *son* tres días.
 **19** En aún tres días levantará Faraón tu cabeza de sobre ti, y te colgará a ti sobre un árbol, y comerán las aves la carne de sobre ti.
 **20** Y sucedió en el día tercero, día del naci­miento de Faraón, *que *hizo un banquete para todos, y él levantó la cabeza del jefe de los coperos y la cabeza del jefe de los panaderos en medio de sus siervos.
@@ -1539,7 +1539,7 @@ Estos son los hijos de Yaakov que le na­cieron en Padán Aram.
 **25** Y dijo Iosef a Faraón: El sueño de Faraón uno es; lo que Elohim va a hacer ha contado a Faraón.
 **26** Las siete vacas buenas, siete años *son* ellas, y las siete espigas buenas siete años *son* ellas; el sueño uno es.
 **27** Y las siete vacas flacas y malas que su­bieron después de ellas, siete años *son* ellas,
-**1** y las siete espigas vacías arruinadas *por el* viento del este, serán siete años de hambre.
+y las siete espigas vacías arruinadas *por el* viento del este, serán siete años de hambre.
 **28** Estas palabras que he dicho a Faraón, lo que Elohim va a hacer ha mostrado a Fa­raón.
 **29** He aquí, siete años vendrán de gran abun­dancia en toda la tierra de Mitzráim.
 **30** Pero se levantarán siete años de hambre después de ellos, y será olvidada toda la abundancia en la tierra de Mitzráim, y destruirá el hambre toda la tierra.
@@ -1773,14 +1773,14 @@ porque una gran na­ción te haré allí.**4** Yo descenderé contigo a Mitzrái
 **47**
 
 **1** Y vino Iosef y contó a Faraón, y dijo: Mi padre y mis hermanos, y sus re­baños y sus ganados, y todo lo que
-**1** ellos tie­nen, han venido de la tierra de Kenáan, y he aquí están en la tierra de Goshén.
+ellos tie­nen, han venido de la tierra de Kenáan, y he aquí están en la tierra de Goshén.
 **2** Y del extremo de sus hermanos él tomó cinco hombres, y los presentó delante de Faraón.
 **3** Y dijo Faraón a sus hermanos: ¿Cuáles son sus trabajos? Y ellos dijeron a Faraón: Pastores de rebaño *son* tus siervos, tanto nosotros como nuestros padres.
 **4** Y dijeron a Faraón: Para vivir en la tierra hemos venido, porque no hay pasto para el rebaño los cuales son para tus siervos, pues grave es el hambre en la tierra de Kenáan. Y ahora, deja habitar por favor *a* tus siervos en la tierra de Goshén.
 **5** Y dijo Faraón a Iosef, diciendo: Tu padre y tus hermanos han venido a ti;
 **6** la tierra de Mitzráim delante de ti está, en lo mejor de la tierra habiten tu padre y tus her­manos; habiten en la tierra de Goshén, y si sabes y hay entre ellos hombres fuertes, nóm­bralos jefes de ganado sobre lo que es mío.
 **7** Y
-**1** trajo Iosef a Yaakov su padre y lo paró delante de Faraón, y bendijo Yaakov a Faraón.
+trajo Iosef a Yaakov su padre y lo paró delante de Faraón, y bendijo Yaakov a Faraón.
 **8** Y dijo Faraón a Yaakov: ¿Cuántos son los días de los años de tu vida?
 **9** Y dijo Yaakov a Faraón: Los días de los años de mi residencia son ciento treinta años; pocos y malos han sido los días de los años de mi vida, y no han superado a los días de los años de la vida de mis padres en los días de su residencia.
 **10** Y bendijo Yaakov a Faraón, y salió de delante de Faraón.

--- a/data/tth_2/markdown/devarim.md
+++ b/data/tth_2/markdown/devarim.md
@@ -287,7 +287,7 @@ __DEVARIM \(DEUTERONOMIO\)__ דברים
 **7**
 
 **1** Cuando te haya hecho entrar __יהוה__ tu Elo­him
-**1** a la tierra la cual tú entrarás allí para here­darla, y haya expulsado muchas na­ciones de delante de ti: el jití, el girgashí, el emorí, el kenaaní, el perizí, el jiví y el iebusí, siete nacio­nes *más* numerosas y tremendas que tú,
+a la tierra la cual tú entrarás allí para here­darla, y haya expulsado muchas na­ciones de delante de ti: el jití, el girgashí, el emorí, el kenaaní, el perizí, el jiví y el iebusí, siete nacio­nes *más* numerosas y tremendas que tú,
 **2** y los haya dado __יהוה__ tu Elohim delante de ti, y los hayas golpeado, habiendo destruido, los destruirás. No harás[^1159] para ellos pacto, y no los favorecerás.
 **3** Y no se casarán con ellos; tu hija no darás a su hijo, y su hija no tomarás para tu hijo.
 **4** Porque desviará a tu hijo de detrás de Mí *para que* sirva *a* otros dioses; y se calentará la nariz de __יהוה__ contra ustedes, y Él te destruirá pronto.
@@ -301,7 +301,7 @@ __DEVARIM \(DEUTERONOMIO\)__ דברים
 **9** Y sabrás que __יהוה__ tu Elohim, Él es Elo­him, Elohim fiel[^1162], *que *guarda el pacto y la bondad[^1163] para los que lo aman y[^1164] para los que guardan sus mandamientos, por mil genera­ciones.
 **10** Y retribuye a los que le odian hacia su rostro, para hacerlos perecer; no se demorará con el que le odia, hacia su rostro le retribuirá.
 **11** Y guardarás los mandamientos, los decretos y los procesos legales
-**1** que yo te ordeno hoy, para hacerlos.
+que yo te ordeno hoy, para hacerlos.
 
 *Bendiciones de la obediencia*
 
@@ -517,15 +517,15 @@ __DEVARIM \(DEUTERONOMIO\)__ דברים
 **16** Y todo su botín reunirás en medio de la pla­za, y quemarás en el fuego a la ciudad, y todo su botín completo para יהוה tu Elohim; y será un montón siempre, no se edificará más.
 **17** Y no se aferrará en tu mano nada de la pro­hibición, a fin de que regrese יהוה del enojo de su ira, y te dé bondad y te ame entrañablemente, y te haga aumentar, como juró a tus pa­dres;
 **18** porque escucharás a la voz de יהוה para guardar todos sus mandamientos que yo te or­deno
-**1** hoy, para hacer
-**1** lo recto en los ojos de יהוה tu Elohim.
+hoy, para hacer
+lo recto en los ojos de יהוה tu Elohim.
 
 **14**
 
 **1** Hijos[^1197] ustedes *son* para יהוה su Elo­him; no se cortarán y no se harán cal­­vi­cie entre sus ojos por un muerto.
 **2** Porque pueblo kadosh[^1198] *eres* tú
-**1** para יהוה tu Elohim; y te ha escogido יהוה
-**1** para ser a Él por pueblo, una adquisición[^1199] de *entre* todos los pue­blos que *están* sobre la faz de la tierra.
+para יהוה tu Elohim; y te ha escogido יהוה
+para ser a Él por pueblo, una adquisición[^1199] de *entre* todos los pue­blos que *están* sobre la faz de la tierra.
 
 *Animales puros e impuros*
 
@@ -544,7 +544,7 @@ __DEVARIM \(DEUTERONOMIO\)__ דברים
 **15** y la *bat haianáh*[^1214], el *tajmas*[^1215], el *shajaf*[^1216] y el *netz*[^1217], por su tipo;
 **16** el *cos*[^1218], el *ianshuf*[^1219]* *y la *tinshamet*[^1220],
 **17** y
-**1** la *kaat*[^1221], la *rajamáh*[^1222] y el *shálaj*[^1223],
+la *kaat*[^1221], la *rajamáh*[^1222] y el *shálaj*[^1223],
 **18** y la cigüeña y la garza, por su tipo; y la abubilla y el murciélago.
 **19** Y todo insecto volador, impuro es para us­te­­­des; no se comerán.
 **20** Toda ave pura podrán comer.
@@ -715,7 +715,7 @@ __DEVARIM \(DEUTERONOMIO\)__ דברים
 **1** Cuando salgas a la guerra sobre tus enemi­gos y veas caballo y carro, pue­blo *más *nume­ro­so que tú, no tengas temor de ellos, porque יהוה tu Elohim *está* conti­go, el que te hizo subir de la tierra de Mitzráim.
 **2** Y sucederá cuando se acerquen a la guerra, se acercará el sacerdote y hablará al pueblo,
 **3** y *les *dirá a ellos: “¡Escucha Israel, ustedes se acer­can
-**1** hoy a la guerra sobre sus enemigos; no se ablandará su corazón, no temerán y no se a­presurarán, y no temblarán debido a sus ros­tros!
+hoy a la guerra sobre sus enemigos; no se ablandará su corazón, no temerán y no se a­presurarán, y no temblarán debido a sus ros­tros!
 **4** Porque יהוה su Elohim, Él va con us­tedes para luchar por ustedes con sus enemigos, para salvarlos”.
 **5** Y hablarán los oficiales al pueblo, diciendo: “¿Quién es el hombre que ha edificado una ca­sa nue­va y no la ha inaugurado[^1251]? Se irá y volverá a su casa, no sea que muera en la guerra y otro hombre la inaugure[^1252].
 **6**¿Y quién es el hombre que plantó una viña y no la ha comenzado *a comer*? Se irá y volverá a su casa, no sea que muera en la guerra y otro hombre la comience *a comer*.
@@ -808,7 +808,7 @@ __DEVARIM \(DEUTERONOMIO\)__ דברים
 **2** No entrará bastardo[^1261] en la asamblea de יהוה, aún la generación décima, no entrará de él, en la asamblea de יהוה.
 **3** No entrará un amoní y un moabí en la asam­blea de יהוה, aún la generación décima no entrará de ellos en la asamblea de יהוה has­ta el olam[^1262],
 **4** por cosa que no fueron al encuentro de uste­des con pan y con agua en el camino, en su sa­lida
-**1** de Mitzráim, y que contrataron contra ti a Bi­­lam, hijo de Beor, de Petor, Aram Naharáim, para hacerte excluido.
+de Mitzráim, y que contrataron contra ti a Bi­­lam, hijo de Beor, de Petor, Aram Naharáim, para hacerte excluido.
 **5** Y no quiso יהוה tu Elohim escuchar a Bi­lam, e hizo girar יהוה tu Elohim para ti el desprecio para bendición, porque te ama יהוה tu Elohim.
 **6** No investigarás el shalom[^1263] de ellos ni el bien de ellos *por* todos tus días, para el olam.
 **7** *No distorsionarás *al* edomí, porque tu hermano es él; no distorsionarás *al* mitzrí, porque habitan­te fuiste en su tierra.
@@ -825,7 +825,7 @@ __DEVARIM \(DEUTERONOMIO\)__ דברים
 **18** No traerás pago de prostituta y precio de un perro *a* la casa de יהוה tu Elohim para todo voto, porque abominación de יהוה tam­­­­bién son los dos.
 **19** No harás interés[^1267] a tu her­mano: interés de di­nero, inte­rés de comida, interés de cualquier co­sa que se pueda hacer interés.
 **20** A un extranjero harás interés, pero a tu her­mano
-**1** no harás interés, a fin de que te bendiga יהוה en todo extender de tu mano sobre la tierra, la cual tú entrarás allí para heredarla.
+no harás interés, a fin de que te bendiga יהוה en todo extender de tu mano sobre la tierra, la cual tú entrarás allí para heredarla.
 **21** Cuando prometas un voto a יהוה tu Elo­him, no te retrasarás para pagarlo[^1268], porque demandando, lo demandará יהוה tu Elohim de ti, y será en ti pecado.
 **22** Pero cuando desistes de un voto, no será en ti pecado.
 **23** Lo que salga de tus labios guardarás y ha­rás, como prometiste a יהוה tu Elohim vo­lun­tariamente, lo cual hablaste con tu boca.
@@ -1052,7 +1052,7 @@ __DEVARIM \(DEUTERONOMIO\)__ דברים
 **23**“Azufre y sal, incinerada *está* toda su tierra, no se siembra y no se hace brotar, y no ascien­de en ella ninguna hierba, *es* como la destru­cción de Sedom y Gamoráh, de Admáh y Tzeboim, que destruyó יהוה en su ira y en su fu­ror”.
 **24** Y dirán todas las naciones: “¿Por qué hizo יהוה así a esta tierra? ¿Qué *es* este gran ar­dor de ira?”
 **25** Y dirán: “Porque abandonaron el pacto de יהוה, Elohim de sus padres, el cual hizo con ellos
-**1** cuando los sacó de la tie­rra de Mitzráim.
+cuando los sacó de la tie­rra de Mitzráim.
 **26** Y fueron y sirvieron otros dioses, y se incli­naron a ellos, dioses que no conocían y *que* Él no había repartido a ellos.
 **27** Y se encendió la ira de יהוה en esta tie­rra, para traer sobre ella toda la maldición es­cri­ta en este rollo;
 **28** y los desarraigó יהוה de sobre su tierra con ira, con furor y con gran enojo, y los lanzó a otra tierra, como este día”.

--- a/data/tth_2/markdown/hoshea.md
+++ b/data/tth_2/markdown/hoshea.md
@@ -54,7 +54,7 @@ __NEVIÍM \- YEHOSHÚA \(JOSUÉ\)__ יהושע
 **22** Y se fueron y llegaron a la montaña, y per­ma­necieron allí tres días, hasta *que* regresaron los perseguidores. Y *los* buscaron los persegui­dores por todo el camino, pero no *los* encontra­ron.
 **23** Y regresaron los dos hombres y descendie­ron de la montaña, y cruzaron, y vinieron a Yehoshúa, hijo de Nun, y contaron a él todo lo que les había acontecido.
 **24** Y dijeron a Yehoshúa: Ciertamente ha dado יהוה
-**1** en nuestras manos toda la tierra, y a­demás, se han derretido todos los habitantes de la tierra debido a nuestros rostros.
+en nuestras manos toda la tierra, y a­demás, se han derretido todos los habitantes de la tierra debido a nuestros rostros.
 
 *El paso del Iardén*
 
@@ -430,7 +430,7 @@ __NEVIÍM \- YEHOSHÚA \(JOSUÉ\)__ יהושע
 
 **1** Y estos *son los territorios* que hereda­ron los hijos de Israel en la tierra de Kenáan, los cuales les repartieron por herencia Eleazar el sacerdote y Yehoshúa, hijo de Nun, y las cabezas de los padres de las tribus de los hijos de Israel;
 **2** por goral[^1403]
-**1** fue* su herencia, conforme había orde­nado __יהוה__, por mano de Moshéh, a las nueve tri­bus y a la media tribu.
+fue* su herencia, conforme había orde­nado __יהוה__, por mano de Moshéh, a las nueve tri­bus y a la media tribu.
 **3** Porque había dado Moshéh la herencia de las dos tribus y de la media tribu del *otro* lado del Iardén; y a los leviím[^1404] no dio herencia en medio de ellos.
 **4** Porque eran los hijos de Iosef dos tribus, Menasheh y Efráim; y no dieron parte a los le­viím en la tierra, sino ciudades para habitar, y sus tierra exteriores para sus ganados y para sus propiedades.
 **5** Como había ordenado __יהוה__ a Moshéh, así hicieron los hijos de Israel, y repartieron la tie­rra.

--- a/data/tth_2/markdown/iehoshua.md
+++ b/data/tth_2/markdown/iehoshua.md
@@ -54,7 +54,7 @@ __NEVIÍM \- YEHOSHÚA \(JOSUÉ\)__ יהושע
 **22** Y se fueron y llegaron a la montaña, y per­ma­necieron allí tres días, hasta *que* regresaron los perseguidores. Y *los* buscaron los persegui­dores por todo el camino, pero no *los* encontra­ron.
 **23** Y regresaron los dos hombres y descendie­ron de la montaña, y cruzaron, y vinieron a Yehoshúa, hijo de Nun, y contaron a él todo lo que les había acontecido.
 **24** Y dijeron a Yehoshúa: Ciertamente ha dado יהוה
-**1** en nuestras manos toda la tierra, y a­demás, se han derretido todos los habitantes de la tierra debido a nuestros rostros.
+en nuestras manos toda la tierra, y a­demás, se han derretido todos los habitantes de la tierra debido a nuestros rostros.
 
 *El paso del Iardén*
 
@@ -430,7 +430,7 @@ __NEVIÍM \- YEHOSHÚA \(JOSUÉ\)__ יהושע
 
 **1** Y estos *son los territorios* que hereda­ron los hijos de Israel en la tierra de Kenáan, los cuales les repartieron por herencia Eleazar el sacerdote y Yehoshúa, hijo de Nun, y las cabezas de los padres de las tribus de los hijos de Israel;
 **2** por goral[^1403]
-**1** fue* su herencia, conforme había orde­nado __יהוה__, por mano de Moshéh, a las nueve tri­bus y a la media tribu.
+fue* su herencia, conforme había orde­nado __יהוה__, por mano de Moshéh, a las nueve tri­bus y a la media tribu.
 **3** Porque había dado Moshéh la herencia de las dos tribus y de la media tribu del *otro* lado del Iardén; y a los leviím[^1404] no dio herencia en medio de ellos.
 **4** Porque eran los hijos de Iosef dos tribus, Menasheh y Efráim; y no dieron parte a los le­viím en la tierra, sino ciudades para habitar, y sus tierra exteriores para sus ganados y para sus propiedades.
 **5** Como había ordenado __יהוה__ a Moshéh, así hicieron los hijos de Israel, y repartieron la tie­rra.

--- a/data/tth_2/markdown/iejezkel.md
+++ b/data/tth_2/markdown/iejezkel.md
@@ -488,7 +488,7 @@ Parábola de las águilas y la vid
 **22** Así ha dicho Adonai יהוה: Y tomaré Yo de la copa del cedro alto y lo pondré; de la cabe­za de sus brotes tiernos arrancaré y lo plantaré Yo sobre un monte alto y exaltado.
 **23** En el monte de altura de Israel lo plantaré; llevará rama y hará fruto, y será por cedro ma­jestuoso. Y morarán debajo de él todo pájaro, toda ala en la sombra de sus ramas morarán.
 **24** Y sabrán todos los árboles del campo que Yo soy יהוה; hago bajo al árbol elevado y elevo al árbol bajo; seco al árbol fresco y hago flore­cer al
-**1** árbol seco. Yo, יהוה, he hablado y he hecho.
+árbol seco. Yo, יהוה, he hablado y he hecho.
 
 La persona que peque morirá
 

--- a/data/tth_2/markdown/ionah.md
+++ b/data/tth_2/markdown/ionah.md
@@ -64,7 +64,7 @@ El descontento de Yonáh reprendido
 **4** Y dijo יהוה: ¿Haces bien en enfurecerte?
 **5** Y salió Yonáh de la ciudad y se sentó al este de la ciudad; e hizo para sí allí un cobertizo[^3448] y se sentó debajo de él en la sombra, hasta que pudiera ver qué sucede­ría en la ciudad.
 **6** Y dispuso יהוה Elohim un ricino[^3449] y subió por encima de Yonáh para ser sombra sobre su cabeza y lo librara de su mal. Y se alegró Yonáh por el ricino con gran alegría.7
-**1** Pero dispuso Elohim un gusano al subir el amanecer del día siguiente, e hirió al ricino, y se secó.
+Pero dispuso Elohim un gusano al subir el amanecer del día siguiente, e hirió al ricino, y se secó.
 **8** Y sucedió que cuando brilló el sol, dispuso Elohim un viento del este silencioso, e hirió el sol sobre la cabeza de Yonáh, y desfalleció[^3450], y pidió a su ser morirse, y dijo: ¡Mejor es mi muerte que mi vida!
 **9** Y dijo Elohim a Yonáh: ¿Haces bien en enfu­recerte por el ricino? Y él dijo: Hago bien en enfurecerme hasta la muerte.
 **10** Y dijo יהוה: Tú te apiadaste por el ricino en el que no trabajaste, ni lo hiciste crecer, que era hijo de una noche, y siendo hijo de una no­che, pereció;

--- a/data/tth_2/markdown/irmeiahu.md
+++ b/data/tth_2/markdown/irmeiahu.md
@@ -173,7 +173,7 @@ Impiedad de Yerushaláim y Iehudáh
 **12** Han engañado a יהוה, y dijeron: “No es Él,y no vendrá sobre nosotros mal, y espada y hambre no veremos”.
 **13** Y los profetas serán por viento, y la palabra no estará en ellos.Así se les hará a ellos.
 **14** Por eso, así dijo יהוה, Elohei Tzebaot:Porque han hablado ustedes esta palabra, heme aquí, pondré mis palabras en tu boca por fuego,
-**1** maderas, y los consumirá.
+maderas, y los consumirá.
 **15** Heme aquí, haré venir sobre ustedes una na­­ción desde lejos,
 **16** Su aljaba es como tumba abierta, todos ellos poderosos.
 **17** Y comerá tu cosecha y tu pan, comerán a tus hijos y tus hijas,comerán tu rebaño y tu ganado, comerán tus viñas y tus higueras;destrozarán las ciudades de tus fortalezas, que tú confías en ellas, con la espada.

--- a/data/tth_2/markdown/lukas.md
+++ b/data/tth_2/markdown/lukas.md
@@ -1141,7 +1141,7 @@ a todos nuestros deudores.Y no nos hagas entrar en la prueba,sino rescátanos de
 **3** Y había una viuda en aquella ciudad, y venía a él, diciendo: “Defiende mi causa[^1073] de mi opresor”,
 **4** pero él no quiso por un tiempo. Y después de eso, dijo en su corazón: “Aunque no temo a Elohim y al hombre no atiendo,
 **5** ciertamente,
-**1** porque esta viuda me ha cansado, la defenderé[^1074], para que no venga siempre ni me apresure”.
+porque esta viuda me ha cansado, la defenderé[^1074], para que no venga siempre ni me apresure”.
 **6** Y dijo Adonai: Escuchen lo que dijo el juez injusto.
 **7** ¿Y Elohim no defenderá[^1075] a sus escogidos, que claman a Él día y noche, y será prolongado de ira sobre ellos?
 **8** Verdaderamente Yo les digo que hará su defensa[^1076] con rapidez. Por eso, cuando venga el Ben Ha’Adam, ciertamente hallará emunah[^1077] en la tierra.
@@ -1340,7 +1340,7 @@ La ofrenda de la viuda
 **2** Y vio también a una viuda pobre echar ahí dos monedas;
 **3** y dijo: En verdad Yo les digo que esta viuda pobre echó más que todos ellos;
 **4** porque todos estos de sus sobras echaron para las ofrendas[^1116] a Elohim,
-**1** pero esta, de su escasez, echó toda posesión que ella tenía.
+pero esta, de su escasez, echó toda posesión que ella tenía.
 
 Profecía de la destrucción del Santuario
 
@@ -1489,7 +1489,7 @@ Profecía de la destrucción del Santuario
 
 **66** Y sucedió *que *en la mañana se reunieron los ancianos del pueblo, los jefes de los sacerdotes y los escribas, y lo llevaron a su asamblea,
 **67** diciendo:
-**1** Si Tú eres el Mesías, dínoslo. Y les dijo: Si les digo, no creerán;
+Si Tú eres el Mesías, dínoslo. Y les dijo: Si les digo, no creerán;
 **68** y si *les* pregunto, no me responderán ni me soltarán.
 **69** Desde ahora, el Ben Ha’Adam[^1136] estará sentado a la diestra del poder de Elohim.
 **70** Y dijeron todos: Y también, ¿Tú eres el Hijo de Elohim? Y Él les dijo: Ustedes han dicho que Yo soy.

--- a/data/tth_2/markdown/markos.md
+++ b/data/tth_2/markdown/markos.md
@@ -127,7 +127,7 @@ El Dueño del Shabat
 *Multitudes van detrás de Yeshúa*
 
 **7** Y
-**1** se apartó Yeshúa con sus discípulos hacia el mar, y mucha gente venía detrás de Él desde Galil, desde Iehudáh,
+se apartó Yeshúa con sus discípulos hacia el mar, y mucha gente venía detrás de Él desde Galil, desde Iehudáh,
 **8** desde Ierushalem y desde Edom, y del otro lado del Iardén, y desde Tzor y Tzidón, mucha gente; conforme oyeron cuánto había hecho, vinieron a Él.
 **9** Y dijo a sus discípulos que acercasen a Él el bote, por causa del pueblo, para que no lo oprimieran.
 **10** Porque había sanado a muchos, así que todos los que tenían plaga caían sobre Él para tocarlo;

--- a/data/tth_2/markdown/melajim_alef.md
+++ b/data/tth_2/markdown/melajim_alef.md
@@ -492,7 +492,7 @@ Shelomóh se desvía de __יהוה__
 **9** Y se enojó __יהוה__ con Shelomóh, porque había inclinado su corazón de __יהוה__, Elohim de Israel, que se le había aparecido dos veces;
 **10** y le había ordenado sobre esta cosa, para no ir tras de otros dioses, pero no guardó lo que ha­bía ordenado __יהוה__.
 
-Elohim**1** levanta adversarios a Shelomóh
+*Elohim levanta adversarios a Shelomóh*
 
 **11** Y dijo __יהוה__ a Shelomóh: Porque ha sido esto contigo, y no has guardado mi pacto y mis estatutos que he ordenado sobre ti, ciertamente arrancaré[^2029] el reino de so­bre ti, y lo daré a tu siervo.
 **12** Sin embargo, en tus días no lo haré, por causa de David tu padre, de la mano de tu hijo lo arrancaré.
@@ -598,7 +598,7 @@ Iarobam y el hombre de Elohim
 **22** y volviste, y comiste pan y bebiste agua en el lugar el cual te habló: ‘No comerás pan y no be­­be­rás agua’, no entrará tu cadáver en la tum­ba de tus padres”.
 **23** Y sucedió que después de su comer pan y después de su beber, ató el asno para él, para el profeta que lo había hecho volver.
 **24** Y se fue, y lo encontró un león en el camino y lo mató; y estuvo su cadáver tirado en el ca­mino, y el asno parado junto a él, y el león pa­rado
-**1** junto al cadáver.
+junto al cadáver.
 **25** Y he aquí, unos hombres pasaron y vieron el cadáver tirado en el camino y el león parado junto al cadáver; y fueron y hablaron en la ciu­dad en la cual el profeta anciano habitaba.
 **26** Y oyó el profeta que lo había hecho vol­­ver del camino, y dijo: El hombre de Elohim es él, que se rebeló a la boca de __יהוה__; y lo entregó __יהוה__ al león, y lo desgarró y lo mató, con­for­me a la palabra de __יהוה__ que le había ha­bla­do.
 **27** Y habló a sus hijos, diciendo: Aten para mí al asno. Y lo ataron.

--- a/data/tth_2/markdown/micah.md
+++ b/data/tth_2/markdown/micah.md
@@ -41,7 +41,7 @@ Juicio contra los opresores
 **9** A las mujeres de mi pueblo expulsaron de la casa de su placer;de sobre sus niños quitaron mi esplendor para siempre.
 **10** ¡Levántense y váyanse!, porque no es este el lugar de descansopor causa de la impureza que destruirá, y destrucción dolorosa.
 **11** Si un hombre anda
-**1** en viento y falsedad, miente: “Destilaré para ti de vino y de bebida embriagante”,sería uno que destila de este pueblo.
+en viento y falsedad, miente: “Destilaré para ti de vino y de bebida embriagante”,sería uno que destila de este pueblo.
 
 **12** Ciertamente[^3468] reuniré, Yaakov, todo tú;ciertamente[^3469] recogeré al remanente de Israel.Juntos los pondré como ovejas del redil; como rebaño en medio de su pasto,harán mucho ruido por la multitud de hombres.
 **13** Subirá el que abre brecha delante de ellos; abrirán brecha y pasarán la puerta, y saldrán por ella; y pasará su rey delante de ellos,y יהוה a su cabeza.

--- a/data/tth_2/markdown/shemot.md
+++ b/data/tth_2/markdown/shemot.md
@@ -74,7 +74,7 @@ __SHEMOT \(ÉXODO\)__ שמות
 **11** Pero dijo Moshéh a Elohim: ¿Quién soy yo *para* ir a Faraón, y pues, sacar a los hijos de Israel de Mitzráim?
 **12** Y Él dijo: Porque Yo seré contigo, y ésta para ti *será *una señal que Yo te he enviado: cuando saques al pueblo de Mitzráim, servirán a Elohim en este monte.
 **13** Y dijo Moshéh a Elohim: He aquí, yo voy a los hijos de Israel, y les diré: “El Elohim de sus padres
-**1** me ha enviado a ustedes”. Y ellos me dirán: “¿Cuál es su nombre?”, ¿qué les diré?
+me ha enviado a ustedes”. Y ellos me dirán: “¿Cuál es su nombre?”, ¿qué les diré?
 **14** Y dijo Elohim a Moshéh: Ehyeh Asher Ehyeh[^264]. Y dijo: Así dirás a los hijos de Israel: Ehyeh[^265] me ha enviado a ustedes.
 **15** Y dijo además Elohim a Moshéh: Así dirás a los hijos de Israel:
 
@@ -270,7 +270,7 @@ Este es mi Nombre para siempre,
 **31** E hizo יהוה conforme a la palabra de Moshéh, y retiró la mez­cla *de insectos *de Faraón, de sus siervos y de su pueblo; no quedó uno.
 **32** Pero permaneció pesado Faraón su corazón tam­bién esta vez, y no envió al pueblo.
 
-**1** Quinta plaga: peste en el ganado*
+Quinta plaga: peste en el ganado*
 
 **9**
 
@@ -309,7 +309,7 @@ Este es mi Nombre para siempre,
 **27** Y envió Faraón y llamó a Moshéh y a Aha­rón, y* les *dijo a ellos: He pecado esta vez; יהוה es justo, y yo y mi pueblo *somos* malvados.
 **28** Pidan a יהוה, ha habido muchas voces de Elohim, y granizo. Los en­viaré, y no se quedarán más* aquí*.
 **29** Y le dijo Moshéh: Cuando salga de la ciu­dad extenderé mis palmas a יהוה; las voces cesarán y el granizo no es­tará más, para que sepas que de יהוה
-**1** es la tierra.
+es la tierra.
 **30** Pero tú y tus siervos, sé que aún no temen delante de יהוה Elohim.
 **31** Y el lino y la cebada fueron golpeados, pues la cebada *era* Abib[^288], y el lino *estaba en* caña;
 **32** pero el trigo y la espelta[^289] no fueron golpeados, pues estos son tardíos.
@@ -511,7 +511,7 @@ Cantaré a יהוה porque altamente es exal­­­tado[^306]; *al *caballo y su 
 **6** Tu diestra, יהוה, majestuosa[^312] en poder; tu diestra, יהוה, ha destrozado al enemigo.
 **7** Y en la multitud de tu grandeza destruyes a los que se levantan contra ti, envías tu ira, y los consumes como paja.
 **8** Y en el aliento de tus narices se acu­mu­laron las aguas, se pararon como un pilar de agua las corrientes[^313];
-**1** se congelaron los abismos en el corazón del mar.
+se congelaron los abismos en el corazón del mar.
 **9** Dijo el enemigo: “Perseguiré, superaré, divi­diré el botín, se saciará mi ser; vaciaré mi espada, los destruirá mi mano”.
 **10** Soplaste con tu viento, los cubrió el mar, se hundieron como plomo en las aguas majestuosas.
 **11**¿Quién como Tú entre los dioses, יהוה?
@@ -550,7 +550,7 @@ Canten a יהוה porque altamente es exal­tado[^319],
 **5** Y sucederá en el día sexto, prepararán lo que traigan, y *la porción* será doble, por encima de lo que recojan día *a* día.
 **6** Y dijo Moshéh. y Aharón. a todos los hijos de Israel: *Por* la tarde sabrán que יהוה *los *ha sa­cado a ustedes de la tierra de Mitzráim;
 **7** Y* por*
-**1** la mañana verán la gloria de יהוה, por*que* Él escucha sus murmuraciones sobre יהוה; pero nosotros, ¿qué *somos* para que se quejen sobre nosotros?
+la mañana verán la gloria de יהוה, por*que* Él escucha sus murmuraciones sobre יהוה; pero nosotros, ¿qué *somos* para que se quejen sobre nosotros?
 **8** Y dijo Moshéh: *Esto sucederá* cuando les dé יהוה por la tarde carne para comer, y pan por la mañana para saciarse; por*que* ha escuchado יהוה sus quejas que murmuran sobre Él; pero nosotros, ¿qué *somos*?, no *son *sobre nosotros sus murmuraciones, pues *son* sobre יהוה.
 **9** Y dijo Moshéh a Aharón: Di a toda la congregación de los hijos de Israel: “Acér­quen­se delante de[^324] יהוה, por­que *Él* ha escuchado sus murmuraciones”.
 **10** Y sucedió *que* cuando habló Aharón a toda la congregación de los hijos de Israel, se giraron hacia el desierto, y he aquí, la gloria de יהוה apareció en la nube.
@@ -610,7 +610,7 @@ Canten a יהוה porque altamente es exal­tado[^319],
 **18**
 
 **1** Y escuchó Itró, sacerdote
-**1** de Midián, suegro de Moshéh, todo lo que había hecho Elohim por Moshéh y por Israel su pueblo, porque sacó יהוה a Israel de Mitzráim.
+de Midián, suegro de Moshéh, todo lo que había hecho Elohim por Moshéh y por Israel su pueblo, porque sacó יהוה a Israel de Mitzráim.
 **2** Y tomó Itró, suegro de Moshéh, a Tziporáh, mujer de Moshéh, después de que la había enviado;
 **3** y a sus dos hijos, que el nombre de uno era Guershom, porque él dijo: Extranjero[^339] he sido en tierra extranjera[^340].
 **4** Y el nombre del otro era Eliezer, porque *dijo: *El Elohim de mi padre *fue* mi ayuda[^341], y me rescató de la espada de Faraón.
@@ -796,7 +796,7 @@ Canten a יהוה porque altamente es exal­tado[^319],
 **2** No estarás detrás de muchos para *hacer *males, y no responderás en una contienda incli­nándote detrás de muchos para torcer.
 **3** Y *al* débil no favorecerás[^382] en su contienda.
 **4** Cuando te encuentres un buey
-**1** de tu enemigo o su asno perdido, devolviendo, lo devolverás a él.
+de tu enemigo o su asno perdido, devolviendo, lo devolverás a él.
 **5** Cuando veas el asno de quien te odia acostado debajo de su carga, ¿desistirás de liberarlo? Liberando, lo liberarás con él.
 **6** No torcerás el proceso legal de tu necesitado en su contienda.
 **7** De palabra de mentira te alejarás, y *al* inocente y justificado no matarás, porque no justificaré al condenado.

--- a/data/tth_2/markdown/shemuel_alef.md
+++ b/data/tth_2/markdown/shemuel_alef.md
@@ -7,7 +7,7 @@ __SHEMUEL ALEF \(1 SAMUEL\)__א שמואל
 **1** Y había un hombre de Ramataim Tzofím, del monte de Efráim, y su nombre *era* El­kanah, hi­jo de Ierojám, hijo de Elihú, hijo de Toju, hijo de Tzuf efratí[^1598].
 **2** Y para él *había* dos mujeres, el nombre de una *era* Janah, y el hombre de la segunda *era* Penináh; y había para Penináh niños, pero Janah no tenía niños.
 **3** Y subía este hombre de su ciudad cada año[^1599] para inclinarse y para sa­cri­ficar para יהוה
-**1** Tzebaot en Shiloh. Y allí *estaban* los dos hijos de Elí, Jofní y Pinjas, sacerdotes de יהוה.
+Tzebaot en Shiloh. Y allí *estaban* los dos hijos de Elí, Jofní y Pinjas, sacerdotes de יהוה.
 **4** Y fue el día, y sacrificó Elkanah, y dio a Pe­ni­náh su mujer y a todos sus hijos y sus hijas porciones;
 **5** pero a Janah dio una porción, una de narices, porque a Janah él amaba, pero יהוה había cerrado su matriz.
 **6** Y la hacía enojar su angustiadora, incluso *con* ira, a fin de hacerla enfurecer, porque ha­bía cerrado יהוה detrás de su matriz.
@@ -114,7 +114,7 @@ __SHEMUEL ALEF \(1 SAMUEL\)__א שמואל
 **13** Y he dado a conocer a él que juzgaré Yo a su casa hasta siempre por la iniquidad que él conoció, pues se despreciaron a sí *mismos* sus hi­jos, y no reprendió él contra ellos.
 **14** Y por lo tanto, he jurado a la casa de Elí: ¡Si fuera cubierta la iniquidad de la casa de Elí con sacrificio y con ofrenda hasta el olam!
 **15** Y se acostó Shemuel hasta la mañana; y a­brió las puertas de la casa de יהוה; y She­muel
-**1** tenía miedo de dar a conocer la visión a Elí.
+tenía miedo de dar a conocer la visión a Elí.
 **16** Pero llamó Elí a Shemuel, y dijo: Shemuel, hijo mío. Y él dijo: Heme aquí.
 **17** Y él dijo: ¿Cuál es la palabra que habló a ti? Por favor, no la ocultes de mí. Así hará a ti Elohim, y así aumentará, si ocultas de mí una cosa de toda la palabra que habló a ti.
 **18** Y le contó Shemuel todas las palabras, y no escondió de él *nada*. Y él dijo: יהוה es Él, lo bueno en sus ojos hará.

--- a/data/tth_2/markdown/shoftim.md
+++ b/data/tth_2/markdown/shoftim.md
@@ -183,7 +183,7 @@ la tierra tembló, también los cielos gotearon,
 **9** Mi corazón es para los legisladores de Israel,
 **10** Los que cabalgan en asnas blancas, los que se sientan sobre vestimentas,y los que andan por el camino, conversen.
 **11** Del sonido de los que dividen entre los a­bre­­vaderos,
-**1** de sus campesinos en Israel.Entonces descendió a las puertas el pueblo de יהוה.
+de sus campesinos en Israel.Entonces descendió a las puertas el pueblo de יהוה.
 **12** Despierta, despierta, Deboráh; despierta, despierta, habla una canción.Levántate, Barak, y captura tus cautivos, hijo de Abinoam.
 **13** Entonces descendió el sobreviviente a los majestuosos; el pueblo de יהוה descendió a mí con los poderosos;
 **14** de Efráim los radicados en Amalek,
@@ -524,7 +524,7 @@ la tierra tembló, también los cielos gotearon,
 **20** Y sucedió *que* cuando subió la llama de so­bre el altar hacia el cielo, ascendió el mensajero de יהוה en la llama del altar. Y Manóaj y su mu­jer vieron, y cayeron sobre sus rostros a tie­rra.
 **21** Y no volvió más el mensajero de יהוה a apa­recer a Manóaj y a su mujer. Entonces conoció Manóaj que el mensajero de יהוה *era* él.
 **22** Y dijo Manóaj a su mujer: ¡Muriendo, morire­mos!
-**1** Porque *a* Elohim hemos visto.
+Porque *a* Elohim hemos visto.
 **23** Pero le dijo su mujer: ¡Si hubiera deseado יהוה hacernos morir, no habría tomado de nuestras manos la ofrenda ascendida y la o­fren­da de grano[^1556], y no nos habría hecho ver to­das estas *cosas*, y como *este* tiempo, no nos habría hecho escuchar *cosa* como esta!
 **24** Y dio a luz la mujer un hijo, y llamó su nom­bre Shimshón. Y creció el niño, y lo bendijo יהוה.
 **25** Y comenzó el Rúaj[^1557] de יהוה a impulsarse en Majanéh Dan, entre Tzoráh y Eshtaol.

--- a/data/tth_2/markdown/tehilim.md
+++ b/data/tth_2/markdown/tehilim.md
@@ -3919,7 +3919,7 @@ no retendrá el bien para los que andan en plenitud.
 **85**
 
 **1** Te reconciliaste, __יהוה__,
-**1** con* *tu tierra,
+con* *tu tierra,
 
 has hecho volver el cautiverio de Yaakov.
 

--- a/data/tth_2/markdown/vaikra.md
+++ b/data/tth_2/markdown/vaikra.md
@@ -99,7 +99,7 @@ __VAIKRÁ \(LEVÍTICO\)__ ויקרא
 **28** o se le hace saber su pecado que ha pecado, traerá *como* su ofrenda una peluda de las ca­bras, completa, hembra, por su pecado que ha pecado.
 **29** Y pondrá su mano sobre la cabeza de la ofrenda por el pecado, y sacrificará a la ofren­da por el pecado en el lugar de la ofrenda ascendida.
 **30** Y tomará el sacerdote de su sangre con su dedo, y *la* pondrá sobre los cuernos del altar
-**1** de la ofrenda ascendida, y toda la sangre *res­tante* derramará en la base del altar.
+de la ofrenda ascendida, y toda la sangre *res­tante* derramará en la base del altar.
 **31** Y toda su grasa retirará, como es retirada la grasa de sobre el sacrificio de las retribuciones; y *la* quemará el sacerdote en el altar, para olor calmante para יהוה. Y el sacerdote hará expiación por él, y será perdonado a él.
 **32** Y si un cordero él trae para ofrenda por el pecado, una hembra completa traerá.
 **33** Y apoyará su mano sobre la cabeza de la ofrenda por el pecado, y la sacrificará para ofrenda por el pecado en el lugar el cual sacrifican a la ofrenda ascendida.
@@ -134,7 +134,7 @@ __VAIKRÁ \(LEVÍTICO\)__ ויקרא
 **2** La persona que peque y transgreda apro­pián­dose contra יהוה, y engaña a su amigo en un depósito o en algo dado en mano, o por ro­bo, o *por* *haber* explotado a su amigo,
 **3** o ha encontrado algo perdido y ha engañado en ello, y ha jurado en mentira sobre una de todas *las cosas* que puede hacer el hombre, pecando en ellas;
 **4** y
-**1** será, cuando peque y sea culpable, regre­sará lo robado que robó, o la explotación *con* que oprimió, o el depósito que fue depositado con él, o la cosa perdida que ha encontrado,
+será, cuando peque y sea culpable, regre­sará lo robado que robó, o la explotación *con* que oprimió, o el depósito que fue depositado con él, o la cosa perdida que ha encontrado,
 **5** o de todo por lo que ha jurado falsa­mente; y lo pagará en su totalidad[^571], y su quinta parte[^572] añadirá por eso. A quien eso le pertenece *lo* dará en el día de su ofren­da de culpa[^573].
 **6** Y su ofrenda de culpa traerá, para יהוה, un carnero completo del rebaño, conforme a tu valoración, para ofrenda de culpa, al sacerdote.
 **7** Y hará reconciliación el sacerdote por él delante de יהוה, y le será perdonado, por una de todas *las cosas* que pudo haber hecho para ser cul­pable en ella.
@@ -393,7 +393,7 @@ __VAIKRÁ \(LEVÍTICO\)__ ויקרא
 **17** Y lo mirará el sacerdote, y he aquí, se ha vuelto el daño blanco, proclamará puro el sacerdote al *que tenía* el daño; puro es él.
 **18** Y cuando la carne tenga en su piel una ebullición, y se sane,
 **19** y haya en lugar de la ebullición una hinchazón
-**1** blanca, o una mancha blanca rojiza, se mostrará al sacerdote;
+blanca, o una mancha blanca rojiza, se mostrará al sacerdote;
 **20** y *la* mirará el sacerdote, y he aquí, la apariencia de ella es *más* baja que la piel, y su pelo se ha vuelto blanco, lo declarará impuro el sacerdote; es un daño de tzaraat, en la ebullición ha florecido.
 **21** Pero si la ve el sacerdote, y he aquí, no hay en ella pelo blanco, y *más* baja no está que la piel, y esta se ha oscurecido, lo encerrará el sacerdote siete días;
 **22** y si, extendiendo, se extiende en la piel, lo de­clarará impuro el sacerdote; es daño__.23 __Pero si en su lugar permanece la mancha blanca *y* no se ha extendido, la quemadura de la ebullición es esto; lo declarará puro el sacerdote.
@@ -583,7 +583,7 @@ __VAIKRÁ \(LEVÍTICO\)__ ויקרא
 **3** Cada hombre[^730] de la casa de Israel que sacrifique un buey, o un cordero o una cabra en el campamento, o el que *lo* sacrifique fuera del campamento,
 **4** y a la entrada de la Tienda del Mo’ed[^731] no lo lleva para acercar un korbán[^732] para יהוה, delante del Mishkán de יהוה, la sangre será contada a ese hombre. Sangre ha derramado, y será cortado ese hombre de entre su pueblo.
 **5** Con el fin de que puedan traer los hijos de Israel sus sacrificios que ellos sacrificaban so­bre la faz del campo, y los traigan a יהוה
-**1** a la entrada de la Tienda del Mo’ed, al sacerdote, y los sacrifiquen *como *sacrificios de retribución[^733] para יהוה.
+a la entrada de la Tienda del Mo’ed, al sacerdote, y los sacrifiquen *como *sacrificios de retribución[^733] para יהוה.
 **6** Y rociará el sacerdote la sangre sobre el altar de יהוה *a* la entrada de la Tienda del Mo’ed, y quemará la grasa, para olor calmante para יהוה.
 **7** Y no sacrificarán más sus sacrificios a los machos cabríos *con* los cua­les ellos adulteraban detrás de ellos. Esta­tuto olam[^734] será esto para ustedes por sus gene­raciones”.
 **8** Y a ellos dirás: “Cada hombre de la casa de Israel, o del extranjero que habita entre ellos, que ascienda una ofren­da ascendida[^735] o un sacrificio,
@@ -695,7 +695,7 @@ __VAIKRÁ \(LEVÍTICO\)__ ויקרא
 **13** Y el hombre que se acueste con varón como acostarse con mujer, abominación han hecho los dos; muriendo, morirán. Su sangre* será* en ellos.
 **14** Y el hombre que tome a una mujer y a la madre de ella, plan malvado[^763] es esto; en el fuego los quemarán, a él y a ellas, y no habrá plan malvado entre ustedes.
 **15** Y el hombre que dé su acostar con un animal, muriendo, morirá; y el animal
-**1** matarán.
+matarán.
 **16** Y la mujer que se acerque a cualquier animal para acostarse con él, matarás a la mujer y al animal, muriendo, morirán; su sangre *será* en ellos.
 **17** Y el hombre que tome a su hermana, hija de su padre o hija de su madre, y ve su desnudez, y ella ve la desnudez de él, vergüenza es esto; serán cortados ante los ojos de los hijos de su pueblo. La desnudez de su hermana ha descu­bierto, su iniquidad cargará.
 **18** Y el hombre que se acueste con una mujer adolorida *en su menstruación*, y des­cu­bre su desnudez, el flujo[^764] de ella ha despertado, y ella ha descubierto el flujo de su sangre; serán cortados los dos de entre su pue­blo.
@@ -811,7 +811,7 @@ __VAIKRÁ \(LEVÍTICO\)__ ויקרא
 **25** Cualquier trabajo de servicio no harán, y acercarán una ofrenda de fuego a יהוה”.
 **26** Y habló יהוה a Moshéh, diciendo:
 **27** Sin embargo, en el décimo* día* del mes
-**1** sép­timo, este es el día de las reconciliaciones[^806]; una convocación de santidad será para ustedes, y afligirán sus gargantas[^807], y acer­carán una ofrenda de fuego a יהוה.
+sép­timo, este es el día de las reconciliaciones[^806]; una convocación de santidad será para ustedes, y afligirán sus gargantas[^807], y acer­carán una ofrenda de fuego a יהוה.
 **28** Y cualquier trabajo no harán en ese mismo día, porque es el día de las reconciliaciones, para cubrir sobre ustedes delante de יהוה su Elohim.
 **29** Pues, cualquier persona que no esté afligida en ese mismo día, será cortada de su pueblo.
 **30** Y toda persona que haga cualquier trabajo en ese mismo día, destruiré a esa persona de entre su pueblo.
@@ -969,8 +969,8 @@ __VAIKRÁ \(LEVÍTICO\)__ ויקרא
 **38** Y se perderán entre las naciones y los co­merá la tierra de sus enemigos.
 **39** Y los que queden entre ustedes su pudrirán en su iniquidad en las tierras de sus enemigos; y también en las iniquidades de sus padres *que están* con ellos se pudrirán.
 **40** Y si arrojan su iniquidad y la iniquidad de sus padres, por sus infide­lidades
-**1** con* las cuales
-**1** fueron infieles contra Mí, y también que hayan an­dado conmigo con frialdad,
+con* las cuales
+fueron infieles contra Mí, y también que hayan an­dado conmigo con frialdad,
 **41** también Yo andaba con ellos con frialdad, y los lleve en la tierra de sus enemigos; o *si* en verdad se humilla su corazón incircunciso, y entonces aceptan su iniquidad,
 **42** recordaré mi pacto *con* Yaakov, y también mi pacto *con* Itzjak, y también mi pacto *con *Abraham recordaré, y la tierra recordaré.
 **43** Y la tierra será abandonada debido a ellos, y satisfará sus Shabatot cuando quede desolada ella debido a ellos; pero ellos aceptarán su iniquidad, porque y a causa de que mis procesos legales aborrecieron y mis decretos despreció su ser.

--- a/scripts/tth_2/fix_false_restart_markers.py
+++ b/scripts/tth_2/fix_false_restart_markers.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Repair deterministic false verse restart markers in TTH_2 markdown sources.
+
+Targets chapter-internal non-increasing "**1** ..." lines that are known
+DOCX/markdown wrap artifacts. In those cases the marker is removed and the
+line is kept as continuation text.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MARKDOWN_DIR = ROOT / "data" / "tth_2" / "markdown"
+
+CHAPTER_RE = re.compile(r"^\*\*(\d+)\*\*\s*$")
+VERSE_RE = re.compile(r"^\*\*(\d+)\*\*\s+(.+)$")
+
+
+@dataclass
+class Fix:
+    book: str
+    chapter: int
+    line: int
+    previous_verse: int
+    original: str
+
+
+def should_fix_false_restart(verse_num: int, previous_verse: int | None, verse_text: str) -> bool:
+    if previous_verse is None or previous_verse < 1:
+        return False
+    if verse_num != 1:
+        return False
+    trimmed = verse_text.strip()
+    if not trimmed:
+        return False
+    # Verse numbering should never restart to 1 inside a chapter after verse 1.
+    return previous_verse >= 1
+
+
+def process_file(path: Path) -> tuple[int, list[Fix]]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    updated: list[str] = []
+
+    chapter: int | None = None
+    previous_verse: int | None = None
+    fixes: list[Fix] = []
+
+    for idx, line in enumerate(lines, start=1):
+        chapter_match = CHAPTER_RE.match(line.strip())
+        if chapter_match:
+            chapter = int(chapter_match.group(1))
+            previous_verse = None
+            updated.append(line)
+            continue
+
+        verse_match = VERSE_RE.match(line)
+        if verse_match and chapter is not None:
+            verse_num = int(verse_match.group(1))
+            verse_text = verse_match.group(2)
+
+            if should_fix_false_restart(verse_num, previous_verse, verse_text):
+                fixes.append(
+                    Fix(
+                        book=path.stem,
+                        chapter=chapter,
+                        line=idx,
+                        previous_verse=previous_verse,
+                        original=line,
+                    )
+                )
+                updated.append(verse_text)
+                continue
+
+            previous_verse = verse_num
+            updated.append(line)
+            continue
+
+        updated.append(line)
+
+    if fixes:
+        path.write_text("\n".join(updated) + "\n", encoding="utf-8")
+
+    return len(fixes), fixes
+
+
+def repair_books(book_keys: set[str] | None = None, verbose: bool = True) -> tuple[int, int, list[Fix]]:
+    total_fixes = 0
+    touched_files = 0
+    all_fixes: list[Fix] = []
+
+    for path in sorted(MARKDOWN_DIR.glob("*.md")):
+        if book_keys is not None and path.stem not in book_keys:
+            continue
+
+        count, fixes = process_file(path)
+        if count:
+            touched_files += 1
+            total_fixes += count
+            all_fixes.extend(fixes)
+            if verbose:
+                print(f"[fixed] {path.name}: {count}")
+
+    if verbose:
+        print(f"TOTAL_FIXED={total_fixes}")
+        if all_fixes:
+            print("SAMPLE_FIXES:")
+            for fix in all_fixes[:20]:
+                print(
+                    f"- {fix.book} ch{fix.chapter} line{fix.line} prev={fix.previous_verse}: "
+                    f"{fix.original[:120]}"
+                )
+
+    return touched_files, total_fixes, all_fixes
+
+
+def main() -> int:
+    repair_books(verbose=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tth_2/main.py
+++ b/scripts/tth_2/main.py
@@ -36,6 +36,10 @@ except ImportError:
             self.total = total or (len(iterable) if iterable else 0)
             self.n = 0
 
+        @staticmethod
+        def write(message: str):
+            print(message)
+
         def __iter__(self):
             for item in self.iterable:
                 yield item
@@ -74,6 +78,7 @@ try:
     from format_validator import get_format_validator, print_book_report
     from config import BOOKS_INFO
     from section_headers import detect_section_headers_in_json
+    from fix_false_restart_markers import repair_books
 except ImportError:
     # Fallback for direct execution
     import docx_to_md
@@ -83,6 +88,7 @@ except ImportError:
     import format_validator
     import config
     import section_headers
+    import fix_false_restart_markers
     convert_docx = docx_to_md.convert_docx
     split_markdown = book_splitter.split_markdown
     TTH2BookSplitter = book_splitter.TTH2BookSplitter
@@ -92,6 +98,7 @@ except ImportError:
     print_book_report = format_validator.print_book_report
     BOOKS_INFO = config.BOOKS_INFO
     detect_section_headers_in_json = section_headers.detect_section_headers_in_json
+    repair_books = fix_false_restart_markers.repair_books
 
 
 # Default directories
@@ -300,9 +307,40 @@ def convert_book_to_json(book_key: str, verbose: bool = True):
 
     json_file = JSON_DIR / f"{book_key}.json"
 
+    # Normalize known markdown wrap artifacts before conversion so reruns are stable.
+    _, repaired_markers, _ = repair_books(book_keys={book_key}, verbose=False)
+    if repaired_markers > 0 and verbose:
+        print(f"ℹ️  Auto-repaired {repaired_markers} false verse restart marker(s) in {book_key}.md")
+
     try:
         convert_book_markdown_to_json(book_key, str(
             markdown_file), str(json_file), verbose=verbose)
+
+        # Hard guard: converted JSON must never contain non-increasing verse order.
+        with open(json_file, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+
+        regressions = []
+        for chapter_data in data.get('chapters', []):
+            chapter_num = chapter_data.get('chapter', 0)
+            previous_verse = None
+            for verse_data in chapter_data.get('verses', []):
+                verse_num = verse_data.get('verse')
+                if not isinstance(verse_num, int):
+                    continue
+                if previous_verse is not None and verse_num <= previous_verse:
+                    regressions.append((chapter_num, previous_verse, verse_num))
+                previous_verse = verse_num
+
+        if regressions:
+            if verbose:
+                print(f"❌ Failed to convert {book_key}: verse sequence regressions remain in JSON")
+                for chapter_num, prev, cur in regressions[:10]:
+                    print(f"   - Ch {chapter_num}: {cur} after {prev}")
+                if len(regressions) > 10:
+                    print(f"   ... and {len(regressions) - 10} more")
+            return False
+
         if verbose:
             print(f"✓ Converted {book_key} to JSON")
         return True
@@ -326,6 +364,11 @@ def convert_all_books():
         print("❌ No markdown files found")
         print("Run 'python main.py split' first")
         return False
+
+    # Global pre-convert repair to keep future reruns deterministic.
+    repaired_files, repaired_markers, _ = repair_books(verbose=False)
+    if repaired_markers > 0:
+        print(f"ℹ️  Auto-repaired {repaired_markers} false restart marker(s) in {repaired_files} markdown file(s).\n")
 
     converted = 0
     failed = 0

--- a/scripts/tth_2/main.py
+++ b/scripts/tth_2/main.py
@@ -310,7 +310,8 @@ def convert_book_to_json(book_key: str, verbose: bool = True):
     # Normalize known markdown wrap artifacts before conversion so reruns are stable.
     _, repaired_markers, _ = repair_books(book_keys={book_key}, verbose=False)
     if repaired_markers > 0 and verbose:
-        print(f"ℹ️  Auto-repaired {repaired_markers} false verse restart marker(s) in {book_key}.md")
+        print(
+            f"ℹ️  Auto-repaired {repaired_markers} false verse restart marker(s) in {book_key}.md")
 
     try:
         convert_book_markdown_to_json(book_key, str(
@@ -329,12 +330,14 @@ def convert_book_to_json(book_key: str, verbose: bool = True):
                 if not isinstance(verse_num, int):
                     continue
                 if previous_verse is not None and verse_num <= previous_verse:
-                    regressions.append((chapter_num, previous_verse, verse_num))
+                    regressions.append(
+                        (chapter_num, previous_verse, verse_num))
                 previous_verse = verse_num
 
         if regressions:
             if verbose:
-                print(f"❌ Failed to convert {book_key}: verse sequence regressions remain in JSON")
+                print(
+                    f"❌ Failed to convert {book_key}: verse sequence regressions remain in JSON")
                 for chapter_num, prev, cur in regressions[:10]:
                     print(f"   - Ch {chapter_num}: {cur} after {prev}")
                 if len(regressions) > 10:
@@ -368,7 +371,8 @@ def convert_all_books():
     # Global pre-convert repair to keep future reruns deterministic.
     repaired_files, repaired_markers, _ = repair_books(verbose=False)
     if repaired_markers > 0:
-        print(f"ℹ️  Auto-repaired {repaired_markers} false restart marker(s) in {repaired_files} markdown file(s).\n")
+        print(
+            f"ℹ️  Auto-repaired {repaired_markers} false restart marker(s) in {repaired_files} markdown file(s).\n")
 
     converted = 0
     failed = 0

--- a/scripts/tth_2/md_to_json.py
+++ b/scripts/tth_2/md_to_json.py
@@ -515,7 +515,8 @@ class TTH2MdToJson:
                         ):
                             merged = f"{current_verses[-1]['tth']} {split_verse_text}".strip()
                             merged = self.clean_text_preserve_comments(merged)
-                            merged, merged_footnotes = self.extract_footnotes(merged)
+                            merged, merged_footnotes = self.extract_footnotes(
+                                merged)
                             current_verses[-1]['tth'] = merged
                             current_verses[-1]['footnotes'] = merged_footnotes
                             current_verses[-1]['hebrew_terms'] = []
@@ -565,7 +566,8 @@ class TTH2MdToJson:
                     ):
                         merged = f"{current_verses[-1]['tth']} {verse_text}".strip()
                         merged = self.clean_text_preserve_comments(merged)
-                        merged, merged_footnotes = self.extract_footnotes(merged)
+                        merged, merged_footnotes = self.extract_footnotes(
+                            merged)
                         current_verses[-1]['tth'] = merged
                         current_verses[-1]['footnotes'] = merged_footnotes
                         current_verses[-1]['hebrew_terms'] = []

--- a/scripts/tth_2/md_to_json.py
+++ b/scripts/tth_2/md_to_json.py
@@ -414,6 +414,32 @@ class TTH2MdToJson:
 
         return segments
 
+    def should_merge_regressed_marker_as_continuation(
+        self,
+        candidate_num: int,
+        previous_num: Optional[int],
+        candidate_text: str,
+    ) -> bool:
+        """
+        Detect a known wrapped-line corruption pattern across source books.
+
+        Some lines are incorrectly emitted as a fresh "**1** ..." marker while
+        actually continuing the previous verse. Keep this extremely narrow and
+        retain strict failures for any ambiguous/non-deterministic regressions.
+        """
+        if previous_num is None or previous_num < 1:
+            return False
+
+        if candidate_num != 1:
+            return False
+
+        trimmed = candidate_text.strip()
+        if not trimmed:
+            return False
+
+        # Continuation fragments usually start with lowercase narrative text.
+        return bool(re.match(r'^[a-záéíóúñü]', trimmed, re.IGNORECASE))
+
     def parse_chapters_and_verses(self, book_text: str, verbose: bool = False) -> List[Dict[str, Any]]:
         """Parse chapters and verses from the book text."""
         lines = book_text.split('\n')
@@ -479,6 +505,22 @@ class TTH2MdToJson:
                     verse_text = verse_match.group(2).strip()
 
                     for split_verse_num, split_verse_text in self.split_inline_verse_segments(verse_num, verse_text):
+                        if (
+                            current_verses
+                            and self.should_merge_regressed_marker_as_continuation(
+                                split_verse_num,
+                                current_last_verse_num,
+                                split_verse_text,
+                            )
+                        ):
+                            merged = f"{current_verses[-1]['tth']} {split_verse_text}".strip()
+                            merged = self.clean_text_preserve_comments(merged)
+                            merged, merged_footnotes = self.extract_footnotes(merged)
+                            current_verses[-1]['tth'] = merged
+                            current_verses[-1]['footnotes'] = merged_footnotes
+                            current_verses[-1]['hebrew_terms'] = []
+                            continue
+
                         cleaned_text = self.clean_text_preserve_comments(
                             split_verse_text)
                         cleaned_text, footnotes = self.extract_footnotes(
@@ -512,6 +554,23 @@ class TTH2MdToJson:
                     verse_head = malformed_verse_match.group(2).strip()
                     verse_tail = malformed_verse_match.group(3).strip()
                     verse_text = f"{verse_head} {verse_tail}".strip()
+
+                    if (
+                        current_verses
+                        and self.should_merge_regressed_marker_as_continuation(
+                            verse_num,
+                            current_last_verse_num,
+                            verse_text,
+                        )
+                    ):
+                        merged = f"{current_verses[-1]['tth']} {verse_text}".strip()
+                        merged = self.clean_text_preserve_comments(merged)
+                        merged, merged_footnotes = self.extract_footnotes(merged)
+                        current_verses[-1]['tth'] = merged
+                        current_verses[-1]['footnotes'] = merged_footnotes
+                        current_verses[-1]['hebrew_terms'] = []
+                        i += 1
+                        continue
 
                     verse_text = self.clean_text_preserve_comments(verse_text)
                     verse_text, footnotes = self.extract_footnotes(verse_text)


### PR DESCRIPTION
- add deterministic false restart marker repair utility for TTH2 markdown sources (`scripts/tth_2/fix_false_restart_markers.py`)
- integrate auto-repair into conversion flow for single-book and all-book runs in `scripts/tth_2/main.py`
- enforce strict post-convert JSON verse-sequence guard that fails conversion when non-increasing verse numbers remain
- expand parser handling in `scripts/tth_2/md_to_json.py` to merge known wrapped continuation artifacts safely
- normalize affected markdown sources across TTH2 books to remove erroneous internal `**1**` restart markers
- regenerate corresponding JSON outputs across the corpus after pipeline hardening and data cleanup