### PR TITLE
docs: add root README with setup and acknowledgements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Davar
 
 <p align="center">
-  <img src="design/davar_nobackground.png" alt="Davar logo" width="180" />
+  <img src="design/davar_blue.png" alt="Davar logo" width="180" />
 </p>
 
 A minimalist Bible study app focused on Hebrew Scriptures.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,86 @@
+# Davar
+
+<p align="center">
+  <img src="design/davar_nobackground.png" alt="Davar logo" width="180" />
+</p>
+
+A minimalist Bible study app focused on Hebrew Scriptures.
+
+## URL
+
+- https://davar.bible
+
+## Run Locally
+
+### Requirements
+
+- Bun installed
+
+### 1) Clone and install
+
+```bash
+git clone https://github.com/edyhvh/davar.git
+cd davar
+```
+
+### 2) Web app
+
+```bash
+cd web
+bun install
+bun dev
+```
+
+Local web URL:
+- http://localhost:3002
+
+### 3) Mobile app (Expo)
+
+```bash
+cd mobile
+bun install
+bun expo start
+```
+
+## Project Structure
+
+- web: Web app
+- mobile: Mobile app (Expo)
+- data: Source datasets and generated JSON
+- scripts: Data processing and utility scripts
+
+## Acknowledgements & Data Sources
+
+Data in this project comes from public-domain, permissive, and licensed sources.
+
+- Open Scriptures Hebrew Bible Project (morphology): https://github.com/openscriptures/morphhb
+- Open Scriptures Hebrew Lexicon: https://github.com/openscriptures/HebrewLexicon
+- Hebrew Bible source repository: https://github.com/hebrew-bible/hebrew-bible.github.io
+- SPABES (AudioBiblia.org / Irma Flores): https://ebible.org/spabes/
+- Delitzsch Strong's initial reference mapping source: https://www.ph4.org/b4_1.php?l=iw
+- Qumran differences/data reference: https://codeberg.org/dandeto/deadseainsights
+- SBL Hebrew font source: https://www.sbl-site.org/educational/BiblicalFonts_SBLHebrew.aspx
+- Google Fonts: https://fonts.google.com
+
+Licensed translation credits used by permission:
+
+- TS2009 (Institute for Scripture Research):
+  "Scripture taken from The Scriptures, Copyright by Institute for Scripture Research. Used by permission."
+- TTH (Natanael Doldan):
+  "Texto tomado de la Traducción Textual del Hebreo, Copyright por Natanael Doldan. Usado con permiso."
+
+Special thanks:
+
+- Natanael Doldan for the Davar logo.
+- Adi Greenberg for developing the Hebrew Dead Sea Scroll font.
+- Moriah Betzalel for consultation on Dead Sea Scroll Hebrew readability.
+
+For full legal/source details and restrictions, see:
+- docs/terms.md
+- locales/legalContent.ts
+- web/ATTRIBUTIONS.md
+
+## License
+
+This repository contains both code and content with attribution and licensing requirements. See:
+- web/ATTRIBUTIONS.md

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ A minimalist Bible study app focused on Hebrew Scriptures.
 - https://davar.bible
 
 <p align="center">
-  <a href="https://play.google.com/store/apps/details?id=bible.davar" target="_blank" rel="noopener noreferrer">
-    <img src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" alt="Get it on Google Play" height="72" />
+  <a href="https://play.google.com/store/apps/details?id=bible.davar">
+    <img src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" alt="Get it on Google Play" height="64" />
   </a>
-  <a href="https://apps.apple.com/us/search?term=davar" target="_blank" rel="noopener noreferrer">
-    <img src="https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg" alt="Download on the App Store" height="48" />
+  <a href="https://www.apple.com/app-store/">
+    <img src="https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg" alt="Download on the App Store" height="64" />
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ A minimalist Bible study app focused on Hebrew Scriptures.
 
 - https://davar.bible
 
+<p align="center">
+  <a href="https://play.google.com/store/apps/details?id=bible.davar" target="_blank" rel="noopener noreferrer">
+    <img src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" alt="Get it on Google Play" height="72" />
+  </a>
+  <a href="https://apps.apple.com/us/search?term=davar" target="_blank" rel="noopener noreferrer">
+    <img src="https://developer.apple.com/assets/elements/badges/download-on-the-app-store.svg" alt="Download on the App Store" height="48" />
+  </a>
+</p>
+
 ## Run Locally
 
 ### Requirements


### PR DESCRIPTION
- Add a new top-level README with project identity (title, logo, and short description).
- Include the public URL for Davar (https://davar.bible).
- Document local run instructions using Bun for both web and mobile flows.
- Add a concise project structure overview for core directories.
- Add acknowledgements and data-source credits, including public source links.
- Include explicit licensed translation attribution text for TS2009 and TTH.
- Reference legal and attribution documents for usage restrictions and licensing context.