### PR TITLE
fix: miscellaneous fixes for web and mobile

### DIFF
--- a/data/tth_2/json/amos.json
+++ b/data/tth_2/json/amos.json
@@ -541,7 +541,20 @@
         {
           "verse": 13,
           "tth": "Porque, he aquí, el Formador de los montes y el Creador del viento, el que anuncia al hombre su ungido²⁵, el Hacedor del amanecer y de las tinieblas²⁶, y el que camina sobre las alturas de la tierra; יהוה, Elohei Tzebaot, es su Nombre. Llamado a regresar a יהוה",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁵",
+              "number": "25",
+              "word": "ungido",
+              "explanation": "Así en la versión gr., en el T.M.: el que anuncia al hombre cuál es su pensamiento; probablemente, un error de texto."
+            },
+            {
+              "marker": "²⁶",
+              "number": "26",
+              "word": "tinieblas",
+              "explanation": "O, el que hace tinieblas del amanecer."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -1327,7 +1340,14 @@
         {
           "verse": 12,
           "tth": "Para que me busque el resto de los hombres⁶⁵ y todos los gentiles que es invocado mi Nombre sobre ellos –declaración de יהוה, el que hace esto.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁶⁵",
+              "number": "65",
+              "word": "hombres",
+              "explanation": "Así en la versión gr. y en Hechos 15:17, en el T.M.: para que posean el resto de Edom; probablemente un error de texto."
+            }
+          ],
           "hebrew_terms": []
         },
         {

--- a/data/tth_2/json/bamidbar.json
+++ b/data/tth_2/json/bamidbar.json
@@ -2508,7 +2508,14 @@
         {
           "verse": 89,
           "tth": "Y cuando entró Moshéh a la Tienda del Mo'ed⁶⁸ para hablar con Él, escuchó la voz que le hablaba desde sobre la cubierta que <em>estaba</em> sobre el arca del Testimonio, de entre los dos querubines, y habló a él.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁶⁸",
+              "number": "68",
+              "word": "ed",
+              "explanation": "Tiempo señalado. Así también en el cap. 8."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Aharón enciende las lámparas"
         }
@@ -2842,7 +2849,14 @@
         {
           "verse": 14,
           "tth": "Y cuando habite con ustedes un extranjero, y hace el Pésaj para יהוה, conforme al decreto de Pésaj y conforme a su proceso legal⁸¹, así hará; un decreto habrá para ustedes, para el extranjero y para el nativo de la tierra”.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁸¹",
+              "number": "81",
+              "word": "legal",
+              "explanation": "Heb.: Mishpat."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "La nube sobre el Mishkán"
         },
@@ -3827,7 +3841,14 @@
         {
           "verse": 33,
           "tth": "Y allí vimos a los nefilim¹¹⁰, hijos de Anak, <em>que son</em> de los nefilim; éramos en nuestros ojos como saltamontes, y así éramos en los ojos de ellos.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹¹⁰",
+              "number": "110",
+              "word": "nefilim",
+              "explanation": "Caídos; es decir, los gigantes."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "El pueblo se rebela"
         }
@@ -4132,7 +4153,14 @@
         {
           "verse": 45,
           "tth": "Y descendió el amalekí y el kenaaní que habitaba en el monte ese, y los golpearon y los aplastaron hasta Jormáh¹¹⁵.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹¹⁵",
+              "number": "115",
+              "word": "Jormáh",
+              "explanation": "Destrucción."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Korbanot para acercar"
         }
@@ -4887,7 +4915,14 @@
         {
           "verse": 13,
           "tth": "Todo el que se acerque, el que se acerque al Mishkán¹³³ de יהוה, morirá. ¿Acaso todos nosotros <em>estamos</em> para morir?",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹³³",
+              "number": "133",
+              "word": "Mishkán",
+              "explanation": "Tabernáculo."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "La guardia de los sacerdotes"
         }
@@ -5411,7 +5446,14 @@
         {
           "verse": 13,
           "tth": "Estas fueron las aguas de Meribah¹⁴⁹, <em>en</em> las cuales contendieron los hijos de Israel con יהוה, y se santificó en ellos.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁴⁹",
+              "number": "149",
+              "word": "Meribah",
+              "explanation": "Contienda."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Edom rehúsa dar paso a Israel"
         },
@@ -5559,7 +5601,14 @@
         {
           "verse": 3,
           "tth": "<em>Y escuchó יהוה a la voz de Israel y</em> les <em>dio al kenaaní, y los dedicaron, y a sus ciudades. Y llamó el nombre del lugar Jormáh¹⁵⁴.</em> La serpiente de cobre",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁵⁴",
+              "number": "154",
+              "word": "Jormáh",
+              "explanation": "Algo que se dedica para prohibición, anatema."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -8275,7 +8324,14 @@
         {
           "verse": 54,
           "tth": "Y tomaron Moshéh y Eleazar el sacerdote, el oro de los jefes de miles y de cientos, y lo llevaron a la Tienda del Mo'ed²¹⁵ <em>como</em> memorial para los hijos de Israel delante de יהוה.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²¹⁵",
+              "number": "215",
+              "word": "ed",
+              "explanation": "Tiempo señalado."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Reubén y Gad piden habitar en Guilad"
         }
@@ -8554,7 +8610,14 @@
         {
           "verse": 42,
           "tth": "Y Nobaj fue y capturó a Kenat y a sus aldeas²¹⁹, y llamó a esta Nobaj, en su nombre.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²¹⁹",
+              "number": "219",
+              "word": "deas",
+              "explanation": "Lit.: hijas."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "De Ramesés al Iardén"
         }
@@ -9117,7 +9180,14 @@
         {
           "verse": 29,
           "tth": "Estos son los que comandó²²⁶ יהוה para heredar a los hijos de Israel en la tierra de Kenáan.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²²⁶",
+              "number": "226",
+              "word": "comandó",
+              "explanation": "O, capacitó."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Ciudades de los leviím y ciudades de refugio"
         }

--- a/data/tth_2/json/bereshit.json
+++ b/data/tth_2/json/bereshit.json
@@ -308,7 +308,14 @@
         {
           "verse": 3,
           "tth": "Y bendijo Elohim al día séptimo, y lo apartó, porque en él cesó¹⁴ de toda su obra que había creado Elohim para hacer.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁴",
+              "number": "14",
+              "word": "cesó",
+              "explanation": "Heb.: Shabat (en forma verbal)."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "El jardín de Éden"
         },
@@ -458,7 +465,14 @@
         {
           "verse": 17,
           "tth": "pero del árbol del conocimiento, el bien y el mal, no comerás de él; porque en el día que comas de él, ciertamente morirás²⁵.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁵",
+              "number": "25",
+              "word": "morirás",
+              "explanation": "Lit.: muriendo morirás."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Formación de la mujer"
         },
@@ -702,7 +716,14 @@
         {
           "verse": 24,
           "tth": "Y expulsó al hombre; e hizo habitar desde el este del jardín de Éden a los querubines³³, y a la espada de llama que gira en todas direcciones para guardar el camino del árbol de la vida.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "³³",
+              "number": "33",
+              "word": "querubines",
+              "explanation": "Heb.: kerubim."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Káin y Hével"
         }
@@ -769,7 +790,14 @@
         {
           "verse": 8,
           "tth": "Y dijo Káin a Hével su hermano³⁶. Y sucedió <em>que</em> cuando estaban en el campo, se levantó Káin hacia Hével su hermano y lo mató.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "³⁶",
+              "number": "36",
+              "word": "hermano",
+              "explanation": "El texto hebreo no especifica qué le dijo."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "La exclusión de Káin"
         },
@@ -2048,7 +2076,20 @@
         {
           "verse": 9,
           "tth": "Por eso fue llamado su nombre Babel⁵³, porque allí confundió⁵⁴ יהוה el lenguaje de toda la tierra; y de allí los dispersó יהוה sobre la faz de toda la tierra.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁵³",
+              "number": "53",
+              "word": "Babel",
+              "explanation": "Confusión. Sin embargo, en acadio, el nombre de la ciudad era: Bab Ilu, es decir, Puerta de Dios."
+            },
+            {
+              "marker": "⁵⁴",
+              "number": "54",
+              "word": "confundió",
+              "explanation": "Heb.: Balal."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Generaciones de Shem"
         },
@@ -3312,13 +3353,33 @@
         {
           "verse": 18,
           "tth": "y Abraham ciertamente será⁸⁷ una nación grande y poderosa, y serán bendecidos en él cualquiera de los gentiles de la tierra.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁸⁷",
+              "number": "87",
+              "word": "será",
+              "explanation": "Lit.: Siendo, será."
+            }
+          ],
           "hebrew_terms": []
         },
         {
           "verse": 19,
           "tth": "Porque lo conocí a fin de que capacite a sus hijos y a su casa después de él, y guarden el camino de יהוה, para hacer justicia⁸⁸ y juicio⁸⁹, a fin de que traiga יהוה sobre Abraham lo que habló sobre él.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁸⁸",
+              "number": "88",
+              "word": "justicia",
+              "explanation": "Heb.: Tzedakáh."
+            },
+            {
+              "marker": "⁸⁹",
+              "number": "89",
+              "word": "juicio",
+              "explanation": "O, proceso legal. Heb.: Mishpat."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -3670,7 +3731,14 @@
         {
           "verse": 38,
           "tth": "Y la menor, también ella dio a luz un hijo, y llamó su nombre Ben Amí⁹⁵, él es el padre de los hijos de Amón hasta hoy.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁹⁵",
+              "number": "95",
+              "word": "Amí",
+              "explanation": "Hijo de mi pueblo."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Abraham y Abimélej"
         }
@@ -5659,7 +5727,14 @@
         {
           "verse": 14,
           "tth": "Y será tu simiente como el polvo de la tierra, y abrirás brecha¹²³ hacia el mar, hacia el este, y el norte, y el sur, y serán bendecidas en ti todas las familias de la tierra, y en tu simiente.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹²³",
+              "number": "123",
+              "word": "brecha",
+              "explanation": "O, romperás."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -5996,7 +6071,20 @@
         {
           "verse": 35,
           "tth": "Y concibió otra vez y dio a luz un hijo, y ella dijo: Esta vez confesaré¹³⁵ a יהוה. Por eso, ella llamó su nombre Iehudáh¹³⁶.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹³⁵",
+              "number": "135",
+              "word": "confesaré",
+              "explanation": "Heb.: Iadáh."
+            },
+            {
+              "marker": "¹³⁶",
+              "number": "136",
+              "word": "Iehudáh",
+              "explanation": "Confieso a Yah."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Leah y Rajel"
         }
@@ -6224,7 +6312,20 @@
         {
           "verse": 24,
           "tth": "Y ella llamó su nombre Iosef¹⁴⁹, diciendo: Añada¹⁵⁰ יהוה a mí otro hijo.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁴⁹",
+              "number": "149",
+              "word": "Iosef",
+              "explanation": "Él añadirá."
+            },
+            {
+              "marker": "¹⁵⁰",
+              "number": "150",
+              "word": "Añada",
+              "explanation": "Heb.: Iasaf."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Yaakov se enriquece"
         },
@@ -6995,7 +7096,14 @@
         {
           "verse": 32,
           "tth": "Por eso, no comen los hijos de Israel el tendón del nervio¹⁶⁹ que está en la palma del muslo, hasta este día, porque tocó la palma del muslo de Yaakov en el tendón del nervio.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁶⁹",
+              "number": "169",
+              "word": "nervio",
+              "explanation": "Heb.: Guid ha'nasheh."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Reencuentro de Yaakov y Esav"
         }
@@ -7103,7 +7211,14 @@
         {
           "verse": 17,
           "tth": "Y Yaakov viajó a Sucot, y construyó para sí una casa, y para su ganado hizo enramadas¹⁷⁰. Por eso se llama el nombre del lugar Sucot.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁷⁰",
+              "number": "170",
+              "word": "enramadas",
+              "explanation": "Heb.: Sucot."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Yaakov en Shejem"
         },
@@ -8084,7 +8199,14 @@
         {
           "verse": 36,
           "tth": "Y los midianim¹⁸⁶ lo vendieron a Mitzráim, a Potifar, oficial de Faraón, capitán de los guardias.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁸⁶",
+              "number": "186",
+              "word": "midianim",
+              "explanation": "Madianitas. Lit.: Medanim."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Iehudáh y sus hijos"
         }
@@ -8311,7 +8433,14 @@
         {
           "verse": 30,
           "tth": "Y después salió su hermano, el cual <em>tenía</em> sobre su mano <em>el hilo</em> escarlata. Y llamaron su nombre Zaraj¹⁹³.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁹³",
+              "number": "193",
+              "word": "Zaraj",
+              "explanation": "Resplandor."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Iosef en Mitzráim"
         }
@@ -9554,7 +9683,14 @@
         {
           "verse": 34,
           "tth": "Y él llevó presentes de su rostro a ellos, pero era cinco veces²¹⁸ mayor el presente de Biniamín que los presentes de todos ellos. Y bebieron, y se embriagaron con él.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²¹⁸",
+              "number": "218",
+              "word": "veces",
+              "explanation": "Lit.: cinco manos."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Biniamín es acusado de robo"
         }
@@ -10499,7 +10635,14 @@
         {
           "verse": 16,
           "tth": "el mensajero²²⁷ que me ha redimido de todo mal, bendiga a los jóvenes; y sea llamado en ellos mi nombre, y el nombre de mis padres Abraham e Itzjak; y se multipliquen para <em>ser</em> numerosos en medio de la tierra.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²²⁷",
+              "number": "227",
+              "word": "mensajero",
+              "explanation": "Heb.: Malaj."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -10745,6 +10888,12 @@
           "verse": 26,
           "tth": "Las bendiciones de tu padre han vencido sobre las bendiciones de mis padres hasta el límite de las colinas del olam²³⁵, ¡ellas serán para la cabeza de Iosef y para la coronilla del consagrado²³⁶ de sus hermanos!",
           "footnotes": [
+            {
+              "marker": "²³⁵",
+              "number": "235",
+              "word": "olam",
+              "explanation": "Tiempo oculto, sólo conocido por Elohim."
+            },
             {
               "marker": "²³⁶",
               "number": "236",

--- a/data/tth_2/json/devarim.json
+++ b/data/tth_2/json/devarim.json
@@ -559,7 +559,20 @@
         {
           "verse": 25,
           "tth": "Este día comenzaré a poner tu temor y tu terror sobre los rostros de los pueblos debajo de todo el cielo, quienes escucharán de tu fama²⁰ y se agitarán y se retorcerán debido a ti²¹.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁰",
+              "number": "20",
+              "word": "fama",
+              "explanation": "Lit.: de tu oír."
+            },
+            {
+              "marker": "²¹",
+              "number": "21",
+              "word": "ti",
+              "explanation": "Lit.: debido a tu rostro."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Israel derrota a Sijón"
         },
@@ -759,7 +772,26 @@
         {
           "verse": 11,
           "tth": "Porque sólo Og, rey del Bashán, quedaba del resto de los refaim³⁰. He aquí, su cama <em>era</em> una cama de hierro, ¿no <em>está</em> esta en Rabáh de los hijos de Amón? Nueve codos³¹ <em>era</em> su longitud y cuatro codos³² su anchura, con el codo en un hombre.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "³⁰",
+              "number": "30",
+              "word": "refaim",
+              "explanation": "O sea, los caídos. Así también en vers. 13."
+            },
+            {
+              "marker": "³¹",
+              "number": "31",
+              "word": "codos",
+              "explanation": "O sea, cuatro metros."
+            },
+            {
+              "marker": "³²",
+              "number": "32",
+              "word": "codos",
+              "explanation": "O sea, dos metros."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Reubén, Gad y Menasheh se establecen"
         },
@@ -3201,7 +3233,20 @@
         {
           "verse": 2,
           "tth": "Porque pueblo kadosh¹¹⁴ <em>eres</em> tú para יהוה tu Elohim; y te ha escogido יהוה para ser a Él por pueblo, una adquisición¹¹⁵ de <em>entre</em> todos los pueblos que <em>están</em> sobre la faz de la tierra.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹¹⁴",
+              "number": "114",
+              "word": "kadosh",
+              "explanation": "Santo, apartado, distinguido. Así también en vers. 21."
+            },
+            {
+              "marker": "¹¹⁵",
+              "number": "115",
+              "word": "adquisición",
+              "explanation": "O, prototipo."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Animales puros e impuros"
         },
@@ -3519,7 +3564,14 @@
         {
           "verse": 29,
           "tth": "Y vendrá el leví¹⁴⁰, que no hay para él parte y herencia contigo, y el extranjero, y el huérfano y la viuda que <em>están</em> en tus puertas, y comerán y se saciarán, a fin de que te bendiga יהוה tu Elohim en toda obra de tu mano que haga.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁴⁰",
+              "number": "140",
+              "word": "leví",
+              "explanation": "Levita."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "El año de la caída de deudas"
         }
@@ -3771,7 +3823,14 @@
         {
           "verse": 8,
           "tth": "Seis días comerás panes sin levadura, y en el día séptimo habrá una asamblea privada¹⁴⁹ para יהוה tu Elohim; no harás trabajo. <em>Fiesta de las semanas y de las enramadas</em>",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁴⁹",
+              "number": "149",
+              "word": "privada",
+              "explanation": "O, retentiva. Heb.: Atzéret."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -4216,7 +4275,14 @@
         {
           "verse": 22,
           "tth": "El profeta que hable en Nombre de יהוה, y no sucede la palabra y no viene, esa es la palabra que no ha hablado יהוה; con insolencia¹⁶⁴ la ha hablado el profeta; no tendrás miedo de él.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁶⁴",
+              "number": "164",
+              "word": "insolencia",
+              "explanation": "Heb.: Zadón."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Las ciudades de refugio"
         }
@@ -4509,7 +4575,14 @@
         {
           "verse": 20,
           "tth": "Solamente el árbol que sabes que no es árbol de comida, a este destruirás y cortarás, y edificarás muralla¹⁷⁰ sobre la ciudad que hace contigo guerra, hasta caer ella.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁷⁰",
+              "number": "170",
+              "word": "muralla",
+              "explanation": "O, asedio."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Reconciliación en caso de asesinato sin autor conocido"
         }
@@ -5538,7 +5611,14 @@
         {
           "verse": 19,
           "tth": "y para ponerte alto sobre todas las naciones que ha hecho, para alabanza, y para nombre, y para esplendor; y para ser tú un pueblo kadosh¹⁹⁵ para יהוה tu Elohim, como ha hablado.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁹⁵",
+              "number": "195",
+              "word": "kadosh",
+              "explanation": "Santo, apartado, distinguido."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "La inscripción de la Torah en Ebal"
         }
@@ -6391,7 +6471,14 @@
         {
           "verse": 29,
           "tth": "Las <em>cosas</em> escondidas <em>pertenecen</em> a יהוה nuestro Elohim, pero las reveladas a nosotros y a nuestros hijos, hasta el olam²¹⁰, para guardar todas las palabras de esta Torah.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²¹⁰",
+              "number": "210",
+              "word": "olam",
+              "explanation": "Tiempo oculto, solo conocido por Elohim."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Promesa de restauración"
         }
@@ -6834,7 +6921,14 @@
         {
           "verse": 8,
           "tth": "Cuando hacía heredar Elyón²²² <em>a</em> las naciones, cuando separó los hijos de Adam,",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²²²",
+              "number": "222",
+              "word": "Elyón",
+              "explanation": "El Elevado."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -6890,7 +6984,14 @@
         {
           "verse": 15,
           "tth": "Pero engordó Ieshurún²²⁵ y pateó; engordaste, engrosaste, te saciaste; y abandonó a Eloha <em>que</em> lo hizo, y despreció <em>a</em> la Roca de su salvación.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²²⁵",
+              "number": "225",
+              "word": "Ieshurún",
+              "explanation": "Recto. Nombre simbólico para Israel."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -7048,7 +7149,14 @@
         {
           "verse": 39,
           "tth": "Vean ahora que Yo, Yo soy Él²²⁸, y no hay dios conmigo; Yo hago morir y hago vivir, Yo hiero y Yo sano, y no hay <em>quien</em> de mi mano pueda salvar.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²²⁸",
+              "number": "228",
+              "word": "Él",
+              "explanation": "Heb.: Aní Hu."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -7096,7 +7204,14 @@
         {
           "verse": 47,
           "tth": "porque no es palabra vacía esta para ustedes; pues esta es su vida. Y por esta palabra harán largos <em>sus</em> días sobre la tierra la cual ustedes cruzarán el Iardén²²⁹ hacia allí, para heredarla. <em>יהוה permite a Moshéh ver la tierra</em>",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²²⁹",
+              "number": "229",
+              "word": "Iardén",
+              "explanation": "Jordán."
+            }
+          ],
           "hebrew_terms": []
         },
         {

--- a/data/tth_2/json/hoshea.json
+++ b/data/tth_2/json/hoshea.json
@@ -375,7 +375,26 @@
         {
           "verse": 23,
           "tth": "Y la sembraré para Mí en la tierra, y amaré a la no amada²⁴, y diré a lo que no era mi pueblo²⁵: “Pueblo mío eres tú²⁶”, y él dirá: “¡Elohim mío! ” Matrimonio simbólico de Hoshea",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁴",
+              "number": "24",
+              "word": "amada",
+              "explanation": "Heb.: Lo Rujamah."
+            },
+            {
+              "marker": "²⁵",
+              "number": "25",
+              "word": "pueblo",
+              "explanation": "Heb.: Lo Amí."
+            },
+            {
+              "marker": "²⁶",
+              "number": "26",
+              "word": "tú",
+              "explanation": "Heb.: Amí atáh."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -728,7 +747,14 @@
         {
           "verse": 15,
           "tth": "Iré y volveré a mi lugar hasta que vean su culpa y busquen mi rostro; en la estrechez de ellos madrugarán para buscarme⁴². Respuesta del pueblo",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁴²",
+              "number": "42",
+              "word": "buscarme",
+              "explanation": "O, me buscarán ansiosamente."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -955,7 +981,14 @@
         {
           "verse": 16,
           "tth": "Se volvieron⁵¹, mas no a lo alto, fueron como arco engañoso. Caerán por la espada sus príncipes debido a la ira de su lengua; esto será su escarnio en la tierra de Mitzráim. La idolatría de Israel",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁵¹",
+              "number": "51",
+              "word": "volvieron",
+              "explanation": "O, volverán."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -1368,7 +1401,14 @@
         {
           "verse": 15,
           "tth": "Así se hará a ustedes en Betel⁷⁰ debido a lo malo de su maldad. En el amanecer, ciertamente será destruido el rey de Israel. La compasión de Elohim por Israel",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁷⁰",
+              "number": "70",
+              "word": "Betel",
+              "explanation": "La versión gr. dice: a ustedes, casa de Israel."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -1511,7 +1551,14 @@
         {
           "verse": 12,
           "tth": "Me ha rodeado en mentiras Efráim, y en engaño la casa de Israel; y Iehudáh todavía gobierna⁸¹ con Elohim y con el Santo Fiel. Efráim es reprendido",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁸¹",
+              "number": "81",
+              "word": "gobierna",
+              "explanation": "Otra lectura posible es: divaga."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -1638,7 +1685,14 @@
         {
           "verse": 2,
           "tth": "Y ahora pecaron cada vez más⁸⁵; e hicieron para sí imagen de fundición de su plata, ídolos conforme a su entendimiento, obra de artífices todo ello. De ellos dicen: ¡Sacrificadores de entre el hombre, a los becerros besen!",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁸⁵",
+              "number": "85",
+              "word": "más",
+              "explanation": "Lit.: añadieron para pecar."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -1818,7 +1872,14 @@
         {
           "verse": 8,
           "tth": "Volverán los que se sientan a su sombra, revivirán el trigo⁹³ y brotarán como la vid. Su memoria será como el vino del Lebanón.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁹³",
+              "number": "93",
+              "word": "trigo",
+              "explanation": "O, serán revividos como el trigo."
+            }
+          ],
           "hebrew_terms": []
         },
         {

--- a/data/tth_2/json/iehoshua.json
+++ b/data/tth_2/json/iehoshua.json
@@ -760,7 +760,14 @@
         {
           "verse": 12,
           "tth": "Y cesó el man²⁴ desde el día siguiente cuando comieron del producto de la tierra, y no hubo más para los hijos de Israel man, y comieron del producto de la tierra de Kenáan en aquel año.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁴",
+              "number": "24",
+              "word": "man",
+              "explanation": "Maná."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Yehoshúa y el príncipe del ejército de יהוה"
         },
@@ -779,7 +786,14 @@
         {
           "verse": 15,
           "tth": "Y dijo el príncipe del ejército de יהוה a Yehoshúa: Saca tu sandalia de sobre tu pie, porque el lugar el cual tú <em>estás</em> parado sobre él, santidad²⁵ es. E hizo Yehoshúa así.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁵",
+              "number": "25",
+              "word": "santidad",
+              "explanation": "Heb.: Kódesh."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "La conquista de Ierijó"
         }
@@ -1008,7 +1022,14 @@
         {
           "verse": 27,
           "tth": "Y estaba יהוה con Yehoshúa, y era su fama³⁵ por toda la tierra.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "³⁵",
+              "number": "35",
+              "word": "ma",
+              "explanation": "Lit.: su oír."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "El pecado de Aján"
         }
@@ -1231,7 +1252,14 @@
         {
           "verse": 26,
           "tth": "Y levantaron sobre él un montón de piedras hasta este día. Y se volvió יהוה del calor de su nariz. Por eso se llamó el nombre de ese lugar valle de Ajor⁴⁵ hasta este día.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁴⁵",
+              "number": "45",
+              "word": "Ajor",
+              "explanation": "Turbación."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "La conquista de Ai"
         }
@@ -2197,7 +2225,14 @@
         {
           "verse": 23,
           "tth": "Y tomó Yehoshúa toda la tierra, conforme a todo lo que había hablado יהוה a Moshéh. Y la dio Yehoshúa por herencia a Israel conforme a sus divisiones por sus tribus. Y la tierra descansó⁷¹ de la guerra.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁷¹",
+              "number": "71",
+              "word": "cansó",
+              "explanation": "O, se aquietó."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Reyes derrotados por Yehoshúa"
         }
@@ -2465,7 +2500,14 @@
         {
           "verse": 14,
           "tth": "Sólo a la tribu de Levi no dio herencia; las ofrendas de fuego⁷⁶ de יהוה, Elohim de Israel, esta es su herencia, como habló a él.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁷⁶",
+              "number": "76",
+              "word": "fuego",
+              "explanation": "Heb.: Ishéh."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Repartición de Kenáan entre las tribus"
         },
@@ -2712,7 +2754,14 @@
         {
           "verse": 15,
           "tth": "Y el nombre de Jebrón antes <em>era</em> Kiriat Arba, el hombre <em>más</em> grande entre los anakim <em>era</em> él⁸². Y la tierra descansó de la guerra.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁸²",
+              "number": "82",
+              "word": "él",
+              "explanation": "O sea, Arba."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Territorio de Iehudáh"
         }
@@ -3251,7 +3300,14 @@
         {
           "verse": 10,
           "tth": "Pero no desposeyeron al kenaaní⁹⁶, el que habitaba en Gazer; y habitó el kenaaní en medio de Efráim hasta este día, pero estuvieron para trabajo forzado de siervo.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁹⁶",
+              "number": "96",
+              "word": "kenaaní",
+              "explanation": "Cananeo."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Territorio de Menasheh"
         }
@@ -3945,7 +4001,14 @@
         {
           "verse": 51,
           "tth": "Estas son las herencias que dividieron en posesión Eleazar el sacerdote, Yehoshúa, hijo de Nun, y las cabezas de los padres de las tribus de los hijos de Israel, por goral, en Shiloh, delante de יהוה, en la entrada de la Tienda del Mo'ed¹¹⁰. Y terminaron de repartir la tierra.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹¹⁰",
+              "number": "110",
+              "word": "ed",
+              "explanation": "Tiempo señalado."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Las ciudades de refugio"
         }

--- a/data/tth_2/json/iejezkel.json
+++ b/data/tth_2/json/iejezkel.json
@@ -380,7 +380,14 @@
         {
           "verse": 15,
           "tth": "Y vine al exilio de Tel Abib, los que habitaban en el río Kebar, y los que ellos habitaban allí⁷; y me senté allí siete días, horrorizado, en medio de ellos. El vigilante de Israel",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁷",
+              "number": "7",
+              "word": "allí",
+              "explanation": "Otra lectura posible es: Y me senté donde ellos estaban sentados."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -2342,7 +2349,14 @@
         {
           "verse": 14,
           "tth": "Y salió para ti un nombre en las naciones por tu hermosura, porque perfecta era, por el esplendor⁵⁸ que puse en ti –declaración de Adonai יהוה. Infidelidad de Yerushaláim",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁵⁸",
+              "number": "58",
+              "word": "esplendor",
+              "explanation": "O, adorno."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -2556,7 +2570,14 @@
         {
           "verse": 43,
           "tth": "Porque no has recordado los días de tu juventud, y me hiciste agitar⁶⁵ con todas estas cosas, y también Yo, he aquí, tu camino en tu cabeza daré –declaración de Adonai יהוה–, y no harás el artilugio con todas tus abominaciones'. Yerushaláim es como Sedom y Gamoráh",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁶⁵",
+              "number": "65",
+              "word": "agitar",
+              "explanation": "Así en la versión gr., en el T.M., y te agitaste por Mí."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -3602,7 +3623,14 @@
         {
           "verse": 49,
           "tth": "Y dije: ¡Ah⁹⁴, Adonai יהוה! Ellos dicen de mí: “¿No representa parábolas él? ” La espada afilada de יהוה",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁹⁴",
+              "number": "94",
+              "word": "Ah",
+              "explanation": "Heb.: Ahah."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -4895,7 +4923,14 @@
         {
           "verse": 17,
           "tth": "Y haré en ellos venganzas grandes con reprensiones ardientes¹⁴⁴; y sabrán que Yo soy יהוה cuando dé mi venganza en ellos' ”. Profecía contra Tzor",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁴⁴",
+              "number": "144",
+              "word": "ardientes",
+              "explanation": "Lit.: de calor."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -5040,7 +5075,14 @@
         {
           "verse": 21,
           "tth": "Terrores¹⁴⁷ te daré, y no serás más; y serás buscada, pero no serás hallada más para siempre –declaración de Adonai יהוה. Lamentación sobre Tzor",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁴⁷",
+              "number": "147",
+              "word": "Terrores",
+              "explanation": "O, calamidades."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -5258,7 +5300,14 @@
         {
           "verse": 25,
           "tth": "Las naves de Tarshísh eran viajeros tuyos de tu mercadería. Y fuiste llena y muy gloriosa¹⁵⁷ en el corazón de los mares.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁵⁷",
+              "number": "157",
+              "word": "gloriosa",
+              "explanation": "Lit.: muy pesada."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -5331,7 +5380,26 @@
         {
           "verse": 36,
           "tth": "Los comerciantes en los pueblos silban por ti¹⁵⁹; Calamidades¹⁶⁰ has sido, y no serás hasta el olam¹⁶¹” ' ”. Profecía contra el príncipe de Tzor",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁵⁹",
+              "number": "159",
+              "word": "ti",
+              "explanation": "O, sobre ti."
+            },
+            {
+              "marker": "¹⁶⁰",
+              "number": "160",
+              "word": "Calamidades",
+              "explanation": "O, terrores."
+            },
+            {
+              "marker": "¹⁶¹",
+              "number": "161",
+              "word": "olam",
+              "explanation": "Tiempo oculto, solo conocido por Elohim."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -5472,7 +5540,20 @@
         {
           "verse": 19,
           "tth": "Todos los que te conocen en los pueblos se horrorizaron por ti; terrores¹⁶⁶ has sido, y no serás hasta el olam¹⁶⁷' ”. Profecía contra Tzidón",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁶⁶",
+              "number": "166",
+              "word": "terrores",
+              "explanation": "O, calamidades."
+            },
+            {
+              "marker": "¹⁶⁷",
+              "number": "167",
+              "word": "olam",
+              "explanation": "Tiempo oculto, solo conocido por Elohim."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -6206,7 +6287,14 @@
         {
           "verse": 32,
           "tth": "Porque Yo di su¹⁸¹ terror en la tierra de los vivientes, y fue hecho yacer en medio de incircuncisos con los traspasados de espada, Faraón y toda su multitud –declaración de Adonai יהוה. El deber del vigilante",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁸¹",
+              "number": "181",
+              "word": "su",
+              "explanation": "O, mi."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -7313,7 +7401,14 @@
         {
           "verse": 28,
           "tth": "Y sabrán las naciones que Yo, יהוה, santifico²¹³ a Israel, cuando esté mi santuario en medio de ellos para siempre' ”. Profecía contra Gog",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²¹³",
+              "number": "213",
+              "word": "tifico",
+              "explanation": "O, aparado; o, distingo."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -7498,7 +7593,14 @@
         {
           "verse": 23,
           "tth": "Y me engrandeceré y me santificaré²²⁰, y seré conocido a ojos de muchos gentiles; y sabrán que Yo soy יהוה' ”. Destrucción de Gog",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²²⁰",
+              "number": "220",
+              "word": "santificaré",
+              "explanation": "O, y me distinguiré."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -9317,7 +9419,14 @@
         {
           "verse": 12,
           "tth": "Y el shekel será de veinte gueráh; veinte shekel, veinticinco shekel y quince shekel, será el manéh³¹³ para ustedes. Ofrendas y Tiempos Señalados",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "³¹³",
+              "number": "313",
+              "word": "manéh",
+              "explanation": "Mina."
+            }
+          ],
           "hebrew_terms": []
         },
         {

--- a/data/tth_2/json/ieshaiahu.json
+++ b/data/tth_2/json/ieshaiahu.json
@@ -630,7 +630,14 @@
         {
           "verse": 6,
           "tth": "cabaña¹⁵ habrá para la sombra durante el día de sequedad, y para refugio y para escondite de la inundación y de la lluvia. Parábola de la viña",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁵",
+              "number": "15",
+              "word": "cabaña",
+              "explanation": "Heb.: Sucah."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -1375,7 +1382,14 @@
         {
           "verse": 7,
           "tth": "Del aumento del dominio y del shalom no habrá final sobre el trono de David y sobre su reino, para afirmarlo y para sostenerlo con juicio y con justicia, desde ahora y hasta el olam³⁶. El celo de יהוה Tzebaot hará esto. Indignación de Elohim contra Israel",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "³⁶",
+              "number": "36",
+              "word": "olam",
+              "explanation": "Tiempo oculto, solo conocido por Elohim."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -3233,6 +3247,12 @@
           "tth": "Y colgarán sobre él toda la gloria de la casa de su padre, los que salen y los descendientes⁸⁸, todos los recipientes pequeños, desde los recipientes de cuencos hasta todos los recipientes de jarras⁸⁹.",
           "footnotes": [
             {
+              "marker": "⁸⁸",
+              "number": "88",
+              "word": "dientes",
+              "explanation": "Heb.: Tzefiot; significado dudoso."
+            },
+            {
               "marker": "⁸⁹",
               "number": "89",
               "word": "jarras",
@@ -3801,6 +3821,12 @@
           "tth": "Mi ser te anhela en la noche, también, mi ánimo¹¹⁴ dentro de mí te busca temprano; porque conforme a tus procesos legales son para la tierra, justicia aprenderán los habitantes del Tevel¹¹⁵.",
           "footnotes": [
             {
+              "marker": "¹¹⁴",
+              "number": "114",
+              "word": "ánimo",
+              "explanation": "O, mente. Heb.: Rúaj."
+            },
+            {
               "marker": "¹¹⁵",
               "number": "115",
               "word": "Tevel",
@@ -4017,7 +4043,14 @@
         {
           "verse": 13,
           "tth": "Y sucederá en aquel día que se soplará con un gran shofar¹²⁴, y vendrán los perecidos en la tierra de Ashur y los empujados en la tierra de Mitzráim, y se postrarán a יהוה en el monte de la santidad en Yerushaláim. Ridiculización de los líderes del pueblo",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹²⁴",
+              "number": "124",
+              "word": "shofar",
+              "explanation": "Cuerno de carnero."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -4153,7 +4186,14 @@
         {
           "verse": 15,
           "tth": "Porque han dicho: Hemos hecho¹³¹ un pacto con la muerte, y con el Sheol hemos hecho un cerco; el azote desbordante, cuando pase, no vendrá a nosotros, porque hemos puesto la falsedad como nuestro refugio y en la mentira nos hemos escondido.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹³¹",
+              "number": "131",
+              "word": "hecho",
+              "explanation": "Lit.: cortado."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -4381,7 +4421,14 @@
         {
           "verse": 11,
           "tth": "Y será para ustedes el cerco¹⁴³ de todo como las palabras del rollo sellado, que se le dará al conocedor de rollo, diciendo: Lee, por favor, esto; y él dirá: No puedo, porque está sellado.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁴³",
+              "number": "143",
+              "word": "cerco",
+              "explanation": "Véase Isaías 28:15."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -4424,7 +4471,14 @@
         {
           "verse": 16,
           "tth": "¡Contrariedad¹⁴⁶ de ustedes! ¿A que no será considerado como la arcilla del alfarero?,porque, ¿dirá la hechura a su hacedor: No me hizo; y lo formado dirá a su formador: No tiene entendimiento? Redención de Israel",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁴⁶",
+              "number": "146",
+              "word": "Contrariedad",
+              "explanation": "Heb.: Héfej. Término referente a la idea de tornar la verdad en mentira."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -4534,7 +4588,14 @@
         {
           "verse": 5,
           "tth": "Todos apestarán¹⁵¹ por un pueblo que no les aprovecha, no es de ayuda ni de provecho, porque es para vergüenza y también para afrenta.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁵¹",
+              "number": "151",
+              "word": "apestarán",
+              "explanation": "O, se avergonzarán."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -4765,13 +4826,33 @@
         {
           "verse": 32,
           "tth": "Y será toda pasada de la vara del fundamento¹⁶², que deje יהוה sobre él, con panderos y con arpas; y con guerras de zarandeo, Él luchará contra ella.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁶²",
+              "number": "162",
+              "word": "fundamento",
+              "explanation": "Otra lectura posible es: de reprensión."
+            }
+          ],
           "hebrew_terms": []
         },
         {
           "verse": 33,
           "tth": "Porque fue preparado desde ayer Tofet¹⁶³, además, este para el rey ha sido establecido. Lo ha hecho profundo y lo ha ensanchado, su pila es de fuego y muchas maderas, la neshamáh¹⁶⁴ de יהוה, es como arroyo de azufre que arde contra ella. Mitzráim es hombre y no El",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁶³",
+              "number": "163",
+              "word": "Tofet",
+              "explanation": "Lugar de quema, donde se sacrificaba a Molej."
+            },
+            {
+              "marker": "¹⁶⁴",
+              "number": "164",
+              "word": "neshamáh",
+              "explanation": "O sea, el Rúaj Ha'Kódesh en Yeshúa el Mesías."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -5052,7 +5133,14 @@
         {
           "verse": 1,
           "tth": "¡Oy del despojador¹⁷⁸, y tú no has sido despojado; y del traidor, y no actuaron traicioneramente contra él! Tal como has completado, despojador, serás despojado; tal como has acabado de traicionar, traicionarán contra ti.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁷⁸",
+              "number": "178",
+              "word": "despojador",
+              "explanation": "O, destructor. Heb.: Shoded."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -5386,7 +5474,20 @@
         {
           "verse": 17,
           "tth": "Y Él ha hecho caer para ellas goral¹⁹², y su mano la ha repartido para ellas con el cordel. Hasta el olam¹⁹³ la poseerán; por generación y generación morarán en ella.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁹²",
+              "number": "192",
+              "word": "goral",
+              "explanation": "Piedrecita lanzada para tomar decisiones y designar tierras."
+            },
+            {
+              "marker": "¹⁹³",
+              "number": "193",
+              "word": "olam",
+              "explanation": "Tiempo oculto, solo conocido por Elohim."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Futuro glorioso de Tzión"
         }
@@ -5459,7 +5560,20 @@
         {
           "verse": 10,
           "tth": "Y los rescatados de יהוה volverán, y entrarán en Tzión con grito de júbilo y alegría olam¹⁹⁵ sobre sus cabezas. Gozo y alegría alcanzarán, y huirán la tristeza y el suspiro¹⁹⁶. Invasión de Sanjerib",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁹⁵",
+              "number": "195",
+              "word": "olam",
+              "explanation": "Tiempo oculto, solo conocido por Elohim."
+            },
+            {
+              "marker": "¹⁹⁶",
+              "number": "196",
+              "word": "suspiro",
+              "explanation": "O, gemido."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -6015,7 +6129,14 @@
         {
           "verse": 14,
           "tth": "Como golondrina, grulla, así chirrío, arrullo como paloma; miran débilmente²¹¹ mis ojos a lo alto. Adonai, hay opresión para mí, dame seguridad.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²¹¹",
+              "number": "211",
+              "word": "débilmente",
+              "explanation": "Lit.: cuelgan."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -6143,7 +6264,14 @@
         {
           "verse": 8,
           "tth": "Y dijo Jizkiyahu a Ieshaiáhu: Buena es la palabra de יהוה que has hablado. Y decía: Porque habrá shalom²¹⁶ y verdad en mis días. Restauración de Israel",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²¹⁶",
+              "number": "216",
+              "word": "shalom",
+              "explanation": "Plenitud, ausencia de deudas."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -6376,7 +6504,20 @@
         {
           "verse": 31,
           "tth": "Pero los que esperan en יהוה cambiarán la fuerza; subirán²²³ alas²²⁴ como las águilas, correrán y no se fatigarán, caminarán y no se cansarán. Promesa de ayuda a Israel",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²²³",
+              "number": "223",
+              "word": "subirán",
+              "explanation": "Otra lectura posible es: les crecerán."
+            },
+            {
+              "marker": "²²⁴",
+              "number": "224",
+              "word": "alas",
+              "explanation": "Lit.: miembro."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -6966,7 +7107,14 @@
         {
           "verse": 28,
           "tth": "Y profanaré a los príncipes de santidad, y daré para anatema²³⁷ a Yaakov, y a Israel para desprecios. Adonai es el único Elohim",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²³⁷",
+              "number": "237",
+              "word": "anatema",
+              "explanation": "O, prohibición."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -7198,7 +7346,20 @@
         {
           "verse": 28,
           "tth": "El que dice de Coresh²⁴⁷: “Mi pastor es, y todo mi deleite él cumplirá”, y diciendo de Yerushaláim: “Serás edificada”, y al Hejal²⁴⁸: “Serás fundado”. Coresh, libertador de Israel",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁴⁷",
+              "number": "247",
+              "word": "Coresh",
+              "explanation": "Ciro."
+            },
+            {
+              "marker": "²⁴⁸",
+              "number": "248",
+              "word": "Hejal",
+              "explanation": "Palacio, Santuario."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -7252,7 +7413,14 @@
         {
           "verse": 7,
           "tth": "formador de la luz y creador de la oscuridad, hacedor de shalom²⁵⁰ y creador de mal, Yo soy יהוה, hacedor de todas estas cosas. יהוה el Creador",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁵⁰",
+              "number": "250",
+              "word": "shalom",
+              "explanation": "Plenitud, ausencia de deudas."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -7344,7 +7512,14 @@
         {
           "verse": 19,
           "tth": "No en secreto he hablado, en un lugar de tierra de oscuridad; no dije a la simiente de Yaakov: “En el vacío²⁵⁴ búsquenme”. Yo, יהוה, hablo justicia, doy a conocer las cosas rectas. El verdadero Elohim y los ídolos",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁵⁴",
+              "number": "254",
+              "word": "vacío",
+              "explanation": "O, caos."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -7764,7 +7939,14 @@
         {
           "verse": 22,
           "tth": "No hay shalom²⁶⁵ –dijo יהוה– para los condenados. Promesa de salvación",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁶⁵",
+              "number": "265",
+              "word": "shalom",
+              "explanation": "Plenitud, ausencia de deudas."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -8044,7 +8226,14 @@
         {
           "verse": 11,
           "tth": "He aquí, todos ustedes que encienden fuego, que se ciñen de chispas, anden en la luz de su fuego y en las chispas que han encendido. De mi mano será esto a ustedes, en tristeza²⁷³ se acostarán. Anuncio de salvación para Tzión",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁷³",
+              "number": "273",
+              "word": "tristeza",
+              "explanation": "O, dolor."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -8221,7 +8410,14 @@
         {
           "verse": 22,
           "tth": "Así dijo tu Amo²⁸⁰, יהוה, y tu Elohim, que lucha por su pueblo: He aquí, he tomado de tu mano la copa del tambaleo, el sedimento de la copa de mi ardor, no volverás a beberla más.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁸⁰",
+              "number": "280",
+              "word": "Amo",
+              "explanation": "Heb.: Adón."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -8419,7 +8615,14 @@
         {
           "verse": 12,
           "tth": "Por eso, le daré parte con los grandes, y con los fuertes repartirá el botín, a causa de que puso al descubierto²⁸⁴ su vida para muerte, y con los transgresores fue contado; y Él el pecado de muchos llevó, y por los transgresores intercedió. El amor de יהוה hacia Israel",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁸⁴",
+              "number": "284",
+              "word": "descubierto",
+              "explanation": "O, desnudó."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -9221,7 +9424,14 @@
         {
           "verse": 21,
           "tth": "Y Yo, este es mi pacto con ellos –dijo יהוה–: Mi Rúaj que está sobre Mí, y mis palabras que he puesto en tu boca, no serán quitadas de tu boca, ni de la boca de tu simiente, ni de la boca de la simiente de tu simiente –dijo יהוה– desde ahora y hasta el olam³¹³. Futura gloria de Yerushaláim",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "³¹³",
+              "number": "313",
+              "word": "olam",
+              "explanation": "Tiempo oculto, solo conocido por Elohim. Así en el resto del cap."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -10064,7 +10274,14 @@
         {
           "verse": 6,
           "tth": "Voz de estruendo de la ciudad, voz del Hejal³³⁹: voz de יהוה que paga la recompensa a sus enemigos.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "³³⁹",
+              "number": "339",
+              "word": "Hejal",
+              "explanation": "Palacio, Santuario."
+            }
+          ],
           "hebrew_terms": []
         },
         {

--- a/data/tth_2/json/ioel.json
+++ b/data/tth_2/json/ioel.json
@@ -256,7 +256,14 @@
         {
           "verse": 11,
           "tth": "Y יהוה dio su voz delante de su ejército, porque es muy grande su campamento, porque poderoso es el que hace su palabra. Porque grande es el día de יהוה y muy temible, ¿y quién podrá contenerlo⁹? יהוה ordena al pueblo a volverse",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁹",
+              "number": "9",
+              "word": "contenerlo",
+              "explanation": "O, soportarlo."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -611,7 +618,14 @@
         {
           "verse": 17,
           "tth": "Y sabrán que Yo soy יהוה su Elohim, que moro en Tzión, monte de mi santidad. Y será Yerushaláim distinguida²⁸, y los extraños no pasarán por ella más. Restauración de Iehudáh",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁸",
+              "number": "28",
+              "word": "distinguida",
+              "explanation": "Heb.: Kadosh."
+            }
+          ],
           "hebrew_terms": []
         },
         {

--- a/data/tth_2/json/iojanan.json
+++ b/data/tth_2/json/iojanan.json
@@ -261,7 +261,14 @@
         {
           "verse": 28,
           "tth": "Y estas cosas sucedieron en Bet Aniah, pasando el Iardén¹³, donde Iojanán sumergía.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹³",
+              "number": "13",
+              "word": "Iardén",
+              "explanation": "Jordán."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "El Cordero de Elohim"
         },
@@ -309,7 +316,7 @@
             {
               "marker": "¹⁶",
               "number": "16",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad."
             }
           ],
@@ -380,7 +387,14 @@
         {
           "verse": 42,
           "tth": "Y lo llevó hacia Yeshúa. Cuando lo miró Yeshúa, dijo: Tú eres Shimón, hijo de Ionah, tú serás llamado Kefa¹⁹.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁹",
+              "number": "19",
+              "word": "Kefa",
+              "explanation": "O sea, Roca. Equivalente al heb.: sela."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Filipos y Netanel"
         },
@@ -460,7 +474,7 @@
             {
               "marker": "²³",
               "number": "23",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -541,7 +555,14 @@
         {
           "verse": 12,
           "tth": "Y después de eso, descendió a Kefar Najum²⁵, Él, su madre, sus hermanos y sus discípulos, y allí estuvieron unos días, no muchos.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁵",
+              "number": "25",
+              "word": "Najum",
+              "explanation": "Capernaúm."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Yeshúa echa a los mercaderes de la casa de יהוה"
         },
@@ -637,7 +658,14 @@
         {
           "verse": 22,
           "tth": "y cuando se levantó de lo muertos recordaron sus discípulos que les había dicho esto; y se afirmaron³¹ por la Escritura y por la palabra que Yeshúa había hablado.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "³¹",
+              "number": "31",
+              "word": "afirmaron",
+              "explanation": "O, recibieron emunah. Así también en vers. 23."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Muchos creen en Yeshúa"
         },
@@ -772,7 +800,7 @@
             {
               "marker": "³⁷",
               "number": "37",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -806,7 +834,14 @@
         {
           "verse": 15,
           "tth": "para que todo el que se afirme por Él, no perezca, sino que tenga vida olam⁴¹.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁴¹",
+              "number": "41",
+              "word": "olam",
+              "explanation": "Tiempo oculto, sólo conocido por Elohim. Así también en el resto del cap."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "El amor de Elohim"
         },
@@ -1117,7 +1152,7 @@
         },
         {
           "verse": 15,
-          "tth": "Y le dijo la mujer: Amo mío, dame esta agua para que yo no tenga sed ni venga aquí para sacar <em>la. </em>",
+          "tth": "Y le dijo la mujer: Amo mío, dame esta agua para que yo no tenga sed ni venga aquí para sacar <em>la.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1197,13 +1232,13 @@
               "marker": "⁵⁸",
               "number": "58",
               "word": "Meshija",
-              "explanation": "‘Mesías' en arameo; es decir, Ungido."
+              "explanation": "'Mesías' en arameo; es decir, Ungido."
             },
             {
               "marker": "⁵⁹",
               "number": "59",
               "word": "Mashíaj",
-              "explanation": "‘Mesías' en hebreo; es decir, Ungido."
+              "explanation": "'Mesías' en hebreo; es decir, Ungido."
             }
           ],
           "hebrew_terms": []
@@ -1981,7 +2016,7 @@
             {
               "marker": "⁸²",
               "number": "82",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -2212,7 +2247,7 @@
             {
               "marker": "⁹³",
               "number": "93",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -2365,7 +2400,14 @@
         {
           "verse": 71,
           "tth": "Y hablaba de Iehudáh, hijo de Shimón, Ish-Kariot¹⁰⁰, porque este era el que lo había de entregar, y era uno de los doce.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁰⁰",
+              "number": "100",
+              "word": "Ish-Kariot",
+              "explanation": "Iscariote; esto es: hombre de Kariot."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "La fiesta de Sucot"
         }
@@ -2678,7 +2720,7 @@
             {
               "marker": "¹¹²",
               "number": "112",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad."
             }
           ],
@@ -2794,7 +2836,14 @@
         {
           "verse": 53,
           "tth": "[¹¹⁷Y volvieron <em>cada</em> hombre a su casa.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹¹⁷",
+              "number": "117",
+              "word": "",
+              "explanation": "Los versículos de 7:53 a 8:11 no aparecen en los mss. más antiguos; se considera una adi-ción."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "La mujer adúltera"
         }
@@ -2970,7 +3019,14 @@
         {
           "verse": 20,
           "tth": "Y estas palabras habló Yeshúa en la casa del tesoro, enseñando en el Hejal¹²⁶; y ningún hombre lo prendió, porque todavía no había venido su tiempo.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹²⁶",
+              "number": "126",
+              "word": "Hejal",
+              "explanation": "Santuario, Palacio."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Yeshúa advierte a los indisciplinados"
         },
@@ -3058,7 +3114,7 @@
             {
               "marker": "¹³²",
               "number": "132",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -3073,7 +3129,14 @@
         {
           "verse": 30,
           "tth": "Y cuando habló estas <em>cosas</em>, muchos se afirmaron¹³³ en Él.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹³³",
+              "number": "133",
+              "word": "afirmaron",
+              "explanation": "O, que habían creído. Así también en vers. 31."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "La verdadera simiente de Abraham"
         },
@@ -3169,7 +3232,7 @@
             {
               "marker": "¹³⁵",
               "number": "135",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             }
           ],
@@ -3220,7 +3283,7 @@
             {
               "marker": "¹³⁹",
               "number": "139",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario. Así también en los versículos 49 y 52."
             }
           ],
@@ -3740,7 +3803,7 @@
             {
               "marker": "¹⁵²",
               "number": "152",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El advesario. Así también en vers. 21."
             }
           ],
@@ -4055,7 +4118,14 @@
         {
           "verse": 16,
           "tth": "Y dijo Tomáh <em>–</em> llamado Teom¹⁶⁵<em>–</em> a sus compañeros los discípulos: Iremos también nosotros para morir con él.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁶⁵",
+              "number": "165",
+              "word": "Teom",
+              "explanation": "Gemelo. Gr.: Didimos."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Yeshúa resucita a Eleazar"
         },
@@ -4154,7 +4224,7 @@
         },
         {
           "verse": 28,
-          "tth": "Y cuando ella dijo estas <em>cosas, </em> se fue, y llamó a Miriam, su hermana, secretamente y en oculto, diciendo: El Maestro está aquí, y te llama.",
+          "tth": "Y cuando ella dijo estas <em>cosas,</em> se fue, y llamó a Miriam, su hermana, secretamente y en oculto, diciendo: El Maestro está aquí, y te llama.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4244,7 +4314,7 @@
         },
         {
           "verse": 43,
-          "tth": "Y cuando dijo estas <em>cosas, </em> clamó con gran voz: ¡Eleazar, ven fuera!",
+          "tth": "Y cuando dijo estas <em>cosas,</em> clamó con gran voz: ¡Eleazar, ven fuera!",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4480,7 +4550,7 @@
         },
         {
           "verse": 16,
-          "tth": "Pero estas palabras no <em>las</em> supieron sus discípulos primero; pero después, cuando fue glorificado Yeshúa, entonces recordaron que acerca de Él habían sido escritas, y que se <em>las</em> habían hecho, estas <em>cosas. </em>",
+          "tth": "Pero estas palabras no <em>las</em> supieron sus discípulos primero; pero después, cuando fue glorificado Yeshúa, entonces recordaron que acerca de Él habían sido escritas, y que se <em>las</em> habían hecho, estas <em>cosas.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4540,7 +4610,7 @@
             {
               "marker": "¹⁸⁰",
               "number": "180",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -4620,7 +4690,7 @@
             {
               "marker": "¹⁸²",
               "number": "182",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -4756,7 +4826,7 @@
             {
               "marker": "¹⁸⁶",
               "number": "186",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             },
             {
@@ -4948,7 +5018,7 @@
             {
               "marker": "¹⁹²",
               "number": "192",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             }
           ],
@@ -4980,7 +5050,7 @@
             {
               "marker": "¹⁹³",
               "number": "193",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -5232,7 +5302,7 @@
             {
               "marker": "²⁰¹",
               "number": "201",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad."
             }
           ],
@@ -5680,7 +5750,26 @@
         {
           "verse": 33,
           "tth": "Estas <em>cosas</em> les he hablado para que ustedes tengan shalom²¹⁰ en Mí; en el olam tendrán estrechez, pero fortalézcanse, y esfuércese su corazón²¹¹, porque Yo he luchado contra el olam y he sido capaz²¹².",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²¹⁰",
+              "number": "210",
+              "word": "shalom",
+              "explanation": "Plenitud, bienestar completo, ausencia de deudas."
+            },
+            {
+              "marker": "²¹¹",
+              "number": "211",
+              "word": "corazón",
+              "explanation": "Véase Salmo 31:24."
+            },
+            {
+              "marker": "²¹²",
+              "number": "212",
+              "word": "capaz",
+              "explanation": "Véase Génesis 32:28."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Yeshúa hace tefilah"
         }
@@ -6269,7 +6358,7 @@
             {
               "marker": "²²⁹",
               "number": "229",
-              "word": "strotos",
+              "word": "Lidsóstrotos",
               "explanation": "O sea, enlosado de piedras."
             },
             {
@@ -6314,7 +6403,7 @@
               "marker": "²³²",
               "number": "232",
               "word": "Gulgolet",
-              "explanation": "‘Cráneo' en hebreo."
+              "explanation": "'Cráneo' en hebreo."
             }
           ],
           "hebrew_terms": []
@@ -6419,7 +6508,7 @@
         },
         {
           "verse": 31,
-          "tth": "Y los iehudim, para que no se quedasen pegados los cadáveres sobre la cruz durante el Shabat, porque era el día de la inspección de la levadura²³⁶, la tarde antes del Shabat <em>–</em> porque aquel Shabat era el día grande <em>–</em>, pidieron a Pilatos quebrar las piernas y tomar <em>los. </em>",
+          "tth": "Y los iehudim, para que no se quedasen pegados los cadáveres sobre la cruz durante el Shabat, porque era el día de la inspección de la levadura²³⁶, la tarde antes del Shabat <em>–</em> porque aquel Shabat era el día grande <em>–</em>, pidieron a Pilatos quebrar las piernas y tomar <em>los.</em>",
           "footnotes": [
             {
               "marker": "²³⁶",
@@ -6470,7 +6559,14 @@
         {
           "verse": 37,
           "tth": "Y otra vez, otra Escritura que dice: Y me mirarán a Mí, al que traspasaron²³⁸.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²³⁸",
+              "number": "238",
+              "word": "traspasaron",
+              "explanation": "Véase Zacarías 12:10."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Sepultura de Yeshúa"
         },
@@ -6665,7 +6761,7 @@
             {
               "marker": "²⁴³",
               "number": "243",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad."
             }
           ],
@@ -6674,7 +6770,14 @@
         {
           "verse": 23,
           "tth": "Todos los hombres a los que les soporten²⁴⁴ los pecados, les serán soportados; y a los que les retengan, les serán retenidos.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁴⁴",
+              "number": "244",
+              "word": "soporten",
+              "explanation": "O, carguen; o, lleven."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Yeshúa y Tomáh"
         },

--- a/data/tth_2/json/irmeiahu.json
+++ b/data/tth_2/json/irmeiahu.json
@@ -1997,7 +1997,14 @@
         {
           "verse": 26,
           "tth": "a Mitzráim, a Iehudáh, a Edom, a los hijos de Amón, a Moab y a todos los que se cortan los lados⁶², los que habitan en el desierto; porque todas las naciones son incircuncisas, y toda la casa de Israel, incircuncisos de corazón. Los falsos dioses y el Elohim verdadero",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁶²",
+              "number": "62",
+              "word": "lados",
+              "explanation": "O, bordes."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -2701,7 +2708,14 @@
         {
           "verse": 27,
           "tth": "Tus adulterios y tus relinchos, el plan malvado⁸² de tu prostitución, sobre las colinas en el campo, he visto tus abominaciones. ¡Oy de ti, Yerushaláim! ¿No serás pura?, ¿después de cuándo todavía? Mensaje con motivo de la sequía",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁸²",
+              "number": "82",
+              "word": "malvado",
+              "explanation": "O, artimaña. Heb.: Zimáh."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -2886,7 +2900,14 @@
         {
           "verse": 22,
           "tth": "¿Hay entre las vacuidades⁹⁰ de las naciones que hagan llover? ¿O los cielos darán muchas lluvias? ¿No eres Tú Él, יהוה, nuestro Elohim? Y esperaremos en ti, porque Tú has hecho todas estas cosas. El enojo de Elohim contra Iehudáh",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁹⁰",
+              "number": "90",
+              "word": "vacuidades",
+              "explanation": "Lit.: vapores. O, cosas corruptibles."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -2945,7 +2966,20 @@
         {
           "verse": 9,
           "tth": "Se debilitó la que dio a luz siete hijos; suspiró⁹¹ su ser⁹². Se puso su sol cuando todavía era de día, se avergonzó y fue abochornada; y sus remanentes a espada los daré delante de sus enemigos –declaración de יהוה. Lamento de Irmeiáhu y respuesta de יהוה",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁹¹",
+              "number": "91",
+              "word": "suspiró",
+              "explanation": "Lit.: sopló."
+            },
+            {
+              "marker": "⁹²",
+              "number": "92",
+              "word": "ser",
+              "explanation": "O, garganta. Heb.: Néfesh."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -4153,7 +4187,14 @@
         {
           "verse": 30,
           "tth": "Así dijo יהוה: “Escriban a este hombre como sin hijos, hombre que no prosperará en sus días; porque no prosperará de su simiente hombre que se siente sobre el trono de David y gobierne todavía¹²⁴ en Iehudáh. Regreso del remanente",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹²⁴",
+              "number": "124",
+              "word": "todavía",
+              "explanation": "O, más."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -4453,7 +4494,14 @@
         {
           "verse": 40,
           "tth": "y pondré sobre ustedes reproche olam¹³³ y vergüenza olam, que no será olvidada. Las dos canastas de higos",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹³³",
+              "number": "133",
+              "word": "olam",
+              "explanation": "Tiempo oculto, solo conocido por Elohim."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -4821,7 +4869,14 @@
         {
           "verse": 38,
           "tth": "Ha abandonado como el leoncillo su matorral, porque ha sido su tierra por horror, a causa del ardor de la opresora¹⁴⁴ y a causa del calor de su nariz. Plan para matar a Irmeiáhu",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁴⁴",
+              "number": "144",
+              "word": "opresora",
+              "explanation": "O, del opresor."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -4941,7 +4996,14 @@
         {
           "verse": 18,
           "tth": "Micaiáh el morashtí¹⁴⁶ estuvo y profetizó en días de Jizkiyahu, rey de Iehudáh, y dijo a todo el pueblo de Iehudáh, diciendo: “Así ha dicho יהוה Tzebaot: 'Tzión como campo será arada, y Yerushaláim ruinas será, y el monte de la casa será por alturas de bosque' ”.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁴⁶",
+              "number": "146",
+              "word": "morashtí",
+              "explanation": "Habitante de Moreset."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -5672,7 +5734,14 @@
         {
           "verse": 24,
           "tth": "No regresará el ardor de la ira de יהוה hasta hacer Él y hasta cumplir Éllos propósitos de su corazón; en el final de los días discernirán en ello¹⁶². Gozo en lugar de luto",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁶²",
+              "number": "162",
+              "word": "ello",
+              "explanation": "O, comprenderán esto."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -6509,7 +6578,14 @@
         {
           "verse": 26,
           "tth": "también, a la simiente de Yaakov y David mi siervo, rechazaré de tomar de su simiente quienes gobiernen en la simiente de Abraham, Isjak¹⁸⁷ y Yaakov. Pero haré volver a sus cautivos y los amaré entrañablemente”. Profecía contra Tzidkiyahu",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁸⁷",
+              "number": "187",
+              "word": "jak",
+              "explanation": "Forma alternativa de Itzjak."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -8590,7 +8666,20 @@
         {
           "verse": 28,
           "tth": "Tú no temas, siervo mío Yaakov –declaración de יהוה– porque contigo estoy Yo; pues haré finalización en todas las naciones que te he desterrado²⁴⁴ allá; pero contigo no haré finalización, y te disciplinaré para juicio²⁴⁵, pero, absolviendo, no te absolveré. Profecía sobre los pelishtim",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁴⁴",
+              "number": "244",
+              "word": "desterrado",
+              "explanation": "Lit.: empujado."
+            },
+            {
+              "marker": "²⁴⁵",
+              "number": "245",
+              "word": "juicio",
+              "explanation": "O, proceso legal. Heb.: Mishpat."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -9302,7 +9391,20 @@
         {
           "verse": 33,
           "tth": "Y será Jatzor para morada de reptiles²⁷², desolación hasta el olam²⁷³; no habitará allí hombre, y no residirá en ella hijo de hombre. Profecía sobre Eilam",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁷²",
+              "number": "272",
+              "word": "reptiles",
+              "explanation": "O, chacales. Heb.: Tanim."
+            },
+            {
+              "marker": "²⁷³",
+              "number": "273",
+              "word": "olam",
+              "explanation": "Tiempo oculto, solo conocido por Elohim."
+            }
+          ],
           "hebrew_terms": []
         },
         {

--- a/data/tth_2/json/jabakuk.json
+++ b/data/tth_2/json/jabakuk.json
@@ -96,7 +96,7 @@
         },
         {
           "verse": 11,
-          "tth": "Entonces mudará el viento⁴, y pasará, y será culpable, <em>porque</em> esta su fuerza <em>atribuye</em> a su dios⁵.",
+          "tth": "Entonces mudará el viento⁴, y pasará, y será culpable,<em>porque</em> esta su fuerza <em>atribuye</em> a su dios⁵.",
           "footnotes": [
             {
               "marker": "⁴",
@@ -221,7 +221,7 @@
         },
         {
           "verse": 5,
-          "tth": "Y también, porque el vino traiciona <em>al</em> varón altivo, y no habitará <em>en su casa</em>. <em>Por</em> que ha ensanchado como el Sheol su garganta¹², y él es como la muerte, y no se saciará; y reunirá hacia sí <em>mismo</em> todas las naciones, y recogerá hacia sí <em>mismo</em> todos los pueblos.",
+          "tth": "Y también, porque el vino traiciona <em>al</em> varón altivo, y no habitará <em>en su casa</em>.<em>Por</em> que ha ensanchado como el Sheol su garganta¹², y él es como la muerte, y no se saciará; y reunirá hacia sí <em>mismo</em> todas las naciones, y recogerá hacia sí <em>mismo</em> todos los pueblos.",
           "footnotes": [
             {
               "marker": "¹²",
@@ -340,7 +340,14 @@
         {
           "verse": 20,
           "tth": "Pero יהוה está en el Hejal¹⁶ de su santidad, calle delante de Él toda la tierra.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁶",
+              "number": "16",
+              "word": "Hejal",
+              "explanation": "Templo, Santuario."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Tefilah de Jabakuk"
         }
@@ -383,7 +390,7 @@
         },
         {
           "verse": 3,
-          "tth": "Eloha de Teimán vendrá, y el Kadosh²⁰, del monte Parán. <em>Selah. </em> Cubrió los cielos su esplendor, y su alabanza llenó la tierra.",
+          "tth": "Eloha de Teimán vendrá, y el Kadosh²⁰, del monte Parán. <em>Selah.</em> Cubrió los cielos su esplendor, y su alabanza llenó la tierra.",
           "footnotes": [
             {
               "marker": "²⁰",
@@ -489,7 +496,7 @@
         },
         {
           "verse": 13,
-          "tth": "Saldrás para salvación de tu pueblo, para salvación con tu Mesías; heriste la cabeza de la casa del condenado, desnudándo <em>la desde</em> el cimiento hasta el cuello. <em>Selah. </em>",
+          "tth": "Saldrás para salvación de tu pueblo, para salvación con tu Mesías; heriste la cabeza de la casa del condenado, desnudándo <em>la desde</em> el cimiento hasta el cuello. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -507,7 +514,7 @@
         },
         {
           "verse": 16,
-          "tth": "Oí y se agitó mi vientre, a la voz temblaron mis labios. Entra podredumbre en mis huesos, y debajo de mí tiemblo; <em>por</em> que descansaré en el día de la estrechez, para subir al pueblo que nos atacará.",
+          "tth": "Oí y se agitó mi vientre, a la voz temblaron mis labios. Entra podredumbre en mis huesos, y debajo de mí tiemblo;<em>por</em> que descansaré en el día de la estrechez, para subir al pueblo que nos atacará.",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/jabakuk.json
+++ b/data/tth_2/json/jabakuk.json
@@ -221,7 +221,7 @@
         },
         {
           "verse": 5,
-          "tth": "Y también, porque el vino traiciona <em>al</em> varón altivo, y no habitará <em>en su casa</em>.<em>Por</em> que ha ensanchado como el Sheol su garganta¹², y él es como la muerte, y no se saciará; y reunirá hacia sí <em>mismo</em> todas las naciones, y recogerá hacia sí <em>mismo</em> todos los pueblos.",
+          "tth": "Y también, porque el vino traiciona <em>al</em> varón altivo, y no habitará <em>en su casa</em>. <em>Por</em> que ha ensanchado como el Sheol su garganta¹², y él es como la muerte, y no se saciará; y reunirá hacia sí <em>mismo</em> todas las naciones, y recogerá hacia sí <em>mismo</em> todos los pueblos.",
           "footnotes": [
             {
               "marker": "¹²",

--- a/data/tth_2/json/jagai.json
+++ b/data/tth_2/json/jagai.json
@@ -21,7 +21,7 @@
         },
         {
           "verse": 2,
-          "tth": "Así ha dicho יהוה Tzebaot, diciendo: “Este pueblo dice: ‘No ha llegado el tiempo, el tiempo de la casa de יהוה para edificarla' ”.",
+          "tth": "Así ha dicho יהוה Tzebaot, diciendo: “Este pueblo dice: 'No ha llegado el tiempo, el tiempo de la casa de יהוה para edificarla' ”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -100,7 +100,14 @@
         {
           "verse": 15,
           "tth": "en el día veinticuatro del mes, en el sexto, en el año dos de Dareyávesh¹ el rey.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹",
+              "number": "1",
+              "word": "Dareyávesh",
+              "explanation": "Darío. Posiblemente, un título de realeza y no un nombre propio."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Palabras de יהוה al pueblo"
         }
@@ -184,7 +191,7 @@
         },
         {
           "verse": 12,
-          "tth": "‘He aquí, un hombre lleva carne consagrada en el ala de su vestido, y toca con su ala pan, alimento hervido, vino, aceite o cualquier comida, ¿será consagrada? ' ” Y respondieron los sacerdotes, y dijeron: No.",
+          "tth": "'He aquí, un hombre lleva carne consagrada en el ala de su vestido, y toca con su ala pan, alimento hervido, vino, aceite o cualquier comida, ¿será consagrada? ' ” Y respondieron los sacerdotes, y dijeron: No.",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/lukas.json
+++ b/data/tth_2/json/lukas.json
@@ -150,7 +150,7 @@
             {
               "marker": "⁸",
               "number": "8",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad."
             }
           ],
@@ -351,7 +351,7 @@
             {
               "marker": "²⁰",
               "number": "20",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad."
             },
             {
@@ -584,7 +584,7 @@
             {
               "marker": "²⁶",
               "number": "26",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad."
             }
           ],
@@ -871,7 +871,14 @@
         {
           "verse": 21,
           "tth": "Y cuando se completaron los ocho días para circuncidar al niño, llamaron su nombre Yeshúa³⁸, llamado por el ángel <em>desde</em> antes que Él fuera concebido en el vientre.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "³⁸",
+              "number": "38",
+              "word": "Yeshúa",
+              "explanation": "יהוה salva."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Yeshúa es presentado en el Santuario"
         },
@@ -921,7 +928,7 @@
             {
               "marker": "⁴²",
               "number": "42",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad."
             }
           ],
@@ -934,7 +941,7 @@
             {
               "marker": "⁴³",
               "number": "43",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad."
             },
             {
@@ -1332,7 +1339,7 @@
             {
               "marker": "⁶⁴",
               "number": "64",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad; así también en vers. 22."
             }
           ],
@@ -1496,7 +1503,7 @@
             {
               "marker": "⁶⁷",
               "number": "67",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad."
             },
             {
@@ -1521,7 +1528,7 @@
             {
               "marker": "⁷⁰",
               "number": "70",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario. Así también en los versículos 3 y 9."
             }
           ],
@@ -1877,7 +1884,14 @@
         {
           "verse": 37,
           "tth": "Y salió su fama⁹² por todo lugar de la región.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁹²",
+              "number": "92",
+              "word": "fama",
+              "explanation": "Lit.: su oír."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Yeshúa sana a la suegra de Shimón y a muchos más"
         },
@@ -2036,7 +2050,14 @@
         {
           "verse": 16,
           "tth": "Y Él se fue sigilosamente al desierto, para hacer tefilah⁹⁵.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁹⁵",
+              "number": "95",
+              "word": "tefilah",
+              "explanation": "Oración, participación en juicio."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Yeshúa sana a un inmóvil"
         },
@@ -2110,7 +2131,7 @@
             {
               "marker": "⁹⁹",
               "number": "99",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -2297,7 +2318,7 @@
             {
               "marker": "¹⁰⁸",
               "number": "108",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             },
             {
@@ -2440,7 +2461,7 @@
             {
               "marker": "¹¹⁴",
               "number": "114",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -2919,7 +2940,7 @@
             {
               "marker": "¹³⁰",
               "number": "130",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             }
           ],
@@ -2932,7 +2953,7 @@
             {
               "marker": "¹³¹",
               "number": "131",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             },
             {
@@ -3066,7 +3087,20 @@
         {
           "verse": 49,
           "tth": "Y los que estaban sentados en ronda comenzaron a decir en su ser: ¿Quién es este, que también soporta iniquidades? Y Él dijo a la mujer: Tu emunah¹³⁸ te ha salvado, ve en shalom¹³⁹.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹³⁸",
+              "number": "138",
+              "word": "emunah",
+              "explanation": "Firmeza, fidelidad, crianza."
+            },
+            {
+              "marker": "¹³⁹",
+              "number": "139",
+              "word": "shalom",
+              "explanation": "Plenitud, bienestar completo."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Mujeres que servían a Yeshúa"
         }
@@ -3148,7 +3182,7 @@
             {
               "marker": "¹⁴⁰",
               "number": "140",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             }
           ],
@@ -3213,7 +3247,14 @@
         {
           "verse": 21,
           "tth": "Y Él respondió, y les dijo: Mi madre y mis hermanos son los que escuchan la palabra de Elohim y la hacen¹⁴².",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁴²",
+              "number": "142",
+              "word": "hacen",
+              "explanation": "Así en Ver. Políglota de Nuremberg, Ms. Oo,1.32.2 dice: ¿Quién es mi madre y quiénes son mis hermanos? Y extendió su mano hacia sus discípulos, y dijo: ¡Estos son mi madre y mis hermanos! Todo el que hace la voluntad de mi Padre, ese es mi hermano y mi hermana y mi madre."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Yeshúa calma la tormenta"
         },
@@ -3245,7 +3286,14 @@
         {
           "verse": 25,
           "tth": "Y les dijo: ¿Dónde está su emunah¹⁴⁴? Y temieron, y dijo <em>cada</em> hombre a su compañero: ¿Y quién es Este, que también a los vientos y a las aguas manda, y lo escuchan?",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁴⁴",
+              "number": "144",
+              "word": "emunah",
+              "explanation": "Firmeza, fidelidad, crianza."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "El poseído por demonio"
         },
@@ -3288,7 +3336,7 @@
             {
               "marker": "¹⁴⁷",
               "number": "147",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             }
           ],
@@ -3427,7 +3475,20 @@
         {
           "verse": 48,
           "tth": "Y Él le dijo__: __Fortalécete y esfuérzate, hija mía, tu emunah¹⁵¹ te ha salvado; ve en shalom¹⁵².",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁵¹",
+              "number": "151",
+              "word": "emunah",
+              "explanation": "Firmeza, fidelidad, crianza."
+            },
+            {
+              "marker": "¹⁵²",
+              "number": "152",
+              "word": "shalom",
+              "explanation": "Plenitud, bienestar completo."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Yeshúa revive a la hija de Iair"
         },
@@ -3661,7 +3722,7 @@
             {
               "marker": "¹⁵⁹",
               "number": "159",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -3911,7 +3972,14 @@
         {
           "verse": 56,
           "tth": "Porque el Ben Ha'Adam¹⁶⁶ no vino para hacer perecer las vidas de los hombres, sino para salvar. Y fueron a otra aldea.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁶⁶",
+              "number": "166",
+              "word": "Ben Ha'Adam",
+              "explanation": "Hijo del Hombre; un título para el Mesías."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Lo que requiere seguir a Yeshúa"
         },
@@ -4462,7 +4530,7 @@
             {
               "marker": "¹⁸⁷",
               "number": "187",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             }
           ],
@@ -4557,7 +4625,7 @@
             {
               "marker": "¹⁹⁰",
               "number": "190",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -4856,7 +4924,7 @@
             {
               "marker": "²⁰⁵",
               "number": "205",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -4875,7 +4943,7 @@
             {
               "marker": "²⁰⁶",
               "number": "206",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad."
             }
           ],
@@ -5123,7 +5191,7 @@
             {
               "marker": "²¹⁶",
               "number": "216",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -5211,7 +5279,14 @@
         {
           "verse": 53,
           "tth": "Porque estará dividido el padre contra su hijo, y el hijo contra su padre; la madre contra su hija, y la hija contra su madre; la suegra contra su nuera, y la nuera contra su suegra²¹⁸.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²¹⁸",
+              "number": "218",
+              "word": "suegra",
+              "explanation": "Véase Miqueas 7:6."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Cómo discernir el tiempo"
         },
@@ -5382,7 +5457,7 @@
             {
               "marker": "²²³",
               "number": "223",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             }
           ],
@@ -5415,7 +5490,20 @@
         {
           "verse": 21,
           "tth": "Es semejante a la levadura²²⁴, que la tomó una mujer y la escondió en tres seah²²⁵ de harina fina, hasta que se leuda toda.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²²⁴",
+              "number": "224",
+              "word": "levadura",
+              "explanation": "Heb.: Jámetz."
+            },
+            {
+              "marker": "²²⁵",
+              "number": "225",
+              "word": "seah",
+              "explanation": "Unidad de medida seca y líquida, equivale a un tercio de un efáh."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "La puerta cerrada"
         },
@@ -5529,7 +5617,14 @@
         {
           "verse": 35,
           "tth": "He aquí, alejada será a ustedes su casa, desolada. Porque Yo les digo que no me verán hasta que venga el que digan: ¡Bendito el que viene en el Nombre de יהוה²³⁰! ”",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²³⁰",
+              "number": "230",
+              "word": "יהוה",
+              "explanation": "Véase Salmo 118:26."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Yeshúa sana a un enfermo en el Shabat"
         }
@@ -5901,7 +5996,7 @@
         },
         {
           "verse": 18,
-          "tth": "Me levantaré e iré a mi padre, y le diré: ‘Padre mío, he pecado contra los cielos y contra tu rostro;",
+          "tth": "Me levantaré e iré a mi padre, y le diré: 'Padre mío, he pecado contra los cielos y contra tu rostro;",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -6442,7 +6537,7 @@
             {
               "marker": "²⁵⁵",
               "number": "255",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -6861,7 +6956,7 @@
             {
               "marker": "²⁷⁵",
               "number": "275",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -7035,7 +7130,7 @@
             {
               "marker": "²⁸⁰",
               "number": "280",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -7716,7 +7811,14 @@
         {
           "verse": 47,
           "tth": "los cuales se comen las casas de las viudas, y con pretextos de palabras alargan su tefilah³⁰⁵; y ellos más juicio recibirán. La ofrenda de la viuda",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "³⁰⁵",
+              "number": "305",
+              "word": "tefilah",
+              "explanation": "Oración, participación en juicio."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -7745,7 +7847,14 @@
         {
           "verse": 4,
           "tth": "porque todos estos de sus sobras echaron para las ofrendas³⁰⁶ a Elohim, pero esta, de su escasez, echó toda posesión que ella tenía. Profecía de la destrucción del Santuario",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "³⁰⁶",
+              "number": "306",
+              "word": "ofrendas",
+              "explanation": "Lit.: acercamientos. Heb.: korbanot. Así también en vers. 5."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -8027,7 +8136,7 @@
             {
               "marker": "³¹⁴",
               "number": "314",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             },
             {
@@ -8090,7 +8199,7 @@
         },
         {
           "verse": 11,
-          "tth": "Y dirán al dueño de la casa: “El Maestro te dice: ‘¿Dónde está la posada donde comeré el Pésaj con mis discípulos? ' ”",
+          "tth": "Y dirán al dueño de la casa: “El Maestro te dice: '¿Dónde está la posada donde comeré el Pésaj con mis discípulos? ' ”",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8162,7 +8271,7 @@
             {
               "marker": "³¹⁷",
               "number": "317",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -8225,7 +8334,7 @@
             {
               "marker": "³¹⁸",
               "number": "318",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             }
           ],
@@ -8353,7 +8462,7 @@
             {
               "marker": "³²³",
               "number": "323",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -8502,7 +8611,7 @@
             {
               "marker": "³²⁶",
               "number": "326",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -8781,7 +8890,7 @@
               "marker": "³³⁵",
               "number": "335",
               "word": "Gulgolet",
-              "explanation": "‘Cráneo' en hebreo."
+              "explanation": "'Cráneo' en hebreo."
             }
           ],
           "hebrew_terms": []
@@ -9022,7 +9131,7 @@
             {
               "marker": "³⁴³",
               "number": "343",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],

--- a/data/tth_2/json/maasei_hashlijim.json
+++ b/data/tth_2/json/maasei_hashlijim.json
@@ -33,7 +33,7 @@
             {
               "marker": "²",
               "number": "2",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad. Así en el resto del cap."
             }
           ],
@@ -213,6 +213,12 @@
           "tth": "Porque está escrito en el libro de los Salmos: Será desolado su campamento, en sus tiendas no habrá habitante¹³; y: su cargo tomará otro¹⁴.",
           "footnotes": [
             {
+              "marker": "¹³",
+              "number": "13",
+              "word": "habitante",
+              "explanation": "Véase Salmo 69:25."
+            },
+            {
               "marker": "¹⁴",
               "number": "14",
               "word": "otro",
@@ -301,7 +307,14 @@
         {
           "verse": 26,
           "tth": "Y pusieron sus goralot²², y cayó el goral sobre Matia, y fue contado con los once discípulos.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²²",
+              "number": "22",
+              "word": "goralot",
+              "explanation": "Piedrecitas lanzadas para tomar decisiones."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "La entrega del Rúaj Ha'Kódesh"
         }
@@ -349,7 +362,7 @@
             {
               "marker": "²⁵",
               "number": "25",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad. Así en el resto del cap."
             }
           ],

--- a/data/tth_2/json/malaji.json
+++ b/data/tth_2/json/malaji.json
@@ -175,7 +175,14 @@
         {
           "verse": 9,
           "tth": "Y también Yo <em>los</em> he dado a ustedes <em>como</em> despreciables y bajos para todo el pueblo, así como ustedes no guardaron mis caminos y alzaron los rostros⁴ en la Torah.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁴",
+              "number": "4",
+              "word": "rostros",
+              "explanation": "O sea, mostraron favoritismo."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "El pecado de traición"
         },
@@ -419,7 +426,7 @@
         },
         {
           "verse": 18,
-          "tth": "Y volverán y verán entre el justificado y el condenado, entre el siervo de Elohim y el que no le sirve. <em>El gran día de</em>__יהוה__",
+          "tth": "Y volverán y verán entre el justificado y el condenado, entre el siervo de Elohim y el que no le sirve. <em>El gran día de</em> יהוה",
           "footnotes": [],
           "hebrew_terms": []
         }

--- a/data/tth_2/json/markos.json
+++ b/data/tth_2/json/markos.json
@@ -121,7 +121,7 @@
             {
               "marker": "¹⁰",
               "number": "10",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad."
             }
           ],
@@ -171,7 +171,7 @@
             {
               "marker": "¹³",
               "number": "13",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             }
           ],
@@ -304,7 +304,20 @@
         {
           "verse": 28,
           "tth": "Y salió aquella fama inmediatamente por todo el distrito²⁰ de Galil²¹.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁰",
+              "number": "20",
+              "word": "distrito",
+              "explanation": "Lit.: el círculo."
+            },
+            {
+              "marker": "²¹",
+              "number": "21",
+              "word": "Galil",
+              "explanation": "Galilea. Así también en vers. 39."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Yeshúa sana a la suegra de Shimón y a muchos más"
         },
@@ -465,7 +478,7 @@
         },
         {
           "verse": 4,
-          "tth": "Y como no podían acercarse a Él por causa de la congregación, subieron por encima del techo y sacaron la cubierta que estaba allí <em>, </em> y horadaron, e hicieron bajar la camilla en la que estaba acostado el privado de miembros.",
+          "tth": "Y como no podían acercarse a Él por causa de la congregación, subieron por encima del techo y sacaron la cubierta que estaba allí <em>,</em> y horadaron, e hicieron bajar la camilla en la que estaba acostado el privado de miembros.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -502,7 +515,7 @@
         },
         {
           "verse": 9,
-          "tth": "¿Cómo abriré <em>mi boca</em>? <em>, </em> ¿diciendo al privado de miembros: “Te son soportadas tus transgresiones”?, ¿o diciendo: “Levántate, toma tu camilla y camina”?",
+          "tth": "¿Cómo abriré <em>mi boca</em>?<em>,</em> ¿diciendo al privado de miembros: “Te son soportadas tus transgresiones”?, ¿o diciendo: “Levántate, toma tu camilla y camina”?",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -513,7 +526,7 @@
             {
               "marker": "²⁷",
               "number": "27",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -565,7 +578,20 @@
         {
           "verse": 17,
           "tth": "Y escuchó Yeshúa, y les dijo: Los saludables²⁹ no están necesitados de sanador, sino los enfermos. No he venido a llamar a los justos, sino a los pecadores a teshuváh³⁰. Pregunta sobre el ayuno",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁹",
+              "number": "29",
+              "word": "saludables",
+              "explanation": "Lit.: los fuertes."
+            },
+            {
+              "marker": "³⁰",
+              "number": "30",
+              "word": "teshuváh",
+              "explanation": "Retorno, arrepentimiento y vuelta."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -845,7 +871,7 @@
             {
               "marker": "⁴¹",
               "number": "41",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             }
           ],
@@ -870,7 +896,7 @@
             {
               "marker": "⁴²",
               "number": "42",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             }
           ],
@@ -895,7 +921,7 @@
             {
               "marker": "⁴³",
               "number": "43",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad."
             }
           ],
@@ -1067,7 +1093,7 @@
             {
               "marker": "⁴⁹",
               "number": "49",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             }
           ],
@@ -1500,7 +1526,20 @@
         {
           "verse": 34,
           "tth": "Y Él le dijo: Hija mía, tu emunah⁵⁹ te ha salvado; ve en shalom⁶⁰ y serás aliviada de tu enfermedad.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁵⁹",
+              "number": "59",
+              "word": "emunah",
+              "explanation": "Firmeza, fidelidad, crianza."
+            },
+            {
+              "marker": "⁶⁰",
+              "number": "60",
+              "word": "shalom",
+              "explanation": "Plenitud, bienestar completo."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Yeshúa revive a la hija de Iair"
         },
@@ -2551,7 +2590,7 @@
             {
               "marker": "⁹⁴",
               "number": "94",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -2570,7 +2609,7 @@
             {
               "marker": "⁹⁵",
               "number": "95",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             }
           ],
@@ -2727,7 +2766,7 @@
             {
               "marker": "¹⁰²",
               "number": "102",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Así en Ms. Oo.1.32.2, Ms. Vat.Ebr.100 dice: Hijo de Eloha."
             }
           ],
@@ -2766,7 +2805,7 @@
         },
         {
           "verse": 18,
-          "tth": "Y en dondequiera que lo tome, le provoca dolor¹⁰³, y babea¹⁰⁴ y rechina los dientes, y se va secando. Y dije a tus discípulos para que lo sacaran, pero no pudieron <em>. </em>",
+          "tth": "Y en dondequiera que lo tome, le provoca dolor¹⁰³, y babea¹⁰⁴ y rechina los dientes, y se va secando. Y dije a tus discípulos para que lo sacaran, pero no pudieron <em>.</em>",
           "footnotes": [
             {
               "marker": "¹⁰³",
@@ -3035,7 +3074,20 @@
         {
           "verse": 50,
           "tth": "Buena es la sal, pero si salamos la sal, ¿con qué la asarán? Esté con ustedes la sal, y haya shalom¹¹⁴ entre ustedes¹¹⁵.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹¹⁴",
+              "number": "114",
+              "word": "shalom",
+              "explanation": "Plenitud, bienestar completo."
+            },
+            {
+              "marker": "¹¹⁵",
+              "number": "115",
+              "word": "ustedes",
+              "explanation": "Así en Ver. Políglota de Nuremberg, Ms. Oo.1.32.2 dice: Buena es la sal si se la halla en recipientes salados; después ustedes deben ser hijos de sal, y tengan shalom unos con otros."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Yeshúa en tierra de Iehudáh"
         }
@@ -3345,7 +3397,7 @@
             {
               "marker": "¹³¹",
               "number": "131",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -3434,7 +3486,7 @@
         },
         {
           "verse": 46,
-          "tth": "Y entraron a Ierijó¹³³. Y cuando Él salió de Ierijó, y sus discípulos y un gran pueblo, el hijo de Timai, BarTimai, un ciego, estaba sentado en el camino, y pedía <em>. </em>",
+          "tth": "Y entraron a Ierijó¹³³. Y cuando Él salió de Ierijó, y sus discípulos y un gran pueblo, el hijo de Timai, BarTimai, un ciego, estaba sentado en el camino, y pedía <em>.</em>",
           "footnotes": [
             {
               "marker": "¹³³",
@@ -3492,7 +3544,14 @@
         {
           "verse": 52,
           "tth": "Y Yeshúa le dijo: Ve por ti, tu emunah¹³⁶ te ha salvado. Y al instante vio, y fue detrás de Yeshúa por el camino.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹³⁶",
+              "number": "136",
+              "word": "emunah",
+              "explanation": "Firmeza, fidelidad, crianza."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "El Rey montando sobre un asnito"
         }
@@ -3528,7 +3587,7 @@
         },
         {
           "verse": 3,
-          "tth": "Y si <em>algún</em> hombre les dice: ¿Por qué hacen esto?, digan que para Adonai es necesario, y enseguida lo enviará acá <em>. </em>",
+          "tth": "Y si <em>algún</em> hombre les dice: ¿Por qué hacen esto?, digan que para Adonai es necesario, y enseguida lo enviará acá <em>.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3937,7 +3996,7 @@
         },
         {
           "verse": 18,
-          "tth": "Y vinieron a Él los tzedukim¹⁵⁶, los que dicen que no hay levantamiento de los muertos <em>, </em> y le preguntaron, diciendo:",
+          "tth": "Y vinieron a Él los tzedukim¹⁵⁶, los que dicen que no hay levantamiento de los muertos <em>,</em> y le preguntaron, diciendo:",
           "footnotes": [
             {
               "marker": "¹⁵⁶",
@@ -3987,7 +4046,7 @@
         },
         {
           "verse": 23,
-          "tth": "En el levantamiento <em>, </em> cuando se levanten ¿de quién de estos será la mujer?, porque los siete la tuvieron por mujer.",
+          "tth": "En el levantamiento <em>,</em> cuando se levanten ¿de quién de estos será la mujer?, porque los siete la tuvieron por mujer.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4005,7 +4064,7 @@
         },
         {
           "verse": 26,
-          "tth": "Y acerca de los muertos que han de levantarse, ¿no han leído en el libro de Moshéh, diciendo: “Y lo llamó Elohim de dentro de la zarza, y le dijo: ‘Yo soy el Elohim de Abraham, el Elohim de Itzjak y el Elohim de Iaacob¹⁵⁹' ”?",
+          "tth": "Y acerca de los muertos que han de levantarse, ¿no han leído en el libro de Moshéh, diciendo: “Y lo llamó Elohim de dentro de la zarza, y le dijo: 'Yo soy el Elohim de Abraham, el Elohim de Itzjak y el Elohim de Iaacob¹⁵⁹' ”?",
           "footnotes": [
             {
               "marker": "¹⁵⁹",
@@ -4049,7 +4108,7 @@
         },
         {
           "verse": 31,
-          "tth": "Y el segundo es semejante a este, es: “Y amarás a tu compañero como a ti <em>mismo¹⁶¹”. </em> Mandamiento <em>más</em> grande que estos no hay.",
+          "tth": "Y el segundo es semejante a este, es: “Y amarás a tu compañero como a ti <em>mismo¹⁶¹”.</em> Mandamiento <em>más</em> grande que estos no hay.",
           "footnotes": [
             {
               "marker": "¹⁶¹",
@@ -4075,7 +4134,7 @@
         },
         {
           "verse": 33,
-          "tth": "y <em>hay que</em> amarlo con todo el corazón, con todo el ser¹⁶³ y con toda la abundancia <em>, </em> y amar al compañero como a sí <em>mismo</em>. Grande es <em>esto, </em> por encima de todas las ofrendas ascendidas y los sacrificios.",
+          "tth": "y <em>hay que</em> amarlo con todo el corazón, con todo el ser¹⁶³ y con toda la abundancia <em>,</em> y amar al compañero como a sí <em>mismo</em>. Grande es <em>esto,</em> por encima de todas las ofrendas ascendidas y los sacrificios.",
           "footnotes": [
             {
               "marker": "¹⁶³",
@@ -4113,7 +4172,7 @@
             {
               "marker": "¹⁶⁵",
               "number": "165",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad."
             },
             {
@@ -4153,7 +4212,14 @@
         {
           "verse": 40,
           "tth": "que se comen las casas de las viudas, y con pretextos alargan las palabras de su tefilah¹⁶⁸; por eso, recibirán mayor juicio. La ofrenda de la viuda",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁶⁸",
+              "number": "168",
+              "word": "tefilah",
+              "explanation": "Oración, participación en juicio."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -4220,7 +4286,7 @@
         },
         {
           "verse": 4,
-          "tth": "Dinos, ¿cuándo serán estas <em>cosas, </em> y qué señal <em>habrá</em> cuando se acaben todas estas cosas?",
+          "tth": "Dinos, ¿cuándo serán estas <em>cosas,</em> y qué señal <em>habrá</em> cuando se acaben todas estas cosas?",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4281,7 +4347,7 @@
             {
               "marker": "¹⁷³",
               "number": "173",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad."
             }
           ],
@@ -4483,7 +4549,7 @@
               "marker": "¹⁸¹",
               "number": "181",
               "word": "gritar",
-              "explanation": "‘El grito del gallo' era el nombre que se le daba a la vigilia que daba entre la medianoche y las tres de la madrugada."
+              "explanation": "'El grito del gallo' era el nombre que se le daba a la vigilia que daba entre la medianoche y las tres de la madrugada."
             }
           ],
           "hebrew_terms": []
@@ -4497,7 +4563,14 @@
         {
           "verse": 37,
           "tth": "Y lo que Yo <em>les</em> digo a ustedes, a todos <em>lo</em> digo: ¡Vigilen¹⁸²!",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁸²",
+              "number": "182",
+              "word": "Vigilen",
+              "explanation": "O, ¡Sean diligentes!"
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Complot para apresar y matar a Yeshúa"
         }
@@ -4578,7 +4651,20 @@
         {
           "verse": 9,
           "tth": "verdaderamente Yo les digo <em>que</em> en todos los lugares donde sea proclamada esta Besorah¹⁸⁶, en todo el olam¹⁸⁷, también lo que ha hecho ella será contado para memoria de ella.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁸⁶",
+              "number": "186",
+              "word": "Besorah",
+              "explanation": "Buena noticia."
+            },
+            {
+              "marker": "¹⁸⁷",
+              "number": "187",
+              "word": "olam",
+              "explanation": "Tiempo oculto, sólo conocido por Elohim."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "La traición de Iehudáh"
         },
@@ -4628,7 +4714,7 @@
         },
         {
           "verse": 14,
-          "tth": "Y donde entre, digan al dueño de la casa: “El Rabí¹⁹¹ dijo: ‘¿Dónde está la habitación donde comeré el Pésaj con mis discípulos? ' ”",
+          "tth": "Y donde entre, digan al dueño de la casa: “El Rabí¹⁹¹ dijo: '¿Dónde está la habitación donde comeré el Pésaj con mis discípulos? ' ”",
           "footnotes": [
             {
               "marker": "¹⁹¹",
@@ -4839,7 +4925,7 @@
             {
               "marker": "¹⁹⁷",
               "number": "197",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -5003,7 +5089,7 @@
             {
               "marker": "²⁰²",
               "number": "202",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -5204,7 +5290,14 @@
         {
           "verse": 15,
           "tth": "Y Pilatos quiso hacer para el pueblo como ellos querían, y <em>les</em> soltó <em>a</em> Baraba²⁰⁹ y <em>les</em> dio a Yeshúa, para castigarlo con azotes y para colgarlo.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁰⁹",
+              "number": "209",
+              "word": "Baraba",
+              "explanation": "Barrabás, que significa: Hijo del padre."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Los soldados se burlan de Yeshúa"
         },
@@ -5278,13 +5371,13 @@
               "marker": "²¹⁴",
               "number": "214",
               "word": "Gólgota",
-              "explanation": "Palabra aramea que significa ‘cráneo', proveniente de la palabra hebrea ‘gulgolet'."
+              "explanation": "Palabra aramea que significa 'cráneo', proveniente de la palabra hebrea 'gulgolet'."
             },
             {
               "marker": "²¹⁵",
               "number": "215",
               "word": "Gulgolet",
-              "explanation": "‘Cráneo' en hebreo."
+              "explanation": "'Cráneo' en hebreo."
             }
           ],
           "hebrew_terms": []
@@ -5475,7 +5568,20 @@
         {
           "verse": 41,
           "tth": "las cuales también, cuando Él estaba en Galil²²⁷, iban detrás de Él y le servían, y otras muchas, y habían subido con Él a Ierushaláim²²⁸.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²²⁷",
+              "number": "227",
+              "word": "Galil",
+              "explanation": "Galilea."
+            },
+            {
+              "marker": "²²⁸",
+              "number": "228",
+              "word": "Ierushaláim",
+              "explanation": "Jerusalén."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Sepultura de Yeshúa"
         },
@@ -5680,7 +5786,14 @@
         {
           "verse": 18,
           "tth": "serpientes tomarán²³⁷, y si cosa dañina es la que bebieren, serán sin daño, y pondrán las manos sobre los enfermos y serán sanados.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²³⁷",
+              "number": "237",
+              "word": "tomarán",
+              "explanation": "O, quitarán."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Yeshúa sube a los cielos"
         },

--- a/data/tth_2/json/matityahu.json
+++ b/data/tth_2/json/matityahu.json
@@ -174,7 +174,7 @@
             {
               "marker": "⁹",
               "number": "9",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad; a veces como Rúaj Ha'Kadosh."
             }
           ],
@@ -409,7 +409,14 @@
         {
           "verse": 15,
           "tth": "y estuvo allá hasta la muerte de Horodós, para completar lo que se dijo por boca del profeta: Y de Mitzráim llamé a mi hijo²⁴.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁴",
+              "number": "24",
+              "word": "hijo",
+              "explanation": "Véase Oseas 11:1."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "La matanza de los niños"
         },
@@ -448,7 +455,14 @@
         {
           "verse": 18,
           "tth": "Voz en Ramáh se oye, lamento, llanto de amarguras, Rajel llora por sus hijos, rehúsa a ser consolada, por sus hijos que no están más²⁸.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁸",
+              "number": "28",
+              "word": "más",
+              "explanation": "Véase Jeremías 31:15."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Vuelta a la tierra de Israel"
         },
@@ -674,7 +688,7 @@
             {
               "marker": "⁴⁷",
               "number": "47",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Así en Ms. Shem Tov, Ver. Munster y Ver. Políglota de Nuremberg dicen: En Rúaj Ha'Kódesh y fuego."
             }
           ],
@@ -740,7 +754,14 @@
         {
           "verse": 17,
           "tth": "Y he aquí, una voz de los cielos dijo: Este es mi Hijo, mi amado, muy muy amado, y mi deleite <em>está</em> en Él⁵².",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁵²",
+              "number": "52",
+              "word": "Él",
+              "explanation": "Así en Ms. Shem Tov, Ver. Munster dice: mi Hijo amado, y en Él se complace mi ser."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Yeshúa en el desierto"
         }
@@ -756,7 +777,7 @@
             {
               "marker": "⁵³",
               "number": "53",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad."
             },
             {
@@ -768,7 +789,7 @@
             {
               "marker": "⁵⁵",
               "number": "55",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             }
           ],
@@ -1202,7 +1223,14 @@
         {
           "verse": 16,
           "tth": "Así iluminará la luz de ustedes delante de todo hombre para mostrarles las buenas obras de ustedes, alabadas y honradas por su Padre que <em>está</em> en los cielos⁸³.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁸³",
+              "number": "83",
+              "word": "cielos",
+              "explanation": "Así en Ms. Shem Tov, Ver. Munster y Ver. Políglota de Nuremberg dicen: para que vean las buenas obras de ustedes, y honren a su Padre que está en los cielos."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Yeshúa no vino a romper la Torah"
         },
@@ -1653,7 +1681,14 @@
         {
           "verse": 4,
           "tth": "para que sea tu justicia en el secreto, y tu Padre que ve en el secreto, te retribuirá en público¹¹⁸. <em>La tefilah</em>",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹¹⁸",
+              "number": "118",
+              "word": "público",
+              "explanation": "Ms. Shem Tov omite: en público. Así también en vers. 6."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -2051,7 +2086,26 @@
         {
           "verse": 6,
           "tth": "De nuevo les dijo: No den el kódesh¹⁴⁵ a los perros ni pongan sus monedas¹⁴⁶ delante de los cerdos, no sea que las mastiquen a ojos de ustedes¹⁴⁷ y se vuelvan a ustedes para despedazarlos.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁴⁵",
+              "number": "145",
+              "word": "kódesh",
+              "explanation": "La santidad. Así en Ver. Munster y Ver. Políglota de Nuremberg, Ms. Shem Tov dice: la carne de santidad (heb.: kódesh)."
+            },
+            {
+              "marker": "¹⁴⁶",
+              "number": "146",
+              "word": "monedas",
+              "explanation": "Lit.: sus caras; posiblemente se refiere a las monedas con caras en ellas."
+            },
+            {
+              "marker": "¹⁴⁷",
+              "number": "147",
+              "word": "ustedes",
+              "explanation": "Así en Ms. Shem Tov, Ver. Munster y Ver. Políglota de Nuremberg dicen: que las pisoteen con sus pies."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Todo el que pide, recibirá"
         },
@@ -2210,7 +2264,14 @@
         {
           "verse": 23,
           "tth": "Entonces les diré: Nunca los conocí; apártense de mí, todos los hacedores de vacuidad¹⁵⁶.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁵⁶",
+              "number": "156",
+              "word": "vacuidad",
+              "explanation": "Véase Salmo 6:8."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "La casa sobre la roca y sobre la arena"
         },
@@ -2450,7 +2511,20 @@
         {
           "verse": 17,
           "tth": "para completar lo que se dijo por mano de Ieshaiáh¹⁷¹ el profeta: Verdaderamente nuestras enfermedades Él llevó, y nuestros dolores Él los cargó¹⁷².",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁷¹",
+              "number": "171",
+              "word": "Ieshaiáh",
+              "explanation": "Isaías."
+            },
+            {
+              "marker": "¹⁷²",
+              "number": "172",
+              "word": "cargó",
+              "explanation": "Véase Isaías 53:4."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Lo que requiere seguir a Yeshúa"
         },
@@ -2480,7 +2554,7 @@
             {
               "marker": "¹⁷⁴",
               "number": "174",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -2648,7 +2722,7 @@
             {
               "marker": "¹⁸⁰",
               "number": "180",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -2927,7 +3001,14 @@
         {
           "verse": 34,
           "tth": "Y decían los perushim: En verdad, en el nombre¹⁹⁷ de los demonios saca <em>a</em> los demonios.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁹⁷",
+              "number": "197",
+              "word": "nombre",
+              "explanation": "Así en Ms. Shem Tov, Ver. Políglota de Nuremberg y Ver. Munster, dicen: por el príncipe de."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "El trabajo de Yeshúa"
         },
@@ -3222,7 +3303,7 @@
             {
               "marker": "²¹⁷",
               "number": "217",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -3569,7 +3650,20 @@
         {
           "verse": 19,
           "tth": "Y el Ben Ha'Adam²³⁵ vino para comer y para beber, y se dice acerca de Él: “Él es glotón²³⁶ y borracho, amante de los violentos y pecadores”. Y los necios juzgan a los sabios.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²³⁵",
+              "number": "235",
+              "word": "Ben Ha'Adam",
+              "explanation": "Hijo del Hombre; un título para el Mesías."
+            },
+            {
+              "marker": "²³⁶",
+              "number": "236",
+              "word": "glotón",
+              "explanation": "Lit.: despreciado."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Ayes sobre ciudades de Galil"
         },
@@ -3762,7 +3856,7 @@
             {
               "marker": "²⁴⁷",
               "number": "247",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             },
             {
@@ -3863,7 +3957,20 @@
         {
           "verse": 21,
           "tth": "No se atenuará y no será aplastado, hasta que haya puesto en la tierra la justicia, y por su Torah²⁵¹ las islas esperarán²⁵².",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁵¹",
+              "number": "251",
+              "word": "Torah",
+              "explanation": "Así en Ver. Munster, los demás mss. de Mateo sustituyen 'Torah' por 'Nombre'."
+            },
+            {
+              "marker": "²⁵²",
+              "number": "252",
+              "word": "esperarán",
+              "explanation": "Véase Isaías 42:1\\-4."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Injuria contra el Rúaj Ha'Kódesh"
         },
@@ -3962,7 +4069,7 @@
             {
               "marker": "²⁵⁷",
               "number": "257",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             },
             {
@@ -4037,7 +4144,7 @@
             {
               "marker": "²⁶¹",
               "number": "261",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -4204,7 +4311,20 @@
         {
           "verse": 14,
           "tth": "Para cumplir lo que se dijo por boca²⁶⁴ de Ieshaiáh²⁶⁵ el profeta: Ve, y dirás a este pueblo: “Escuchando, han escuchado, pero no han entendido; viendo, han visto, pero no han conocido. Él ha engrosado el corazón de este pueblo, sus oídos ha hecho pesados, y sus ojos ha embadurnado, para que no vea con sus ojos, y con sus oídos escuche,",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁶⁴",
+              "number": "264",
+              "word": "boca",
+              "explanation": "Otro ms. de Shem Tov dice: por medio."
+            },
+            {
+              "marker": "²⁶⁵",
+              "number": "265",
+              "word": "Ieshaiáh",
+              "explanation": "Isaías."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -4232,13 +4352,13 @@
             {
               "marker": "²⁶⁶",
               "number": "266",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             },
             {
               "marker": "²⁶⁷",
               "number": "267",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             },
             {
@@ -4326,7 +4446,7 @@
         },
         {
           "verse": 30,
-          "tth": "Sino dejen estas y aquellas, y crezcan hasta la cosecha, y en el tiempo de la cosecha diré a los cosechadores: ‘Recojan la cizaña primero y átenla <em>en</em> manojos, manojos para quemar; y el trigo pónganlo en el almacén' ”.",
+          "tth": "Sino dejen estas y aquellas, y crezcan hasta la cosecha, y en el tiempo de la cosecha diré a los cosechadores: 'Recojan la cizaña primero y átenla <em>en</em> manojos, manojos para quemar; y el trigo pónganlo en el almacén' ”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4387,7 +4507,7 @@
             {
               "marker": "²⁷³",
               "number": "273",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -4413,7 +4533,7 @@
             {
               "marker": "²⁷⁵",
               "number": "275",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             }
           ],
@@ -4531,7 +4651,7 @@
               "marker": "²⁷⁸",
               "number": "278",
               "word": "Iaacob",
-              "explanation": "El nombre de Iaacob en Ms. Shem Tov se presenta con una letra ‘guímel' (g), representándolo en idioma extranjero: ‘Guimi'. Por otro lado, según la Peshita, ‘guímel' aquí significa ‘tres', traduciendo: sus tres hermanos; omitiendo así a Iaacob."
+              "explanation": "El nombre de Iaacob en Ms. Shem Tov se presenta con una letra 'guímel' (g), representándolo en idioma extranjero: 'Guimi'. Por otro lado, según la Peshita, 'guímel' aquí significa 'tres', traduciendo: sus tres hermanos; omitiendo así a Iaacob."
             }
           ],
           "hebrew_terms": []
@@ -4686,7 +4806,7 @@
               "marker": "²⁸⁴",
               "number": "284",
               "word": "torres",
-              "explanation": "Posiblemente signifique: ‘aldeas'."
+              "explanation": "Posiblemente signifique: 'aldeas'."
             }
           ],
           "hebrew_terms": []
@@ -5159,7 +5279,14 @@
         {
           "verse": 31,
           "tth": "Y la gente estaba asombrada, ¿cómo los mudos estaban hablando, y los lisiados andaban y los ciegos veían? Y todos alababan a El³⁰⁷.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "³⁰⁷",
+              "number": "307",
+              "word": "El",
+              "explanation": "Contracción de Elohim. Así en Ms. Shem Tov, otros mss. dicen: al Elohim de Israel."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Alimentación de los cuatro mil"
         },
@@ -5339,7 +5466,14 @@
         {
           "verse": 12,
           "tth": "Entonces entendieron que no estaba diciendo de guardarse de la levadura del pan, sino de la enseñanza de los perushim y los tzedukim³¹⁶.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "³¹⁶",
+              "number": "316",
+              "word": "tzedukim",
+              "explanation": "Así en Ver. Munster, Ms. Shem Tov omite este versículo."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Shimón cree que Yeshúa es el Mesías"
         },
@@ -5357,7 +5491,7 @@
               "marker": "³¹⁸",
               "number": "318",
               "word": "Filipos",
-              "explanation": "Así solamente en Ms. Shem Tov. Filipos el tetrarca llamó a esta ciudad ‘Cesarea', luego pasó a formar parte de la prov. romana de Siria."
+              "explanation": "Así solamente en Ms. Shem Tov. Filipos el tetrarca llamó a esta ciudad 'Cesarea', luego pasó a formar parte de la prov. romana de Siria."
             }
           ],
           "hebrew_terms": []
@@ -5414,7 +5548,7 @@
               "marker": "³²²",
               "number": "322",
               "word": "oración",
-              "explanation": "Así en Ms. Shem Tov; en heb., las palabras ‘piedra' (even) y ‘edificaré' (avnéh) se conectan, formándose así una paranomasia. Ver. Munster dice: Tú eres Kefah, y sobre esta piedra (aram., kefah) edificaré mi congregación (…)."
+              "explanation": "Así en Ms. Shem Tov; en heb., las palabras 'piedra' (even) y 'edificaré' (avnéh) se conectan, formándose así una paranomasia. Ver. Munster dice: Tú eres Kefah, y sobre esta piedra (aram., kefah) edificaré mi congregación (…)."
             }
           ],
           "hebrew_terms": []
@@ -5470,7 +5604,7 @@
             {
               "marker": "³²⁶",
               "number": "326",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             },
             {
@@ -5496,7 +5630,7 @@
               "marker": "³²⁹",
               "number": "329",
               "word": "travesaño",
-              "explanation": "Heb.: Ha'shti ve'arev; ‘Shti' y ‘Arev' son los nombres de los hilos entrecruzados con los que se teje una tela. En la tradición judía popular, la combinación se utiliza como eufemismo para la forma de la cruz."
+              "explanation": "Heb.: Ha'shti ve'arev; 'Shti' y 'Arev' son los nombres de los hilos entrecruzados con los que se teje una tela. En la tradición judía popular, la combinación se utiliza como eufemismo para la forma de la cruz."
             }
           ],
           "hebrew_terms": []
@@ -5542,7 +5676,14 @@
         {
           "verse": 28,
           "tth": "Verdaderamente Yo les digo que hay <em>algunos</em> de los que están aquí que no probarán la muerte hasta que vean al Hijo de Eloha³³³ venir en su reino.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "³³³",
+              "number": "333",
+              "word": "Eloha",
+              "explanation": "Singular de Elohim. Así en Ms. Shem Tov; Ver. Políglota de Nuremberg y Ver. Munster dicen: Hijo del Hombre."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "El cuerpo de Yeshúa se transforma"
         }
@@ -5583,7 +5724,7 @@
               "marker": "³³⁶",
               "number": "336",
               "word": "Él",
-              "explanation": "Desde ‘y le hablaban' hasta ‘dos hombres con Él', aparece solamente en Ms. Shem Tov."
+              "explanation": "Desde 'y le hablaban' hasta 'dos hombres con Él', aparece solamente en Ms. Shem Tov."
             }
           ],
           "hebrew_terms": []
@@ -5596,7 +5737,7 @@
               "marker": "³³⁷",
               "number": "337",
               "word": "hablaba",
-              "explanation": "‘Porque no se sabía lo que Él hablaba' aparece solamente en Ms. Shem Tov."
+              "explanation": "'Porque no se sabía lo que Él hablaba' aparece solamente en Ms. Shem Tov."
             }
           ],
           "hebrew_terms": []
@@ -5633,7 +5774,7 @@
             {
               "marker": "³³⁸",
               "number": "338",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -5672,7 +5813,7 @@
             {
               "marker": "³⁴¹",
               "number": "341",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -5716,7 +5857,7 @@
             {
               "marker": "³⁴³",
               "number": "343",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             },
             {
@@ -5734,7 +5875,7 @@
             {
               "marker": "³⁴⁶",
               "number": "346",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             }
           ],
@@ -5791,7 +5932,7 @@
             {
               "marker": "³⁵¹",
               "number": "351",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -5954,7 +6095,7 @@
             {
               "marker": "³⁶⁰",
               "number": "360",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             },
             {
@@ -6105,7 +6246,7 @@
               "marker": "³⁶⁷",
               "number": "367",
               "word": "debes",
-              "explanation": "‘¡Completa lo que tú me debes!', fue tomado de Ver. Munster, los mss. de Shem Tov omiten esta frase."
+              "explanation": "'¡Completa lo que tú me debes!', fue tomado de Ver. Munster, los mss. de Shem Tov omiten esta frase."
             }
           ],
           "hebrew_terms": []
@@ -6118,7 +6259,7 @@
               "marker": "³⁶⁸",
               "number": "368",
               "word": "diciendo",
-              "explanation": "‘Y se arrodilló … diciendo', fue tomado de Ver. Munster, los mss. de Shem Tov omiten esta frase."
+              "explanation": "'Y se arrodilló … diciendo', fue tomado de Ver. Munster, los mss. de Shem Tov omiten esta frase."
             }
           ],
           "hebrew_terms": []
@@ -6395,7 +6536,7 @@
         },
         {
           "verse": 21,
-          "tth": "Y le dijo Yeshúa: Si quieres ser entero, ve y vende todo lo que es tuyo y dalo a los pobres, y habrá para ti un tesoro en los cielos, y ven detrás de Mí.",
+          "tth": "Y le dijo Yeshúa: Si quieres ser entero, ve y vende todo lo que es tuyo y dalo a los po\\-bres, y habrá para ti un tesoro en los cielos, y ven detrás de Mí.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -6456,7 +6597,7 @@
             {
               "marker": "³⁸⁷",
               "number": "387",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             },
             {
@@ -6608,7 +6749,7 @@
             {
               "marker": "³⁹¹",
               "number": "391",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -6617,7 +6758,14 @@
         {
           "verse": 19,
           "tth": "y también lo entregarán a los gentiles para golpearlo y para destruirlo³⁹², y al tercer día se levantará.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "³⁹²",
+              "number": "392",
+              "word": "destruirlo",
+              "explanation": "Así en Ms. Shem Tov, Ver. Políglota de Nuremberg y Ver. Munster dicen: para burlarlo, para golpearlo y para colgarlo."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "La petición de la esposa de Zavdi y sus hijos"
         },
@@ -6716,7 +6864,7 @@
               "marker": "³⁹⁷",
               "number": "397",
               "word": "viene",
-              "explanation": "‘y preguntaron … viene' aparece solamente en Ms. Shem Tov."
+              "explanation": "'y preguntaron … viene' aparece solamente en Ms. Shem Tov."
             }
           ],
           "hebrew_terms": []
@@ -6749,7 +6897,20 @@
         {
           "verse": 34,
           "tth": "Y tuvo compasión por ellos Yeshúa, y tocó sus ojos, y les dijo: Su emunah³⁹⁹ los ha sanado. E inmediatamente vieron y alabaron a El⁴⁰⁰, y fueron detrás de Él. Y todo el pueblo alabó a El por esto",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "³⁹⁹",
+              "number": "399",
+              "word": "emunah",
+              "explanation": "Firmeza, fidelidad, crianza."
+            },
+            {
+              "marker": "⁴⁰⁰",
+              "number": "400",
+              "word": "El",
+              "explanation": "Contracción de Elohim."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "El Rey montando sobre un asnito"
         }
@@ -6886,7 +7047,20 @@
         {
           "verse": 11,
           "tth": "Y <em>los del</em> pueblo se decían unos a otros⁴¹¹: Es Yeshúa, el profeta de Natzrat, que <em>está</em> en Galil⁴¹².",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁴¹¹",
+              "number": "411",
+              "word": "otros",
+              "explanation": "Lit.: este a este."
+            },
+            {
+              "marker": "⁴¹²",
+              "number": "412",
+              "word": "Galil",
+              "explanation": "Galilea."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Yeshúa echa a los mercaderes de la casa de יהוה"
         },
@@ -7000,7 +7174,14 @@
         {
           "verse": 22,
           "tth": "Y todo lo que pidan en tefilah y sean firmes⁴²⁰, lo recibirán.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁴²⁰",
+              "number": "420",
+              "word": "firmes",
+              "explanation": "O, y crean."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "El poder de Yeshúa"
         },
@@ -7012,7 +7193,7 @@
         },
         {
           "verse": 24,
-          "tth": "Y les respondió Yeshúa, y les dijo: Yo también pediré de ustedes una palabra, y si me la dicen, Yo también les diré con qué poder hago <em>esto. </em>",
+          "tth": "Y les respondió Yeshúa, y les dijo: Yo también pediré de ustedes una palabra, y si me la dicen, Yo también les diré con qué poder hago <em>esto.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7037,7 +7218,7 @@
         },
         {
           "verse": 27,
-          "tth": "Y dijeron: No sabemos. Y Él dijo: Yo tampoco les digo con qué poder hago <em>esto. </em>",
+          "tth": "Y dijeron: No sabemos. Y Él dijo: Yo tampoco les digo con qué poder hago <em>esto.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7234,7 +7415,7 @@
         },
         {
           "verse": 4,
-          "tth": "Y envió de nuevo <em>a</em> otros siervos, diciendo: “Digan a los llamados: ‘He aquí, he preparado un banquete, y he sacrificado toros y aves, y todo está listo. ¡Vengan a la boda! ' ”.",
+          "tth": "Y envió de nuevo <em>a</em> otros siervos, diciendo: “Digan a los llamados: 'He aquí, he preparado un banquete, y he sacrificado toros y aves, y todo está listo. ¡Vengan a la boda! ' ”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7545,7 +7726,7 @@
         },
         {
           "verse": 39,
-          "tth": "El segundo es semejante a este: Y amarás a tu compañero como a ti <em>mismo</em>⁴⁴⁵<em>. </em>",
+          "tth": "El segundo es semejante a este: Y amarás a tu compañero como a ti <em>mismo</em>⁴⁴⁵<em>.</em>",
           "footnotes": [
             {
               "marker": "⁴⁴⁵",
@@ -7589,7 +7770,7 @@
             {
               "marker": "⁴⁴⁷",
               "number": "447",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad."
             }
           ],
@@ -7977,7 +8158,14 @@
         {
           "verse": 39,
           "tth": "En verdad Yo les digo: No me verán desde ahora en adelante, hasta que digan: ¡Bendito nuestro Salvador⁴⁶⁷! Profecía de la destrucción del Santuario",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁴⁶⁷",
+              "number": "467",
+              "word": "Salvador",
+              "explanation": "Así en Ms. Shem Tov, Políglota de Nuremberg y Ver. Munster dicen: Bendito el que viene en el Nombre de יהוה."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -8081,7 +8269,14 @@
         {
           "verse": 14,
           "tth": "Y se enseñará esta buena noticia⁴⁷⁰ en toda la tierra para testimonio acerca de Mí a todas las naciones, y entonces vendrá la consumación.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁴⁷⁰",
+              "number": "470",
+              "word": "noticia",
+              "explanation": "Heb.: Besorah."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "La abominación desoladora"
         },
@@ -8198,7 +8393,7 @@
             {
               "marker": "⁴⁷⁶",
               "number": "476",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -8230,7 +8425,7 @@
             {
               "marker": "⁴⁷⁸",
               "number": "478",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías. Así en el resto del cap."
             },
             {
@@ -8648,7 +8843,7 @@
             {
               "marker": "⁴⁹³",
               "number": "493",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -8736,7 +8931,7 @@
             {
               "marker": "⁴⁹⁷",
               "number": "497",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             }
           ],
@@ -8804,7 +8999,7 @@
             {
               "marker": "⁵⁰⁰",
               "number": "500",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             },
             {
@@ -8856,7 +9051,7 @@
               "marker": "⁵⁰⁴",
               "number": "504",
               "word": "Jananiáh",
-              "explanation": "Betania. ‘Bet Jananiáh' en Mateo 21:17."
+              "explanation": "Betania. 'Bet Jananiáh' en Mateo 21:17."
             }
           ],
           "hebrew_terms": []
@@ -8907,7 +9102,26 @@
         {
           "verse": 13,
           "tth": "Verdaderamente Yo les digo: En todo lugar que se proclame esta buena noticia⁵⁰⁶, en todo el olam⁵⁰⁷, se dirá lo que esta ha hecho en mi memoria⁵⁰⁸.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁵⁰⁶",
+              "number": "506",
+              "word": "noticia",
+              "explanation": "Heb.: Besorah."
+            },
+            {
+              "marker": "⁵⁰⁷",
+              "number": "507",
+              "word": "olam",
+              "explanation": "Tiempo oculto, sólo conocido por Elohim."
+            },
+            {
+              "marker": "⁵⁰⁸",
+              "number": "508",
+              "word": "memoria",
+              "explanation": "Así en Ms. Shem Tov, Políglota de Nuremberg y Ver. Munster dicen: en memoria suya."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "La traición de Iehudáh"
         },
@@ -8963,7 +9177,7 @@
         },
         {
           "verse": 18,
-          "tth": "Y Él les dijo: Vayan a la ciudad, a cierto hombre cuyo corazón será voluntario para obrar, y díganle: “Así ha dicho el Rab⁵¹³: ‘Mi tiempo está cerca, contigo haré el Pésaj junto a mis discípulos' ”.",
+          "tth": "Y Él les dijo: Vayan a la ciudad, a cierto hombre cuyo corazón será voluntario para obrar, y díganle: “Así ha dicho el Rab⁵¹³: 'Mi tiempo está cerca, contigo haré el Pésaj junto a mis discípulos' ”.",
           "footnotes": [
             {
               "marker": "⁵¹³",
@@ -9032,7 +9246,7 @@
             {
               "marker": "⁵¹⁷",
               "number": "517",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -9041,7 +9255,14 @@
         {
           "verse": 25,
           "tth": "Y respondió Iehudáh, el que lo vendió, y le dijo: Rabí⁵¹⁸, ¿soy yo ese? Y Él dijo: Tú has hablado.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁵¹⁸",
+              "number": "518",
+              "word": "Rabí",
+              "explanation": "Grande; un título para el maestro."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "El pacto renovado"
         },
@@ -9072,7 +9293,14 @@
         {
           "verse": 30,
           "tth": "Y se fueron y salieron al monte de los Olivos⁵¹⁹.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁵¹⁹",
+              "number": "519",
+              "word": "Olivos",
+              "explanation": "Así en Ms. Shem Tov, Ver. Políglota de Nuremberg dice: y cuando alabaron, salió al monte de los Olivos. Ver. Munster dice: y cuando dijeron la alabanza, salieron al monte de los Olivos."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Yeshúa anuncia la negación de Kefa"
         },
@@ -9189,7 +9417,7 @@
             {
               "marker": "⁵²³",
               "number": "523",
-              "word": "Adam",
+              "word": "Ben Ha'Adam",
               "explanation": "Hijo del Hombre; un título para el Mesías."
             }
           ],
@@ -9379,7 +9607,7 @@
               "marker": "⁵³³",
               "number": "533",
               "word": "blasfemó",
-              "explanation": "Así en el texto de los mss. de Shem Tov, que utilizan el término ‘bérej', es decir: bendijo; pero dicho como eufemismo, por lo tanto, se traduce como: blasfemó o maldijo."
+              "explanation": "Así en el texto de los mss. de Shem Tov, que utilizan el término 'bérej', es decir: bendijo; pero dicho como eufemismo, por lo tanto, se traduce como: blasfemó o maldijo."
             }
           ],
           "hebrew_terms": []
@@ -9656,7 +9884,7 @@
         },
         {
           "verse": 20,
-          "tth": "Pero los grandes de los sacerdotes y los ancianos de la ley congregaron al pueblo, <em>diciendo: </em>¡Pidan a Baraba, y que Yeshúa muera!",
+          "tth": "Pero los grandes de los sacerdotes y los ancianos de la ley congregaron al pueblo, <em>diciendo:</em>¡Pidan a Baraba, y que Yeshúa muera!",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -9718,7 +9946,7 @@
         },
         {
           "verse": 29,
-          "tth": "E hicieron una corona de espinas y la pusieron sobre su cabeza, y le pusieron una vara en la mano derecha; y se inclinaban burlándose de Él, <em>diciendo: </em>¡Paz a ti⁵⁴⁸, Rey de los iehudim⁵⁴⁹!",
+          "tth": "E hicieron una corona de espinas y la pusieron sobre su cabeza, y le pusieron una vara en la mano derecha; y se inclinaban burlándose de Él, <em>diciendo:</em>¡Paz a ti⁵⁴⁸, Rey de los iehudim⁵⁴⁹!",
           "footnotes": [
             {
               "marker": "⁵⁴⁸",
@@ -9761,7 +9989,7 @@
               "marker": "⁵⁵¹",
               "number": "551",
               "word": "travesaño",
-              "explanation": "Heb.: Ha'shti ve'arev; ‘Shti' y ‘Arev' son los nombres de los hilos entrecruzados con los que se teje una tela. En la tradición judía popular, la combinación se utiliza como eufemismo para la forma de la cruz."
+              "explanation": "Heb.: Ha'shti ve'arev; 'Shti' y 'Arev' son los nombres de los hilos entrecruzados con los que se teje una tela. En la tradición judía popular, la combinación se utiliza como eufemismo para la forma de la cruz."
             }
           ],
           "hebrew_terms": []
@@ -9774,20 +10002,20 @@
               "marker": "⁵⁵²",
               "number": "552",
               "word": "Gólgota",
-              "explanation": "Palabra aramea que significa ‘cráneo', proveniente de la palabra hebrea ‘gulgolet'."
+              "explanation": "Palabra aramea que significa 'cráneo', proveniente de la palabra hebrea 'gulgolet'."
             },
             {
               "marker": "⁵⁵³",
               "number": "553",
               "word": "Caluvari",
-              "explanation": "Palabra del latín ‘calvari', que significa ‘cráneo'."
+              "explanation": "Palabra del latín 'calvari', que significa 'cráneo'."
             }
           ],
           "hebrew_terms": []
         },
         {
           "verse": 34,
-          "tth": "Y le dieron vino mezclado con hiel. Y cuando comenzó a beber, <em>lo</em> percibió, y no quiso beber <em>lo. </em>",
+          "tth": "Y le dieron vino mezclado con hiel. Y cuando comenzó a beber, <em>lo</em> percibió, y no quiso beber <em>lo.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -10025,7 +10253,14 @@
         {
           "verse": 61,
           "tth": "Y estaban allí Miriam Migdalit y la otra Miriam, sentadas delante del sepulcro⁵⁶⁵.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁵⁶⁵",
+              "number": "565",
+              "word": "sepulcro",
+              "explanation": "Todos los mss. de Shem Tov omiten este vers."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Los guardias en el sepulcro"
         },
@@ -10141,7 +10376,14 @@
         {
           "verse": 10,
           "tth": "Entonces les dijo Yeshúa: No teman. Digan a mis hermanos que vayan a Galil⁵⁶⁹, y allá me verán.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁵⁶⁹",
+              "number": "569",
+              "word": "Galil",
+              "explanation": "Galilea. Así también en vers. 16."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Informe de los guardias"
         },
@@ -10165,7 +10407,7 @@
         },
         {
           "verse": 14,
-          "tth": "Y si esto llega a oídos de Pilatos, nosotros hablaremos con él, <em>y</em> en el asunto los dejará <em>en paz. </em>",
+          "tth": "Y si esto llega a oídos de Pilatos, nosotros hablaremos con él, <em>y</em> en el asunto los dejará <em>en paz.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/melajim_alef.json
+++ b/data/tth_2/json/melajim_alef.json
@@ -41,7 +41,14 @@
         {
           "verse": 4,
           "tth": "Y la joven <em>era</em> hermosa extremadamente²; y ella al rey cuidaba y le servía, pero el rey no la conoció.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²",
+              "number": "2",
+              "word": "extremadamente",
+              "explanation": "Lit.: hasta mucho."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Rebelión de Adoniyah"
         },
@@ -1234,7 +1241,14 @@
         {
           "verse": 12,
           "tth": "Y יהוה dio sabiduría a Shelomóh, como había hablado a él, y hubo shalom entre Jiram y Shelomóh, e hicieron²⁶ un pacto los dos. Edificación de la casa de יהוה",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁶",
+              "number": "26",
+              "word": "hicieron",
+              "explanation": "Unidad de medida. O sea, alrededor de cuatro mil cuatrocientos litros."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -1277,7 +1291,14 @@
         {
           "verse": 18,
           "tth": "Y cortaron los constructores de Shelomóh y los constructores de Jiram y los giblim²⁸, y afirmaron las maderas y las piedras para edificar la casa. Shelomóh construye la casa",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁸",
+              "number": "28",
+              "word": "giblim",
+              "explanation": "Giblitas."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -1558,7 +1579,20 @@
         {
           "verse": 38,
           "tth": "Y en el año undécimo, en el mes lunar de Bul³⁶, este es el mes octavo, terminó la casa por todas sus cosas y por todo su proceso legal³⁷. Y la edificó en siete años. El palacio de Shelomóh",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "³⁶",
+              "number": "36",
+              "word": "Bul",
+              "explanation": "O sea, el mes octavo."
+            },
+            {
+              "marker": "³⁷",
+              "number": "37",
+              "word": "legal",
+              "explanation": "Heb.: Mishpat."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -2137,7 +2171,14 @@
         {
           "verse": 21,
           "tth": "Y puse allí un lugar para el arca, que allí está el pacto de יהוה el cual hizo⁵⁸ con nuestros padres cuando los hizo salir de la tierra de Mitzráim. Oración de dedicación de la casa",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁵⁸",
+              "number": "58",
+              "word": "hizo",
+              "explanation": "Lit.: cortó."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -2914,7 +2955,14 @@
         {
           "verse": 29,
           "tth": "Y subía y salía un carro de Mitzráim por seiscientos shekel de plata, y un caballo por ciento cincuenta, y así para todos los reyes de los jitim⁸² y para los reyes de Aram por su mano los sacaban. Shelomóh se desvía de יהוה",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁸²",
+              "number": "82",
+              "word": "jitim",
+              "explanation": "Hititas."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -3890,7 +3938,14 @@
         {
           "verse": 31,
           "tth": "Y descansó Rejabam con sus padres y fue enterrado con sus padres en la ciudad de David; y el nombre de su madre era Naamáh la amonit⁹⁹. Y reinó Abiam, su hijo, en su lugar. Reinado de Abiam",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁹⁹",
+              "number": "99",
+              "word": "nit",
+              "explanation": "Amonita."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -4349,7 +4404,26 @@
         {
           "verse": 34,
           "tth": "En sus días edificó Jiel el betelí¹⁰⁶, a Ierijó¹⁰⁷. En Abiram su primogénito la fundó, y en Segub su menor estableció sus puertas; conforme a la palabra de יהוה que había hablado por mano de Yehoshúa, hijo de Nun¹⁰⁸. Eliyáhu predice la sequía",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁰⁶",
+              "number": "106",
+              "word": "betelí",
+              "explanation": "Habitante de Betel."
+            },
+            {
+              "marker": "¹⁰⁷",
+              "number": "107",
+              "word": "Ierijó",
+              "explanation": "Jericó."
+            },
+            {
+              "marker": "¹⁰⁸",
+              "number": "108",
+              "word": "Nun",
+              "explanation": "Véase Josué 6:26."
+            }
+          ],
           "hebrew_terms": []
         }
       ]

--- a/data/tth_2/json/melajim_bet.json
+++ b/data/tth_2/json/melajim_bet.json
@@ -1725,7 +1725,20 @@
         {
           "verse": 13,
           "tth": "Y se apresuraron y tomaron cada hombre su vestidura y las pusieron debajo de él en la desnudez³⁹ de las escaleras, y soplaron con el shofar⁴⁰ y dijeron: ¡Reina Iehú! Muerte de Ioram y de Ajazyáhu",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "³⁹",
+              "number": "39",
+              "word": "desnudez",
+              "explanation": "Lit.: el hueso."
+            },
+            {
+              "marker": "⁴⁰",
+              "number": "40",
+              "word": "shofar",
+              "explanation": "Cuerno de carnero."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -4318,7 +4331,14 @@
         {
           "verse": 19,
           "tth": "Y dijo Jizkiyahu a Ieshaiáhu: Buena es la palabra de יהוה que has hablado. Y decía: ¿No?, ¿si shalom¹⁰⁷ y verdad hay en mis días? Muerte de Jizkiyahu",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁰⁷",
+              "number": "107",
+              "word": "shalom",
+              "explanation": "Plenitud, ausencia de deudas."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -4545,7 +4565,14 @@
         {
           "verse": 7,
           "tth": "Sin embargo, no se les pedirá cuenta del¹⁰⁹ dinero dado en sus manos, porque con fidelidad ellos obran. Hallazgo del rollo de la Torah",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁰⁹",
+              "number": "109",
+              "word": "del",
+              "explanation": "Lit.: no se calculará con ellos el…"
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -4630,7 +4657,14 @@
         {
           "verse": 20,
           "tth": "'Por eso, he aquí, Yo te reuniré con tus padres, y serás reunido en tu tumba en shalom¹¹¹ y no verán tus ojos a todo el mal que Yo haré venir sobre este lugar' ”. Y regresaron palabra al rey. Reformas del rey Ioshiyahu",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹¹¹",
+              "number": "111",
+              "word": "shalom",
+              "explanation": "Plenitud, ausencia de deudas."
+            }
+          ],
           "hebrew_terms": []
         }
       ]

--- a/data/tth_2/json/micah.json
+++ b/data/tth_2/json/micah.json
@@ -217,7 +217,14 @@
         {
           "verse": 4,
           "tth": "En aquel día se levantará sobre ustedes un proverbio¹³, y se lamentará con elegía de lamentación, diciendo: “Ciertamente fuimos devastados; la porción de mi pueblo Él ha cambiado. ¡Cómo me la ha quitado! Al rebelde nuestros campos ha repartido”.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹³",
+              "number": "13",
+              "word": "proverbio",
+              "explanation": "O, una parábola."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -506,7 +513,14 @@
         {
           "verse": 13,
           "tth": "¡Levántate y trilla, hija de Tzión!, porque tu cuerno pondré de hierro y tus pezuñas pondré de cobre, y molerás muchos pueblos, y apartarás para יהוה su ganancia injusta, y su fuerza para el Adón²⁵ de toda la tierra. Nacimiento del Rey en Bet Léjem",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁵",
+              "number": "25",
+              "word": "Adón",
+              "explanation": "Amo, Señor."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -561,7 +575,14 @@
         {
           "verse": 5,
           "tth": "Y Este será shalom²⁹. Cuando Ashur entre en nuestra tierra, y pise en nuestros palacios, levantaremos sobre él siete pastores y ocho príncipes de hombres.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁹",
+              "number": "29",
+              "word": "shalom",
+              "explanation": "Plenitud, ausencia de deudas."
+            }
+          ],
           "hebrew_terms": []
         },
         {

--- a/data/tth_2/json/mishlei.json
+++ b/data/tth_2/json/mishlei.json
@@ -2154,7 +2154,7 @@
         },
         {
           "verse": 28,
-          "tth": "En la senda de justicia <em>hay</em> vida, pero otro camino <em>va</em> a la muerte (El T. M. dice: u'dérej netivah al mávet, ‘y un camino, una senda, no muerte', el texto es incierto. En la versión gr. dice, pero el camino de los vengativos va hacia la muerte).",
+          "tth": "En la senda de justicia <em>hay</em> vida, pero otro camino <em>va</em> a la muerte (El T. M. dice: u'dérej netivah al mávet, 'y un camino, una senda, no muerte', el texto es incierto. En la versión gr. dice, pero el camino de los vengativos va hacia la muerte).",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -3157,7 +3157,7 @@
         },
         {
           "verse": 8,
-          "tth": "Las palabras del murmurador son como heridas (O, <em>un ávido comer; </em> o, <em>incitación</em>), y ellas descienden a las cámaras del vientre.",
+          "tth": "Las palabras del murmurador son como heridas (O, <em>un ávido comer;</em> o, <em>incitación</em>), y ellas descienden a las cámaras del vientre.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4482,7 +4482,7 @@
         },
         {
           "verse": 11,
-          "tth": "Manzanas de oro en figuras de plata es la palabra hablada de manera sabia (Lit.: <em>en sus ruedas; </em> o, <em>en sus caras. </em> Significado dudoso).",
+          "tth": "Manzanas de oro en figuras de plata es la palabra hablada de manera sabia (Lit.: <em>en sus ruedas;</em> o, <em>en sus caras.</em> Significado dudoso).",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4721,7 +4721,7 @@
         },
         {
           "verse": 22,
-          "tth": "Las palabras del murmurador son como heridas (O, <em>un ávido comer; </em> o, <em>incitación</em>), y ellas descienden a las cámaras del vientre.",
+          "tth": "Las palabras del murmurador son como heridas (O, <em>un ávido comer;</em> o, <em>incitación</em>), y ellas descienden a las cámaras del vientre.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5535,127 +5535,127 @@
         },
         {
           "verse": 10,
-          "tth": "Mujer de valor, ¿quién <em>la</em> hallará? y lejano <em>más</em> que las perlas su comercio. <em>Bet. </em>",
+          "tth": "Mujer de valor, ¿quién <em>la</em> hallará? y lejano <em>más</em> que las perlas su comercio. <em>Bet.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 11,
-          "tth": "Confía en ella el corazón de su esposo, y botín no faltará. <em>Guímel. </em>",
+          "tth": "Confía en ella el corazón de su esposo, y botín no faltará. <em>Guímel.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 12,
-          "tth": "Ella le retribuye bien y no mal, todos los días de la vida de ella. <em>Dálet. </em>",
+          "tth": "Ella le retribuye bien y no mal, todos los días de la vida de ella. <em>Dálet.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 13,
-          "tth": "Busca lana y lino, y hacen con deleite sus palmas. <em>He. </em>",
+          "tth": "Busca lana y lino, y hacen con deleite sus palmas. <em>He.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 14,
-          "tth": "Ella es como los barcos del mercader, desde lejos hace venir su pan. <em>Vav. </em>",
+          "tth": "Ella es como los barcos del mercader, desde lejos hace venir su pan. <em>Vav.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 15,
-          "tth": "Y se levanta aún en la noche, y da alimento a su casa y porción asignada a sus siervas. <em>Záin. </em>",
+          "tth": "Y se levanta aún en la noche, y da alimento a su casa y porción asignada a sus siervas. <em>Záin.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 16,
-          "tth": "Considera cuidadosamente un campo y lo compra, del fruto de sus palmas planta una viña. <em>Jet. </em>",
+          "tth": "Considera cuidadosamente un campo y lo compra, del fruto de sus palmas planta una viña. <em>Jet.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 17,
-          "tth": "Ciñe con fuerza sus lomos y fortalece sus brazos. <em>Tet. </em>",
+          "tth": "Ciñe con fuerza sus lomos y fortalece sus brazos. <em>Tet.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 18,
-          "tth": "Degusta que su mercadeo es bueno, no se apaga en la noche su lámpara. <em>Yud. </em>",
+          "tth": "Degusta que su mercadeo es bueno, no se apaga en la noche su lámpara. <em>Yud.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 19,
-          "tth": "Sus manos envía a la rueca, y sus palmas sostienen el huso. <em>Caf. </em>",
+          "tth": "Sus manos envía a la rueca, y sus palmas sostienen el huso. <em>Caf.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 20,
-          "tth": "Su palma extiende al humilde, y sus manos envía al necesitado. <em>Lámed. </em>",
+          "tth": "Su palma extiende al humilde, y sus manos envía al necesitado. <em>Lámed.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 21,
-          "tth": "No tiene miedo de la nieve para su casa, porque toda su casa está vestida doble. <em>Mem. </em>",
+          "tth": "No tiene miedo de la nieve para su casa, porque toda su casa está vestida doble. <em>Mem.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 22,
-          "tth": "Colchas hace para ella, lino fino y púrpura es su vestido. <em>Nun. </em>",
+          "tth": "Colchas hace para ella, lino fino y púrpura es su vestido. <em>Nun.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 23,
-          "tth": "Conocido en las puertas es su esposo, cuando se sienta con los ancianos de la tierra. <em>Sámej. </em>",
+          "tth": "Conocido en las puertas es su esposo, cuando se sienta con los ancianos de la tierra. <em>Sámej.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 24,
-          "tth": "Sábanas hace, y vende; y cinturón entrega al comerciante. <em>Áin. </em>",
+          "tth": "Sábanas hace, y vende; y cinturón entrega al comerciante. <em>Áin.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 25,
-          "tth": "Fuerza y ornamento es su vestido, y ríe para el día postrero. <em>Peh. </em>",
+          "tth": "Fuerza y ornamento es su vestido, y ríe para el día postrero. <em>Peh.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 26,
-          "tth": "Su boca abre con sabiduría, y la Torah de bondad sobre su lengua. <em>Tzadi. </em>",
+          "tth": "Su boca abre con sabiduría, y la Torah de bondad sobre su lengua. <em>Tzadi.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 27,
-          "tth": "Ella vigila el caminar de su casa, y el pan de la pereza no come. <em>Kuf. </em>",
+          "tth": "Ella vigila el caminar de su casa, y el pan de la pereza no come. <em>Kuf.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 28,
-          "tth": "Se levantan sus hijos y la llaman ¡feliz!, su esposo, y la alaba. <em>Resh. </em>",
+          "tth": "Se levantan sus hijos y la llaman ¡feliz!, su esposo, y la alaba. <em>Resh.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 29,
-          "tth": "Muchas hijas han hecho valor, pero tú subiste por encima de todas ellas. <em>Shin. </em>",
+          "tth": "Muchas hijas han hecho valor, pero tú subiste por encima de todas ellas. <em>Shin.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 30,
-          "tth": "Mentira es la gracia y vapor la belleza, la mujer que teme a יהוה, ella será alabada. <em>Tav. </em>",
+          "tth": "Mentira es la gracia y vapor la belleza, la mujer que teme a יהוה, ella será alabada. <em>Tav.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/najum.json
+++ b/data/tth_2/json/najum.json
@@ -148,7 +148,14 @@
         {
           "verse": 15,
           "tth": "¡He aquí sobre los montes los pies del que trae buenas noticias, del que hace escuchar shalom⁸! ¡Celebra, Iehudáh, tus fiestas, completa tus votos! Porque no volverá más a pasar en ti el sin provecho, todo él ha sido cortado. Caída de Ninevéh",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁸",
+              "number": "8",
+              "word": "shalom",
+              "explanation": "Plenitud, ausencia de deudas."
+            }
+          ],
           "hebrew_terms": []
         }
       ]

--- a/data/tth_2/json/romanos.json
+++ b/data/tth_2/json/romanos.json
@@ -58,7 +58,7 @@
             {
               "marker": "⁴",
               "number": "4",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad."
             },
             {
@@ -148,7 +148,7 @@
         },
         {
           "verse": 12,
-          "tth": "y esto es, para hacer confortación en ustedes, <em>o sea, </em> en los que están entre nosotros, con la emunah de ustedes y con mi emunah.",
+          "tth": "y esto es, para hacer confortación en ustedes, <em>o sea,</em> en los que están entre nosotros, con la emunah de ustedes y con mi emunah.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -174,7 +174,14 @@
         {
           "verse": 15,
           "tth": "Asimismo, todo en lo que a mí respecta¹², voluntariedades son también a ustedes, los que están en Roma, para anunciarles la Besorah. <em>La Besorah</em>",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹²",
+              "number": "12",
+              "word": "respecta",
+              "explanation": "Lit.: todo lo que hay en mí."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -570,6 +577,12 @@
           "tth": "¡Profanación! Será יהוה firme²⁵ y todo hombre mentiroso, como está escrito: A fin de que estés justificado en tu hablar, limpio en tu juzgar²⁶.",
           "footnotes": [
             {
+              "marker": "²⁵",
+              "number": "25",
+              "word": "firme",
+              "explanation": "O, verdadero."
+            },
+            {
               "marker": "²⁶",
               "number": "26",
               "word": "juzgar",
@@ -665,6 +678,12 @@
           "tth": "Tumba abierta su garganta; harán suave su lengua³². Veneno de víbora hay bajo sus labios³³.",
           "footnotes": [
             {
+              "marker": "³²",
+              "number": "32",
+              "word": "lengua",
+              "explanation": "Véase Salmo 5:9."
+            },
+            {
               "marker": "³³",
               "number": "33",
               "word": "labios",
@@ -690,6 +709,12 @@
           "verse": 15,
           "tth": "Sus pies se apresuran para derramar sangre³⁵. 16 devastación y calamidad hay en sus carreteras³⁶.",
           "footnotes": [
+            {
+              "marker": "³⁵",
+              "number": "35",
+              "word": "sangre",
+              "explanation": "Véase Isaías 59:7 y Proverbios 1:16."
+            },
             {
               "marker": "³⁶",
               "number": "36",
@@ -1064,7 +1089,14 @@
         {
           "verse": 25,
           "tth": "el que fue traspasado por nuestras transgresiones, aplastado por nuestras iniquidades⁵⁵, y se levantó por causa de nuestra justificación. <em>La justificación</em>",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁵⁵",
+              "number": "55",
+              "word": "iniquidades",
+              "explanation": "Véase Isaías 53:5."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -1136,7 +1168,7 @@
             {
               "marker": "⁶¹",
               "number": "61",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad."
             }
           ],
@@ -1243,7 +1275,14 @@
         {
           "verse": 21,
           "tth": "para que, tal como reinó el pecado por la muerte, así reinará el favor por Yeshúa el Mesías nuestro Adón⁶³.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁶³",
+              "number": "63",
+              "word": "Adón",
+              "explanation": "Amo, Señor. Así también en vers. 11."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Los muertos al pecado"
         }
@@ -1576,7 +1615,14 @@
         {
           "verse": 25,
           "tth": "Confieso yo a Elohim en Yeshúa el Mesías nuestro Adón⁶⁹. Por lo tanto, yo en mi mente sirvo a la Torah de Elohim, pero en la carne a la Torah del pecado. Andar en el Rúaj",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁶⁹",
+              "number": "69",
+              "word": "Adón",
+              "explanation": "Amo, Señor."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -1771,7 +1817,14 @@
         {
           "verse": 27,
           "tth": "Y el que escudriña los corazones sabe cuál es la intención del Rúaj, porque conforme al deseo de Elohim intercede por los santos⁷⁴. El amor de Elohim",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁷⁴",
+              "number": "74",
+              "word": "santos",
+              "explanation": "O, apartados; o, distinguidos."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -1883,7 +1936,14 @@
         {
           "verse": 39,
           "tth": "ni lo elevado, ni lo profundo, ni ninguna otra creación, podrán separarnos del amor de Elohim que es en Yeshúa el Mesías nuestro Adón⁸¹.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁸¹",
+              "number": "81",
+              "word": "Adón",
+              "explanation": "Amo, Señor."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "La elección de Elohim"
         }
@@ -1899,7 +1959,7 @@
             {
               "marker": "⁸²",
               "number": "82",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad."
             }
           ],
@@ -2131,6 +2191,12 @@
           "verse": 25,
           "tth": "Como también en Hoshea dice: Y diré al que no era mi pueblo⁹⁵: “Pueblo mío eres tú”, y amaré a la no amada⁹⁶.",
           "footnotes": [
+            {
+              "marker": "⁹⁵",
+              "number": "95",
+              "word": "pueblo",
+              "explanation": "Heb.: Lo Amí."
+            },
             {
               "marker": "⁹⁶",
               "number": "96",
@@ -2398,6 +2464,12 @@
           "tth": "¿Y cómo anunciarán si no han sido enviados? Como está escrito: Qué hermosos son sobre los montes los pies del que da buenas noticias, quien hace escuchar el shalom¹¹⁵, quien da buenas noticias de bien¹¹⁶.",
           "footnotes": [
             {
+              "marker": "¹¹⁵",
+              "number": "115",
+              "word": "shalom",
+              "explanation": "Plenitud, ausencia de deudas."
+            },
+            {
               "marker": "¹¹⁶",
               "number": "116",
               "word": "bien",
@@ -2410,6 +2482,12 @@
           "verse": 16,
           "tth": "Pero no todos han escuchado a la Besorah¹¹⁷, porque Ieshaiáhu dijo: יהוה, ¿quién ha sido afirmado¹¹⁸ a¹¹⁹ nuestro hacer oír¹²⁰?",
           "footnotes": [
+            {
+              "marker": "¹¹⁷",
+              "number": "117",
+              "word": "Besorah",
+              "explanation": "Evangelio, Buena Noticia."
+            },
             {
               "marker": "¹¹⁸",
               "number": "118",
@@ -2486,7 +2564,14 @@
         {
           "verse": 21,
           "tth": "Pero a Israel dijo: Extendí mis manos todo el día hacia un pueblo rebelde, quienes caminan por el camino no bueno, tras sus pensamientos¹²⁵.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹²⁵",
+              "number": "125",
+              "word": "pensamientos",
+              "explanation": "Véase Isaías 65:2."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "La elección del remanente de Israel"
         }
@@ -2581,7 +2666,14 @@
         {
           "verse": 8,
           "tth": "como está escrito: Porque ha derramado sobre ustedes יהוה un espíritu de sueño profundo, y Él ha cerrado sus ojos, y a sus cabezas, ha cubierto con velo¹³², hasta este día.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹³²",
+              "number": "132",
+              "word": "velo",
+              "explanation": "Véase Isaías 29:10."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -2593,7 +2685,14 @@
         {
           "verse": 10,
           "tth": "Se oscurecerán sus ojos de ver, y sus lomos continuamente haz agitar¹³³.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹³³",
+              "number": "133",
+              "word": "agitar",
+              "explanation": "Véase Salmo 69:22."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Los gentiles plantados en el olivo natural"
         },
@@ -2723,7 +2822,14 @@
         {
           "verse": 27,
           "tth": "Y Yo, este es mi pacto con ellos¹³⁸, cuando Yo cargue sus pecados.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹³⁸",
+              "number": "138",
+              "word": "ellos",
+              "explanation": "Véase Isaías 59:20\\-21."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -2781,6 +2887,12 @@
           "tth": "¿Quién midió al Rúaj¹⁴¹ de יהוה, y qué hombre su consejo dará a conocer? ¿A quién pidió consejo y quién le dio entendimiento¹⁴²?,",
           "footnotes": [
             {
+              "marker": "¹⁴¹",
+              "number": "141",
+              "word": "Rúaj",
+              "explanation": "Espíritu, viento, mente, poder."
+            },
+            {
               "marker": "¹⁴²",
               "number": "142",
               "word": "entendimiento",
@@ -2798,7 +2910,14 @@
         {
           "verse": 36,
           "tth": "Porque de Él, por Él, y hacia Él es todo, y para Él es la gloria por los tiempos¹⁴³. Amén.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁴³",
+              "number": "143",
+              "word": "tiempos",
+              "explanation": "Heb.: Olamim."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "El servicio a Elohim"
         }
@@ -3134,7 +3253,14 @@
         {
           "verse": 14,
           "tth": "Sino vístanse del Adón¹⁶¹ Yeshúa el Mesías, y preocúpense de la carne, no haciendo los deseos.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁶¹",
+              "number": "161",
+              "word": "Adón",
+              "explanation": "Amo, Señor."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Los débiles de la emunah"
         }
@@ -3299,7 +3425,7 @@
             {
               "marker": "¹⁷⁰",
               "number": "170",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad."
             }
           ],
@@ -3400,7 +3526,14 @@
         {
           "verse": 6,
           "tth": "para que, en una misma mente y en una misma boca, glorifiquen al Elohim y Padre en nuestro Adón¹⁷⁴ Yeshúa el Mesías. La Besorah a los gentiles",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁷⁴",
+              "number": "174",
+              "word": "Adón",
+              "explanation": "Amo, Señor."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -3419,6 +3552,12 @@
           "verse": 9,
           "tth": "y para que los gentiles glorifiquen a Elohim por causa de su amor bondadoso¹⁷⁵, como está escrito: Por eso te confesaré entre los gentiles, יהוה, y a tu Nombre cantaré melodías¹⁷⁶.",
           "footnotes": [
+            {
+              "marker": "¹⁷⁵",
+              "number": "175",
+              "word": "bondadoso",
+              "explanation": "Heb.: Jésed."
+            },
             {
               "marker": "¹⁷⁶",
               "number": "176",
@@ -3480,7 +3619,7 @@
             {
               "marker": "¹⁸¹",
               "number": "181",
-              "word": "Kódesh",
+              "word": "Rúaj Ha'Kódesh",
               "explanation": "Espíritu de Santidad. Así también en vers. 16."
             }
           ],
@@ -3558,7 +3697,14 @@
         {
           "verse": 21,
           "tth": "sino como está escrito: Porque lo que no se les había contado verán, y lo que no habían escuchado entenderán¹⁸⁶. Planificación de futuros viajes",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁸⁶",
+              "number": "186",
+              "word": "entenderán",
+              "explanation": "Véase Isaías 52:15."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -3671,7 +3817,14 @@
         {
           "verse": 33,
           "tth": "Y el Elohim de shalom¹⁹³ sea con todos ustedes. Amén. Saludos personales",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁹³",
+              "number": "193",
+              "word": "shalom",
+              "explanation": "Plenitud, ausencia de deudas."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -3848,7 +4001,7 @@
             {
               "marker": "²⁰¹",
               "number": "201",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             }
           ],

--- a/data/tth_2/json/shemot.json
+++ b/data/tth_2/json/shemot.json
@@ -542,7 +542,14 @@
         {
           "verse": 15,
           "tth": "Y dijo además Elohim a Moshéh: Así dirás a los hijos de Israel: “יהוה ²³, el Elohim de Abraham, el Elohim de Itzjak y el Elohim de Yaakov me ha enviado a ustedes”. Este es mi Nombre para siempre, y este mi memorial de generación en generación.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²³",
+              "number": "23",
+              "word": "",
+              "explanation": "יהוה. El que será."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -3009,7 +3016,14 @@
         {
           "verse": 16,
           "tth": "Cae sobre ellos terror y miedo; por la grandeza de tu brazo callan⁷³, como piedra, hasta que pase tu pueblo, יהוה, hasta que pasa el pueblo que has comprado.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁷³",
+              "number": "73",
+              "word": "callan",
+              "explanation": "O, quedan inmóviles."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -3053,7 +3067,14 @@
         {
           "verse": 21,
           "tth": "Y respondía Miriam a ellos: Canten a יהוה porque altamente es exaltado⁷⁶, <em>al</em> caballo y su jinete ha arrojado en el mar.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁷⁶",
+              "number": "76",
+              "word": "tado",
+              "explanation": "Heb.: Ga'oh ga'ah."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -4392,7 +4413,14 @@
         {
           "verse": 25,
           "tth": "quemadura en lugar de quemadura, herida en lugar de herida, contusión en lugar de contusión¹²⁷.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹²⁷",
+              "number": "127",
+              "word": "sión",
+              "explanation": "O sea, pago de restitución total del daño causado."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Procesos legales sobre amos y dueños"
         },
@@ -5090,7 +5118,14 @@
         {
           "verse": 8,
           "tth": "Y tomó Moshéh la sangre y <em>la</em> tiró sobre el pueblo, y dijo: He aquí la sangre del pacto el cual ha hecho¹⁵⁵ יהוה con ustedes, sobre todas estas palabras.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁵⁵",
+              "number": "155",
+              "word": "hecho",
+              "explanation": "Lit.: ha cortado."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Visión del Elohim de Israel"
         },
@@ -5923,7 +5958,20 @@
         {
           "verse": 21,
           "tth": "En la Tienda del Mo'ed¹⁸⁰, fuera de la cortina divisora que <em>está</em> sobre el Testimonio; lo organizarán Aharón y sus hijos desde el atardecer hasta la mañana delante de יהוה. <em>Será</em> un decreto olam¹⁸¹ para sus generaciones, de los hijos de Israel.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁸⁰",
+              "number": "180",
+              "word": "ed",
+              "explanation": "Tiempo señalado."
+            },
+            {
+              "marker": "¹⁸¹",
+              "number": "181",
+              "word": "olam",
+              "explanation": "Tiempo oculto, sólo conocido por Elohim."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Las vestiduras sacerdotales"
         }
@@ -6291,7 +6339,20 @@
         {
           "verse": 43,
           "tth": "Y estarán sobre Aharón y sobre sus hijos cuando entren a la Tienda del Mo'ed¹⁹⁸, o cuando se acerquen al altar para ministrar en la Santidad, y no carguen iniquidad y mueran. <em>Será</em> estatuto olam¹⁹⁹ para él y para su simiente después de él.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁹⁸",
+              "number": "198",
+              "word": "ed",
+              "explanation": "Tiempo señalado. Así en el resto del cap."
+            },
+            {
+              "marker": "¹⁹⁹",
+              "number": "199",
+              "word": "olam",
+              "explanation": "Tiempo oculto, sólo conocido por Elohim. Así en el resto del cap."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Consagración de Aharón y de sus hijos"
         }
@@ -6567,7 +6628,14 @@
         {
           "verse": 37,
           "tth": "Siete días harás reconciliación sobre el altar y lo santificarás, y el altar será Santidad de Santidades²⁰⁷, todo lo que toca el altar será consagrado. <em>Ofrendas diarias</em>",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁰⁷",
+              "number": "207",
+              "word": "dades",
+              "explanation": "Heb.: Kódesh Ha'kodashim."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -6714,7 +6782,14 @@
         {
           "verse": 10,
           "tth": "Y hará reconciliación Aharón sobre sus cuernos una <em>vez</em> en el año, de la sangre de la ofrenda por el pecado <em>para</em> las reconciliaciones²¹²; una <em>vez</em> en el año hará reconciliación sobre él por sus generaciones; santidad de santidades es él para יהוה.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²¹²",
+              "number": "212",
+              "word": "reconciliaciones",
+              "explanation": "Heb.: Kipurim."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Terumáh para los encargados"
         },
@@ -6765,7 +6840,14 @@
         {
           "verse": 16,
           "tth": "Y tomarás el dinero de las reconciliaciones de los hijos de Israel, y lo darás por el servicio de la Tienda del Mo'ed²¹⁵, y sea para los hijos de Israel por memorial delante de יהוה, para hacer reconciliación por sus vidas.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²¹⁵",
+              "number": "215",
+              "word": "ed",
+              "explanation": "Tiempo señalado. Así en el resto del cap."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "La pileta de cobre"
         },
@@ -6803,7 +6885,14 @@
         {
           "verse": 21,
           "tth": "Y se lavarán sus manos y sus pies, y no morirán; y será para ellos estatuto olam²¹⁷, para él y para su simiente, por sus generaciones.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²¹⁷",
+              "number": "217",
+              "word": "olam",
+              "explanation": "Tiempo oculto, sólo conocido por Elohim."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "El aceite de la unción y el incienso"
         },
@@ -9087,7 +9176,14 @@
         {
           "verse": 32,
           "tth": "Y fue terminado todo el trabajo del Mishkán de la Tienda del Mo'ed²⁹¹, e hicieron los hijos de Israel conforme a todo lo que había mandado יהוה a Moshéh, así hicieron.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁹¹",
+              "number": "291",
+              "word": "ed",
+              "explanation": "Tiempo señalado. Así en el resto del cap."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Trabajo presentado a Moshéh"
         },

--- a/data/tth_2/json/shemuel_alef.json
+++ b/data/tth_2/json/shemuel_alef.json
@@ -1612,7 +1612,14 @@
         {
           "verse": 27,
           "tth": "Ellos descendieron por el extremo de la ciudad, y Shemuel dijo a Shaúl: Di al joven y pasará delante de nosotros, y cruzará, pero tú párate ahora⁴⁷ y pueda yo hacerte escuchar la palabra de Elohim. Shaúl es ungido rey",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁴⁷",
+              "number": "47",
+              "word": "ahora",
+              "explanation": "Lit.: como el día."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -1813,7 +1820,14 @@
         {
           "verse": 27,
           "tth": "Pero unos hijos de Belial dijeron: ¿Qué nos salvará este? Y lo despreciaron y no le trajeron presente; pero él guardó silencio. [Y Najash, rey de los hijos de Amón, él oprimió a los hijos de Gad y a los hijos de Reubén con fuerza. Y les sacó a todos ellos el ojo derecho, y puso terror y miedo sobre Israel. Y no quedó hombre entre los hijos de Israel al otro lado del Iardén que no le haya sacado Najash, rey de los hijos de Amón, todo ojo derecho. Solamente siete mil hombres huyeron del rostro de los hijos de Amón y fueron a Iabesh Guilad⁵³.] Shaúl asume al reinado",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁵³",
+              "number": "53",
+              "word": "Guilad",
+              "explanation": "Este párrafo no se encuentra en el T.M., pero es parte del texto en los Manuscritos del Mar Muerto, fragmento '4QSam'."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -2136,7 +2150,14 @@
         {
           "verse": 25,
           "tth": "Pero si ciertamente⁶⁵ hacen mal, tanto ustedes como su rey serán barridos. Guerra contra los pelishtim",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁶⁵",
+              "number": "65",
+              "word": "ciertamente",
+              "explanation": "Lit.: si haciendo mal."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -3082,7 +3103,14 @@
         {
           "verse": 13,
           "tth": "Y tomó Shemuel el cuerno de aceite y lo ungió en medio de sus hermanos. Y avanzó el Rúaj⁹³ de יהוה en David desde aquel día y en ascenso. Y se levantó Shemuel y fue a Ramáh. David sirve delante de Shaúl",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁹³",
+              "number": "93",
+              "word": "Rúaj",
+              "explanation": "Espíritu, viento, poder."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -3564,7 +3592,14 @@
         {
           "verse": 58,
           "tth": "Y le dijo Shaúl: ¿Hijo de quién eres tú, joven? Y dijo David: Hijo de tu siervo Ishai, el bet halajmí¹⁰⁴. Amistad de David y Iehonatán",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁰⁴",
+              "number": "104",
+              "word": "halajmí",
+              "explanation": "Betlemita."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -3870,7 +3905,14 @@
         {
           "verse": 10,
           "tth": "Y buscó Shaúl golpear con la lanza a David y a la pared, pero se liberó¹¹³ de delante de Shaúl, y golpeó la lanza a la pared; y David huyó y escapó en aquella noche. Mijal salva a David",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹¹³",
+              "number": "113",
+              "word": "liberó",
+              "explanation": "Lit.: se abrió."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -4517,7 +4559,14 @@
         {
           "verse": 10,
           "tth": "Y preguntó por él a יהוה, y provisiones le dio, y la espada de Goliat el pelishtí¹³⁵ dio a él. Shaúl ordena matar a los sacerdotes",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹³⁵",
+              "number": "135",
+              "word": "pelishtí",
+              "explanation": "Filisteo."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -5487,7 +5536,20 @@
         {
           "verse": 25,
           "tth": "Y dijo Shaúl a David: Bendito tú, hijo mío David; aun grandemente harás¹⁵⁸ y también grandemente prevalecerás¹⁵⁹. Y se fue David por su camino, y Shaúl volvió a su lugar. David entre los pelishtim",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁵⁸",
+              "number": "158",
+              "word": "harás",
+              "explanation": "Lit.: haciendo, harás."
+            },
+            {
+              "marker": "¹⁵⁹",
+              "number": "159",
+              "word": "prevalecerás",
+              "explanation": "Lit.: prevaleciendo, prevalecerás."
+            }
+          ],
           "hebrew_terms": []
         }
       ]

--- a/data/tth_2/json/shemuel_bet.json
+++ b/data/tth_2/json/shemuel_bet.json
@@ -1613,7 +1613,20 @@
         {
           "verse": 18,
           "tth": "y Benaiáhu, hijo de Iehoiada, y el keretí⁵⁰ y el peletí⁵¹, y los hijos de David eran príncipes. Bondad de David con Mefiboshet",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁵⁰",
+              "number": "50",
+              "word": "keretí",
+              "explanation": "Cereteo."
+            },
+            {
+              "marker": "⁵¹",
+              "number": "51",
+              "word": "peletí",
+              "explanation": "Peleteo."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -1843,7 +1856,14 @@
         {
           "verse": 19,
           "tth": "Y vieron todos los reyes, siervos de Hadadezer, que habían sido heridos delante de Israel, e hicieron shalom⁵⁶ con Israel y les sirvieron. Y tuvo temor Aram de salvar más a los hijos de Amón. David y Batsheva",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁵⁶",
+              "number": "56",
+              "word": "shalom",
+              "explanation": "Plenitud, ausencia de deudas."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -2208,7 +2228,14 @@
         {
           "verse": 25,
           "tth": "Y envió <em>palabra</em> por mano de Natán el profeta, y llamó su nombre Iedidiáh⁶³, por causa de יהוה.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁶³",
+              "number": "63",
+              "word": "Iedidiáh",
+              "explanation": "Amado de יהוה."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "David captura Rabáh"
         },
@@ -3313,7 +3340,14 @@
         {
           "verse": 20,
           "tth": "Y vinieron los siervos de Abshalom hacia la mujer a la casa, y dijeron: ¿Dónde están Ajimáatz y Iehonatán, y dijo a ellos la mujer: Han pasado el arroyo⁸³ de aguas. Y buscaron, pero no hallaron, y volvieron a Yerushaláim. Abshalom persigue a David",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁸³",
+              "number": "83",
+              "word": "arroyo",
+              "explanation": "Lit.: contenedor."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -3387,7 +3421,14 @@
         {
           "verse": 29,
           "tth": "miel, mantequilla, rebaño y queso⁸⁷ de ganado, trajeron a David y al pueblo que estaba con él para comer, pues dijeron: El pueblo está hambriento, cansado y sediento en el desierto. Muerte de Abshalom",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁸⁷",
+              "number": "87",
+              "word": "queso",
+              "explanation": "O, crema."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -3929,7 +3970,14 @@
         {
           "verse": 43,
           "tth": "Y respondió un hombre de Israel a un hombre de Iehudáh, y dijo: Diez partes⁹⁹ hay para mí en el rey, y también en David yo tengo más que tú; ¿y por qué me has hecho insignificante? ¿Y no fue mi palabra primera para mí para hacer volver a mi rey? Y fue más dura la palabra del hombre de Iehudáh que la palabra del hombre de Israel. Rebelión y muerte de Sheva",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁹⁹",
+              "number": "99",
+              "word": "partes",
+              "explanation": "Lit.: Diez manos."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -4150,7 +4198,14 @@
         {
           "verse": 26,
           "tth": "Y también Irá, el iairi¹⁰⁹, era sacerdote de David. Venganza de Guibeón",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁰⁹",
+              "number": "109",
+              "word": "iairi",
+              "explanation": "Jaireo."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -4700,7 +4755,26 @@
         {
           "verse": 51,
           "tth": "Engrandeció la salvación de su Rey, y hace bondad a su Mesías¹²⁵, a David y a su simiente¹²⁶ hasta el olam¹²⁷. Últimas palabras de David",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹²⁵",
+              "number": "125",
+              "word": "Mesías",
+              "explanation": "Ungido. Heb.: Mashíaj. Así también en cap. 23:1."
+            },
+            {
+              "marker": "¹²⁶",
+              "number": "126",
+              "word": "simiente",
+              "explanation": "O, semilla."
+            },
+            {
+              "marker": "¹²⁷",
+              "number": "127",
+              "word": "olam",
+              "explanation": "Tiempo oculto, solo conocido por Elohim. Así también en cap. 23:5."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -4761,7 +4835,14 @@
         {
           "verse": 7,
           "tth": "y el hombre que tocare en ellos estará lleno con hierro y madera de lanza, y con fuego serán completamente quemados¹³⁰ en el asiento. Poderosos de David",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹³⁰",
+              "number": "130",
+              "word": "quemados",
+              "explanation": "Lit.: quemando, serán quemados."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -5133,7 +5214,14 @@
         {
           "verse": 39,
           "tth": "Uriyah el jití¹⁵⁸; todos son treinta y siete. David enumera al pueblo",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁵⁸",
+              "number": "158",
+              "word": "jití",
+              "explanation": "Hitita."
+            }
+          ],
           "hebrew_terms": []
         }
       ]

--- a/data/tth_2/json/shir_hashirim.json
+++ b/data/tth_2/json/shir_hashirim.json
@@ -638,7 +638,7 @@
         },
         {
           "verse": 2,
-          "tth": "¡Quién daría que te conduciría, que te haría entrar a la casa de mi madre, que Tú me enseñarías! ¡Quién daría que te daría a beber del vino aromático, del mosto de mi granado!",
+          "tth": "¡Quién daría que te conduciría, que te haría entrar a la casa de mi madre, que Tú me enseñarías!¡Quién daría que te daría a beber del vino aromático, del mosto de mi granado!",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/shoftim.json
+++ b/data/tth_2/json/shoftim.json
@@ -203,7 +203,20 @@
         {
           "verse": 26,
           "tth": "Y fue el hombre <em>a</em> la tierra de los jitim⁶ y edificó una ciudad, y llamó su nombre Luz⁷; este es su nombre hasta este día.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁶",
+              "number": "6",
+              "word": "jitim",
+              "explanation": "Hititas."
+            },
+            {
+              "marker": "⁷",
+              "number": "7",
+              "word": "Luz",
+              "explanation": "Almendro."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Lugares no desposeídos"
         },
@@ -735,7 +748,14 @@
         {
           "verse": 31,
           "tth": "Y después de él estuvo Shamgar, hijo de Anat; e hirió a los pelishtim²⁸, seiscientos hombres, con una aguijada de buey. Y salvó también él a Israel.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁸",
+              "number": "28",
+              "word": "pelishtim",
+              "explanation": "Filisteos."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Deboráh y Barak"
         }
@@ -1186,7 +1206,14 @@
         {
           "verse": 10,
           "tth": "Y dije a ustedes: 'Yo soy יהוה su Elohim. No temerán a los dioses del emorí³⁶ que <em>con</em> ustedes habitan en su tierra'. Pero no escucharon a mi voz”.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "³⁶",
+              "number": "36",
+              "word": "emorí",
+              "explanation": "Amorreo."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Llamamiento de Guideón"
         },
@@ -1325,7 +1352,14 @@
         {
           "verse": 24,
           "tth": "Y edificó allí Guideón un altar a יהוה, y lo llamó: יהוה Shalom⁴⁵; hasta este día aún este <em>permanece</em>, en Ofráh del abiezrí.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁴⁵",
+              "number": "45",
+              "word": "Shalom",
+              "explanation": "יהוה es ausencia de deudas."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Destrucción del altar de Baal"
         },
@@ -1589,7 +1623,20 @@
         {
           "verse": 18,
           "tth": "Soplaremos con el shofar⁵⁴, yo y todo el que <em>esté</em> conmigo, y soplarán con los shofarot⁵⁵ también ustedes alrededor de todo el campamento, y digan: “¡Por יהוה y por Guideón! ”.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁵⁴",
+              "number": "54",
+              "word": "far",
+              "explanation": "Cuerno de carnero."
+            },
+            {
+              "marker": "⁵⁵",
+              "number": "55",
+              "word": "shofarot",
+              "explanation": "Cuernos de carneros."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Confusión y derrota de Midián"
         },
@@ -2821,7 +2868,14 @@
         {
           "verse": 15,
           "tth": "Y murió Abdón, hijo de Hilel el piratoní, y fue enterrado en Piratón, en la tierra de Efráim, en el monte del amalekí⁸¹.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁸¹",
+              "number": "81",
+              "word": "amalekí",
+              "explanation": "Amalequita."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Los pelishtim oprimen a Israel"
         }
@@ -3026,7 +3080,14 @@
         {
           "verse": 25,
           "tth": "Y comenzó el Rúaj⁸⁹ de יהוה a impulsarse en Majanéh Dan, entre Tzoráh y Eshtaol.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁸⁹",
+              "number": "89",
+              "word": "Rúaj",
+              "explanation": "Espíritu, viento, poder."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Shimshón y el león"
         }
@@ -3100,7 +3161,14 @@
         {
           "verse": 9,
           "tth": "Y la tomó⁹² hacia sus palmas y fue, andando y comiendo. Y fue a su padre y a su madre, y dio a ellos <em>miel</em>, y comieron; pero no contó a ellos que del cadáver del león había tomado la miel.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁹²",
+              "number": "92",
+              "word": "tomó",
+              "explanation": "Lit.: subyugó."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "El acertijo de Shimshón"
         },

--- a/data/tth_2/json/sodot.json
+++ b/data/tth_2/json/sodot.json
@@ -278,7 +278,14 @@
         {
           "verse": 7,
           "tth": "Quien tenga oídos, escuchará lo que el Rúaj¹⁶ dice a las congregaciones. Al que venza, le daré de comer del árbol de la vida, que está en medio del jardín de Elohim.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁶",
+              "number": "16",
+              "word": "Rúaj",
+              "explanation": "Espíritu, aliento, poder. Así en el resto del cap."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Mensaje a Smirna"
         },
@@ -301,7 +308,7 @@
             {
               "marker": "¹⁸",
               "number": "18",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario. Así en el resto del cap."
             }
           ],
@@ -360,7 +367,14 @@
         {
           "verse": 17,
           "tth": "Quien tenga oídos, escuchará lo que el Rúaj dice a las congregaciones. Al que venza le daré de comer del maná²⁰ escondido, y le daré una piedrecita blanca, y sobre la piedrecita un nombre nuevo escrito, y ningún hombre <em>lo</em> conoce, sino el que <em>lo</em> recibe.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁰",
+              "number": "20",
+              "word": "maná",
+              "explanation": "Heb.: man."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Mensaje a Tiátira"
         },
@@ -427,7 +441,7 @@
             {
               "marker": "²⁴",
               "number": "24",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             }
           ],
@@ -530,7 +544,14 @@
         {
           "verse": 6,
           "tth": "Quien tenga oídos, escuchará lo que el Rúaj²⁹ dice a las congregaciones.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁹",
+              "number": "29",
+              "word": "Rúaj",
+              "explanation": "Espíritu, aliento, poder. Así en el resto del cap."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Mensaje a Filadelfia"
         },
@@ -572,7 +593,7 @@
             {
               "marker": "³³",
               "number": "33",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             },
             {
@@ -749,7 +770,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Y después de eso miré, y he aquí, una puerta abierta en los cielos; y la primera voz que había escuchado como shofar⁴⁷, hablaba conmigo, diciendo: Sube acá, y te daré a conocer qué es necesario que sea después de estas <em>cosas. </em>",
+          "tth": "Y después de eso miré, y he aquí, una puerta abierta en los cielos; y la primera voz que había escuchado como shofar⁴⁷, hablaba conmigo, diciendo: Sube acá, y te daré a conocer qué es necesario que sea después de estas <em>cosas.</em>",
           "footnotes": [
             {
               "marker": "⁴⁷",
@@ -866,7 +887,20 @@
         {
           "verse": 10,
           "tth": "entonces los veinticuatro ancianos caían delante del que está sentado sobre el trono, y se postraban al que vive le'olmei olamim, y echaban sus coronas delante del trono, diciendo: Digno eres, יהוה, de recibir gloria, esplendor y potencia, porque Tú creaste⁵⁶ todo, y por causa de tu voluntad son y fueron creadas⁵⁷.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁵⁶",
+              "number": "56",
+              "word": "creaste",
+              "explanation": "O, le diste forma a."
+            },
+            {
+              "marker": "⁵⁷",
+              "number": "57",
+              "word": "creadas",
+              "explanation": "O, formadas."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "El Cordero con el rollo"
         }
@@ -1337,7 +1371,14 @@
         {
           "verse": 17,
           "tth": "porque el Cordero que está en medio del trono los pastoreará, y los guiará a fuentes de aguas vivas, y enjugará Elohim la lágrima de sobre todos sus rostros⁸³.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁸³",
+              "number": "83",
+              "word": "rostros",
+              "explanation": "Véase Isaías 25:8."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "El séptimo sello"
         }
@@ -2041,7 +2082,7 @@
             {
               "marker": "¹¹⁹",
               "number": "119",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario. Concepto heb."
             },
             {
@@ -2320,7 +2361,14 @@
         {
           "verse": 18,
           "tth": "Aquí hay sabiduría. El que tiene entendimiento¹³⁷, cuente el número del animal, porque es número de hombre, y su número es seiscientos y sesenta y seis.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹³⁷",
+              "number": "137",
+              "word": "entendimiento",
+              "explanation": "Heb.: Bináh."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "El cántico de los 144 mil"
         }
@@ -2370,7 +2418,14 @@
         {
           "verse": 5,
           "tth": "Y en sus bocas no fue hallada mentira, porque sin defecto¹⁴⁰ son delante del trono de Elohim.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁴⁰",
+              "number": "140",
+              "word": "defecto",
+              "explanation": "Heb.: Mum. Véase Levítico 22:17\\-33."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "El mensaje de los tres mensajeros"
         },
@@ -2536,7 +2591,14 @@
         {
           "verse": 20,
           "tth": "Y fue pisado el lagar fuera de la ciudad; y salió sangre del lagar hasta los frenos de los caballos, por mil seiscientos estadios¹⁵². Las siete plagas postreras",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁵²",
+              "number": "152",
+              "word": "estadios",
+              "explanation": "O sea, alrededor de trescientos kilómetros."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -3252,7 +3314,14 @@
         {
           "verse": 10,
           "tth": "Y caí a mis pies para postrármele, pero me dijo: ¡Guárdate, no sea que hagas esto! Siervo como tú soy, y compañero tuyo y de tus hermanos que tienen el Testimonio de Yeshúa. Póstrate a Elohim, porque el Testimonio de Yeshúa es el Rúaj¹⁸³ de la profecía. El que está sentado sobre el caballo blanco",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁸³",
+              "number": "183",
+              "word": "Rúaj",
+              "explanation": "Espíritu, ánimo, poder."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -3372,7 +3441,7 @@
             {
               "marker": "¹⁸⁹",
               "number": "189",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario. Concepto heb."
             }
           ],
@@ -3813,7 +3882,14 @@
         {
           "verse": 5,
           "tth": "Y la noche no será más; y no tendrán necesidad de luz de lámpara ni de la luz del sol, porque יהוה Elohim los iluminará; y reinarán le'olmei olamim²¹³.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²¹³",
+              "number": "213",
+              "word": "olamim",
+              "explanation": "Es decir, por los tiempos de los tiempos."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "El Adón Yeshúa viene pronto"
         },
@@ -3838,7 +3914,7 @@
         },
         {
           "verse": 8,
-          "tth": "Y yo, Iojanán, soy el que vio y escuchó estas <em>cosas</em>. Y sucedió <em>que</em> cuando escuché y vi, caí postrándome a los pies del mensajero que me había mostrado estas <em>cosas. </em>",
+          "tth": "Y yo, Iojanán, soy el que vio y escuchó estas <em>cosas</em>. Y sucedió <em>que</em> cuando escuché y vi, caí postrándome a los pies del mensajero que me había mostrado estas <em>cosas.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/tehilim.json
+++ b/data/tth_2/json/tehilim.json
@@ -250,7 +250,7 @@
         },
         {
           "verse": 3,
-          "tth": "Sepan que ha apartado יהוה <em>al</em> bondadoso para sí.יהוה escuchará cuando clame a Él.",
+          "tth": "Sepan que ha apartado יהוה <em>al</em> bondadoso para sí. יהוה escuchará cuando clame a Él.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -932,7 +932,7 @@
         },
         {
           "verse": 5,
-          "tth": "Son fuertes³⁴ sus caminos en todo tiempo.<em>En</em> la altura <em>están</em> tus juicios, <em>lejos</em> de delante de él. Todos sus opresores, arremeterá³⁵ contra ellos.",
+          "tth": "Son fuertes³⁴ sus caminos en todo tiempo. <em>En</em> la altura <em>están</em> tus juicios, <em>lejos</em> de delante de él. Todos sus opresores, arremeterá³⁵ contra ellos.",
           "footnotes": [
             {
               "marker": "³⁴",
@@ -3474,7 +3474,7 @@
         },
         {
           "verse": 7,
-          "tth": "Tú eres escondite para mí, de la estrechez me preservarás.<em>Con</em> gritos alegres de liberación me rodearás. <em>Selah.</em>",
+          "tth": "Tú eres escondite para mí, de la estrechez me preservarás. <em>Con</em> gritos alegres de liberación me rodearás. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -10657,7 +10657,7 @@
         },
         {
           "verse": 48,
-          "tth": "¿Quién <em>siendo</em> varón vivirá y no verá muerte? ¿Hará escapar su vida de la mano del Sheol?<em>Selah.</em>",
+          "tth": "¿Quién <em>siendo</em> varón vivirá y no verá muerte? ¿Hará escapar su vida de la mano del Sheol? <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },

--- a/data/tth_2/json/tehilim.json
+++ b/data/tth_2/json/tehilim.json
@@ -145,7 +145,14 @@
         {
           "verse": 12,
           "tth": "Besen <em>con</em> pureza, no sea que se enoje y se pierdan <em>en</em> el camino, pues se encenderá un poco⁴ su nariz. ¡Felices son todos los que se refugian en Él!",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁴",
+              "number": "4",
+              "word": "poco",
+              "explanation": "Lit.: como un poco."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Cántico de David, en su huir de delante de Abshalom, su hijo."
         }
@@ -162,7 +169,7 @@
         },
         {
           "verse": 2,
-          "tth": "Muchos dicen a mi ser: No hay salvación para él en Elohim. <em>Selah</em>⁵<em>. </em>",
+          "tth": "Muchos dicen a mi ser: No hay salvación para él en Elohim. <em>Selah</em>⁵<em>.</em>",
           "footnotes": [
             {
               "marker": "⁵",
@@ -181,7 +188,7 @@
         },
         {
           "verse": 4,
-          "tth": "<em>Con</em> mi voz a יהוה llamé, y me respondió desde el monte de su santidad. <em>Selah. </em>",
+          "tth": "<em>Con</em> mi voz a יהוה llamé, y me respondió desde el monte de su santidad. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -230,7 +237,7 @@
         },
         {
           "verse": 2,
-          "tth": "Hijos del hombre, ¿hasta cuándo mi honra <em>será</em> por vergüenza? ¿Amarán lo vacío, buscarán la mentira? <em>Selah</em>⁷<em>. </em>",
+          "tth": "Hijos del hombre, ¿hasta cuándo mi honra <em>será</em> por vergüenza? ¿Amarán lo vacío, buscarán la mentira? <em>Selah</em>⁷<em>.</em>",
           "footnotes": [
             {
               "marker": "⁷",
@@ -243,13 +250,13 @@
         },
         {
           "verse": 3,
-          "tth": "Sepan que ha apartado יהוה <em>al</em> bondadoso para sí. יהוה escuchará cuando clame a Él.",
+          "tth": "Sepan que ha apartado יהוה <em>al</em> bondadoso para sí.יהוה escuchará cuando clame a Él.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 4,
-          "tth": "Tiemblen, y no pequen; hablen en su corazón sobre su cama, y callen. <em>Selah. </em>",
+          "tth": "Tiemblen, y no pequen; hablen en su corazón sobre su cama, y callen. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -274,9 +281,22 @@
         {
           "verse": 8,
           "tth": "En shalom⁸ juntamente me acostaré y dormiré⁹, porque solo Tú, יהוה, en confianza me harás habitar.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁸",
+              "number": "8",
+              "word": "shalom",
+              "explanation": "Plenitud, ausencia de deudas."
+            },
+            {
+              "marker": "⁹",
+              "number": "9",
+              "word": "dormiré",
+              "explanation": "O sea, moriré."
+            }
+          ],
           "hebrew_terms": [],
-          "subtitle": "Para el vencedor; con las flautas.Cántico de David."
+          "subtitle": "Para el vencedor; con las flautas. Cántico de David."
         }
       ]
     },
@@ -473,8 +493,14 @@
         },
         {
           "verse": 10,
-          "tth": "Se avergonzarán y se aterrarán mucho todos mis enemigos; volverán y se avergonzarán de repente. <em>Shigaión¹⁸ de David, que cantó a</em>__יהוה__<em>sobre las palabras de Cush, benieminí¹⁹. </em>",
+          "tth": "Se avergonzarán y se aterrarán mucho todos mis enemigos; volverán y se avergonzarán de repente.",
           "footnotes": [
+            {
+              "marker": "¹⁸",
+              "number": "18",
+              "word": "Shigaión",
+              "explanation": "Cántico. De etimología incierta."
+            },
             {
               "marker": "¹⁹",
               "number": "19",
@@ -482,7 +508,8 @@
               "explanation": "Benjamita."
             }
           ],
-          "hebrew_terms": []
+          "hebrew_terms": [],
+          "subtitle": "Shigaión¹⁸ de David, que cantó a יהוה sobre las palabras de Cush, benieminí¹⁹."
         }
       ]
     },
@@ -819,7 +846,7 @@
         },
         {
           "verse": 16,
-          "tth": "Se ha hecho conocer יהוה, juicio ha hecho. En la obra de sus palmas fue atrapado el condenado. <em>Higaión</em>³⁰<em>Selah</em>³¹<em>. </em>",
+          "tth": "Se ha hecho conocer יהוה, juicio ha hecho. En la obra de sus palmas fue atrapado el condenado. <em>Higaión</em>³⁰<em>Selah</em>³¹<em>.</em>",
           "footnotes": [
             {
               "marker": "³⁰",
@@ -844,7 +871,7 @@
         },
         {
           "verse": 18,
-          "tth": "Pues no para siempre será olvidado el necesitado, <em>ni</em> la esperanza de los afligidos se perderá para siempre.",
+          "tth": "Pues no para siempre será olvidado el necesitado,<em>ni</em> la esperanza de los afligidos se perderá para siempre.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -905,7 +932,7 @@
         },
         {
           "verse": 5,
-          "tth": "Son fuertes³⁴ sus caminos en todo tiempo. <em>En</em> la altura <em>están</em> tus juicios, <em>lejos</em> de delante de él. Todos sus opresores, arremeterá³⁵ contra ellos.",
+          "tth": "Son fuertes³⁴ sus caminos en todo tiempo.<em>En</em> la altura <em>están</em> tus juicios, <em>lejos</em> de delante de él. Todos sus opresores, arremeterá³⁵ contra ellos.",
           "footnotes": [
             {
               "marker": "³⁴",
@@ -924,7 +951,7 @@
         },
         {
           "verse": 6,
-          "tth": "Dijo en su corazón: “No seré sacudido, por generación y generación, <em>en</em> las cuales no <em>estaré</em> en lo malo”.",
+          "tth": "Dijo en su corazón: “No seré sacudido, por generación y generación,<em>en</em> las cuales no <em>estaré</em> en lo malo”.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1061,7 +1088,7 @@
           "tth": "Porque justo es יהוה, las justicias ama; los rectos verán su rostro.",
           "footnotes": [],
           "hebrew_terms": [],
-          "subtitle": "Para el vencedor; sobre la octava.Cántico de David."
+          "subtitle": "Para el vencedor; sobre la octava. Cántico de David."
         }
       ]
     },
@@ -1127,7 +1154,14 @@
         {
           "verse": 8,
           "tth": "En derredor caminan los condenados, conforme a la exaltación de la inutilidad⁴⁰ de los hijos del hombre.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁴⁰",
+              "number": "40",
+              "word": "inutilidad",
+              "explanation": "O, depravación. Otra posible traducción es: tempestad."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Para el vencedor. Cántico de David."
         }
@@ -1205,7 +1239,7 @@
         },
         {
           "verse": 4,
-          "tth": "¿No conocen todos los hacedores de vacuidad, devoradores de mi pueblo <em>como si</em> comieran pan, <em>y a</em> יהוה no llaman?",
+          "tth": "¿No conocen todos los hacedores de vacuidad, devoradores de mi pueblo <em>como si</em> comieran pan,<em>y a</em> יהוה no llaman?",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1397,7 +1431,7 @@
         },
         {
           "verse": 3,
-          "tth": "Has examinado mi corazón, has visitado de noche; me refinaste sin hallar <em>nada</em>; mi pensamiento no pasó mi boca⁴⁸<em>. </em>",
+          "tth": "Has examinado mi corazón, has visitado de noche; me refinaste sin hallar <em>nada</em>; mi pensamiento no pasó mi boca⁴⁸<em>.</em>",
           "footnotes": [
             {
               "marker": "⁴⁸",
@@ -1447,7 +1481,7 @@
         },
         {
           "verse": 9,
-          "tth": "del rostro de los condenados, los cuales me violentaron, <em>de</em> mis enemigos en la vida que rodean sobre mí.",
+          "tth": "del rostro de los condenados, los cuales me violentaron,<em>de</em> mis enemigos en la vida que rodean sobre mí.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -1477,15 +1511,23 @@
         },
         {
           "verse": 14,
-          "tth": "de los muertos, <em>con</em> tu mano, יהוה, de los muertos, del mundano, <em>que</em> su porción está en <em>esta</em> vida, y llena a tu protegido⁵⁰; el vientre de ellos, se sacian de hijos, y dejan su remanente a sus niños.",
-          "footnotes": [],
+          "tth": "de los muertos, <em>con</em> tu mano, יהוה, de los muertos, del mundano,<em>que</em> su porción está en <em>esta</em> vida, y llena a tu protegido⁵⁰; el vientre de ellos, se sacian de hijos, y dejan su remanente a sus niños.",
+          "footnotes": [
+            {
+              "marker": "⁵⁰",
+              "number": "50",
+              "word": "protegido",
+              "explanation": "O, tu escondido."
+            }
+          ],
           "hebrew_terms": []
         },
         {
           "verse": 15,
-          "tth": "Yo en justicia veré tu rostro, me saciaré cuando despierte <em>a</em> tu semejanza. <em>Para el vencedor. Del siervo de</em>__יהוה__<em>, de David, el cual habló a</em>__יהוה__<em>las palabras de esta canción en el día que lo rescató</em>__יהוה__<em>de la palma de todos sus enemigos, y de la mano de Shaúl, y dijo: </em>",
+          "tth": "Yo en justicia veré tu rostro, me saciaré cuando despierte <em>a</em> tu semejanza.",
           "footnotes": [],
-          "hebrew_terms": []
+          "hebrew_terms": [],
+          "subtitle": "Para el vencedor. Del siervo de יהוה, de David, el cual habló a יהוה las palabras de esta canción en el día que lo rescató יהוה de la palma de todos sus enemigos, y de la mano de Shaúl, y dijo:"
         }
       ]
     },
@@ -1845,7 +1887,20 @@
         {
           "verse": 50,
           "tth": "Él engrandece salvaciones <em>a</em> su rey, y hace bondad a su Mesías⁵⁹, a David y a su simiente, hasta el olam⁶⁰.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁵⁹",
+              "number": "59",
+              "word": "Mesías",
+              "explanation": "Quien porta la unción. Heb.: Mashíaj."
+            },
+            {
+              "marker": "⁶⁰",
+              "number": "60",
+              "word": "olam",
+              "explanation": "Tiempo oculto, solo conocido por Elohim."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Para el vencedor. Cántico de David."
         }
@@ -1962,7 +2017,7 @@
         },
         {
           "verse": 14,
-          "tth": "Serán para deleite los dichos de mi boca y la meditación de mi corazón delante de ti, יהוה, mi Roca y mi Redentor.",
+          "tth": "Serán para deleite los dichos de mi boca y la meditación de mi corazón delante de ti,יהוה, mi Roca y mi Redentor.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Para el vencedor. Cántico de David."
@@ -1986,7 +2041,7 @@
         },
         {
           "verse": 3,
-          "tth": "Recordará todas tus ofrendas, y tu ofrenda ascendida hallará como grosura. <em>Selah</em>⁶⁵<em>. </em>",
+          "tth": "Recordará todas tus ofrendas, y tu ofrenda ascendida hallará como grosura. <em>Selah</em>⁶⁵<em>.</em>",
           "footnotes": [
             {
               "marker": "⁶⁵",
@@ -2047,7 +2102,7 @@
         },
         {
           "verse": 2,
-          "tth": "El deseo de su corazón le diste, y el anhelo de sus labios no retuviste. <em>Selah</em>⁶⁶<em>. </em>",
+          "tth": "El deseo de su corazón le diste, y el anhelo de sus labios no retuviste. <em>Selah</em>⁶⁶<em>.</em>",
           "footnotes": [
             {
               "marker": "⁶⁶",
@@ -2117,7 +2172,7 @@
         },
         {
           "verse": 9,
-          "tth": "Los pondrás como horno de fuego al tiempo de tu rostro; יהוה en su nariz los tragará, y los consumirá el fuego.",
+          "tth": "Los pondrás como horno de fuego al tiempo de tu rostro;יהוה en su nariz los tragará, y los consumirá el fuego.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -2210,7 +2265,7 @@
               "marker": "⁷³",
               "number": "73",
               "word": "carmesí",
-              "explanation": "O sea, el ‘coccus ilisis', insecto del cual se extraía un tinte carmesí."
+              "explanation": "O sea, el 'coccus ilisis', insecto del cual se extraía un tinte carmesí."
             }
           ],
           "hebrew_terms": []
@@ -2439,7 +2494,14 @@
         {
           "verse": 6,
           "tth": "Ciertamente⁷⁹ el bien y la bondad me perseguirán todos los días de mi vida, y habitaré en casa de יהוה por largura de días.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁷⁹",
+              "number": "79",
+              "word": "Ciertamente",
+              "explanation": "O, sólo."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "De David; un cántico."
         }
@@ -2487,7 +2549,7 @@
         },
         {
           "verse": 6,
-          "tth": "Esta es la generación de los que lo requieren, de los que buscan tu rostro, Yaakov⁸¹. <em>Selah</em>⁸²<em>. </em>",
+          "tth": "Esta es la generación de los que lo requieren, de los que buscan tu rostro, Yaakov⁸¹. <em>Selah</em>⁸²<em>.</em>",
           "footnotes": [
             {
               "marker": "⁸¹",
@@ -2696,7 +2758,7 @@
         },
         {
           "verse": 22,
-          "tth": "Redime, Elohim, a Israel de todas sus estrecheces. <em>De David. </em>",
+          "tth": "Redime, Elohim, a Israel de todas sus estrecheces. <em>De David.</em>",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -2780,7 +2842,7 @@
         },
         {
           "verse": 12,
-          "tth": "Mi pie se ha parado en lugar recto; en las congregaciones bendeciré <em>a</em> יהוה. <em>De David. </em>",
+          "tth": "Mi pie se ha parado en lugar recto; en las congregaciones bendeciré <em>a</em> יהוה. <em>De David.</em>",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -2890,7 +2952,7 @@
         },
         {
           "verse": 14,
-          "tth": "Espera a יהוה; Fortalézcase y esfuércese tu corazón, y espera a יהוה. <em>De David. </em>",
+          "tth": "Espera a יהוה; Fortalézcase y esfuércese tu corazón, y espera a יהוה. <em>De David.</em>",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -3071,6 +3133,12 @@
           "verse": 11,
           "tth": "יהוה dará fuerza a su pueblo; יהוה bendecirá a su pueblo con shalom⁹⁹.",
           "footnotes": [
+            {
+              "marker": "⁹⁹",
+              "number": "99",
+              "word": "shalom",
+              "explanation": "Plenitud, ausencia de deudas."
+            },
             {
               "marker": "¹⁰⁰",
               "number": "100",
@@ -3295,7 +3363,7 @@
         },
         {
           "verse": 19,
-          "tth": "¡Qué grande es tu bondad, que has preservado para tus temerosos, <em>que</em> has obrado para los que se refugian en ti frente a los hijos del hombre!",
+          "tth": "¡Qué grande es tu bondad, que has preservado para tus temerosos,<em>que</em> has obrado para los que se refugian en ti frente a los hijos del hombre!",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3338,7 +3406,7 @@
         },
         {
           "verse": 24,
-          "tth": "¡Fortalézcanse, y esfuércese su corazón, todos los que esperan a יהוה! <em>De David</em>; <em>Masquil¹⁰⁶. </em>",
+          "tth": "¡Fortalézcanse, y esfuércese su corazón, todos los que esperan a יהוה! <em>De David</em>; <em>Masquil¹⁰⁶.</em>",
           "footnotes": [
             {
               "marker": "¹⁰⁶",
@@ -3374,7 +3442,7 @@
         },
         {
           "verse": 4,
-          "tth": "Porque de día y de noche era pesada sobre mí tu mano, se tornó mi savia en sequía de verano. <em>Selah</em>¹⁰⁷<em>. </em>",
+          "tth": "Porque de día y de noche era pesada sobre mí tu mano, se tornó mi savia en sequía de verano. <em>Selah</em>¹⁰⁷<em>.</em>",
           "footnotes": [
             {
               "marker": "¹⁰⁷",
@@ -3387,7 +3455,7 @@
         },
         {
           "verse": 5,
-          "tth": "Mi pecado te di a conocer, y mi iniquidad no oculté. Dije: Confesaré sobre mis transgresiones a יהוה; y Tú cargaste la iniquidad de mi pecado. <em>Selah. </em>",
+          "tth": "Mi pecado te di a conocer, y mi iniquidad no oculté. Dije: Confesaré sobre mis transgresiones a יהוה; y Tú cargaste la iniquidad de mi pecado. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -3406,20 +3474,33 @@
         },
         {
           "verse": 7,
-          "tth": "Tú eres escondite para mí, de la estrechez me preservarás. <em>Con</em> gritos alegres de liberación me rodearás. <em>Selah. </em>",
+          "tth": "Tú eres escondite para mí, de la estrechez me preservarás.<em>Con</em> gritos alegres de liberación me rodearás. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 8,
-          "tth": "Yo te enseñaré a ser prudente, y te instruiré por el camino que debes caminar; <em>te</em> aconsejaré, sobre ti <em>está</em> mi ojo.",
+          "tth": "Yo te enseñaré a ser prudente, y te instruiré por el camino que debes caminar;<em>te</em> aconsejaré, sobre ti <em>está</em> mi ojo.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 9,
           "tth": "No sean como el caballo, como el mulo¹⁰⁹, <em>que</em> no tienen entendimiento¹¹⁰; con freno y brida <em>son</em> sus atavíos para refrenar <em>lo</em>, <em>para que</em> no se acerquen a ti.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁰⁹",
+              "number": "109",
+              "word": "mulo",
+              "explanation": "O, asno montés."
+            },
+            {
+              "marker": "¹¹⁰",
+              "number": "110",
+              "word": "entendimiento",
+              "explanation": "O, discernimiento."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -3733,7 +3814,7 @@
         },
         {
           "verse": 22,
-          "tth": "Redime יהוה el ser de sus siervos, y no serán culpables todos los que se refugian en Él. <em>De David. </em>",
+          "tth": "Redime יהוה el ser de sus siervos, y no serán culpables todos los que se refugian en Él. <em>De David.</em>",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -3940,9 +4021,10 @@
         },
         {
           "verse": 28,
-          "tth": "Y mi lengua pronunciará tu justicia, todo el día tu alabanza. <em>Para el vencedor. Del siervo de</em>__יהוה__<em>, de David. </em>",
+          "tth": "Y mi lengua pronunciará tu justicia, todo el día tu alabanza.",
           "footnotes": [],
-          "hebrew_terms": []
+          "hebrew_terms": [],
+          "subtitle": "Para el vencedor. Del siervo de יהוה, de David."
         }
       ]
     },
@@ -4024,7 +4106,7 @@
         },
         {
           "verse": 12,
-          "tth": "Allí han caído los hacedores de vacuidad; fueron empujados, y no podrán levantarse. <em>De David. </em>",
+          "tth": "Allí han caído los hacedores de vacuidad; fueron empujados, y no podrán levantarse. <em>De David.</em>",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -4110,7 +4192,7 @@
         },
         {
           "verse": 10,
-          "tth": "Aún un poco y no <em>estará más</em> el condenado, considerarás atentamente acerca de su camino, y no <em>será más. </em>",
+          "tth": "Aún un poco y no <em>estará más</em> el condenado, considerarás atentamente acerca de su camino, y no <em>será más.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4183,7 +4265,7 @@
         },
         {
           "verse": 20,
-          "tth": "Porque los condenados se perderán, y los enemigos de יהוה <em>serán</em> como la grosura de carneros, se consumen en el humo, se consumen <em>. </em>",
+          "tth": "Porque los condenados se perderán, y los enemigos de יהוה <em>serán</em> como la grosura de carneros, se consumen en el humo, se consumen <em>.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4498,7 +4580,7 @@
           "tth": "Apresúrate a ayudarme, Adonai, mi liberación.",
           "footnotes": [],
           "hebrew_terms": [],
-          "subtitle": "Para el vencedor, de Iedutún.Cántico de David."
+          "subtitle": "Para el vencedor, de Iedutún. Cántico de David."
         }
       ]
     },
@@ -4538,7 +4620,7 @@
         },
         {
           "verse": 5,
-          "tth": "He aquí, has puesto mis días <em>como</em> palmos, y la duración de mi vida es como nada delante de ti; ciertamente todo es vapor, <em>aun</em> cada hombre <em>cuando</em> está afirmado. <em>Selah</em>¹³⁵<em>. </em>",
+          "tth": "He aquí, has puesto mis días <em>como</em> palmos, y la duración de mi vida es como nada delante de ti; ciertamente todo es vapor, <em>aun</em> cada hombre <em>cuando</em> está afirmado. <em>Selah</em>¹³⁵<em>.</em>",
           "footnotes": [
             {
               "marker": "¹³⁵",
@@ -4588,7 +4670,7 @@
         },
         {
           "verse": 11,
-          "tth": "Con reprensiones disciplinas <em>al</em> hombre por <em>su</em> iniquidad; y disuelves como la polilla su deseo; ciertamente, todo hombre es vapor. <em>Selah. </em>",
+          "tth": "Con reprensiones disciplinas <em>al</em> hombre por <em>su</em> iniquidad; y disuelves como la polilla su deseo; ciertamente, todo hombre es vapor. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4607,8 +4689,15 @@
         },
         {
           "verse": 13,
-          "tth": "Préstame atención, y me refrenaré¹³⁸, antes de que me vaya y <em>ya</em> no sea <em>más. Para el vencedor. De David, un cántico. </em>",
-          "footnotes": [],
+          "tth": "Préstame atención, y me refrenaré¹³⁸, antes de que me vaya y <em>ya</em> no sea <em>más. Para el vencedor. De David, un cántico.</em>",
+          "footnotes": [
+            {
+              "marker": "¹³⁸",
+              "number": "138",
+              "word": "refrenaré",
+              "explanation": "O, me despojaré."
+            }
+          ],
           "hebrew_terms": []
         }
       ]
@@ -4642,7 +4731,7 @@
         },
         {
           "verse": 5,
-          "tth": "Muchas son las maravillas que Tú has hecho, יהוה mi Elohim, y tus pensamientos hacia nosotros; nadie se compara contigo; <em>los</em> anunciaré y <em>los</em> hablaré, han sido numerosos <em>para</em> contar <em>los. </em>",
+          "tth": "Muchas son las maravillas que Tú has hecho, יהוה mi Elohim, y tus pensamientos hacia nosotros; nadie se compara contigo; <em>los</em> anunciaré y <em>los</em> hablaré, han sido numerosos <em>para</em> contar <em>los.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4673,7 +4762,7 @@
         },
         {
           "verse": 9,
-          "tth": "He llevado la buena noticia de justicia en la gran congregación; he aquí, mis labios no refrené, יהוה, Tú <em>lo</em> sabes.",
+          "tth": "He llevado la buena noticia de justicia en la gran congregación; he aquí, mis labios no refrené,יהוה, Tú <em>lo</em> sabes.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4783,7 +4872,7 @@
         },
         {
           "verse": 6,
-          "tth": "Y si <em>uno</em> viene a ver <em>me</em>, falsedad habla; su corazón reúne iniquidad para sí; <em>y</em> saldrá afuera <em>y</em> hablará.",
+          "tth": "Y si <em>uno</em> viene a ver <em>me</em>, falsedad habla; su corazón reúne iniquidad para sí;<em>y</em> saldrá afuera <em>y</em> hablará.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -4846,7 +4935,14 @@
         {
           "verse": 13,
           "tth": "¡Bendito יהוה, Elohim de Israel, desde el olam¹⁴⁶ hasta el olam! Amén y amén.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁴⁶",
+              "number": "146",
+              "word": "olam",
+              "explanation": "Tiempo oculto, solo conocido por Elohim."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Para el vencedor. Masquil de los hijos de Koraj."
         }
@@ -5054,7 +5150,7 @@
         },
         {
           "verse": 8,
-          "tth": "En Elohim nos gloriaremos todo el día, y tu Nombre por el olam¹⁵⁴ confesaremos. <em>Selah</em>¹⁵⁵<em>. </em>",
+          "tth": "En Elohim nos gloriaremos todo el día, y tu Nombre por el olam¹⁵⁴ confesaremos. <em>Selah</em>¹⁵⁵<em>.</em>",
           "footnotes": [
             {
               "marker": "¹⁵⁴",
@@ -5183,7 +5279,14 @@
         {
           "verse": 26,
           "tth": "¡Levántate <em>por</em> ayuda a nosotros!, y redímenos por causa de tu bondad.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁵⁷",
+              "number": "157",
+              "word": "Shoshanim",
+              "explanation": "Posiblemente, lirios."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Para el vencedor; sobre Shoshanim¹⁵⁷. De los hijos de Koraj. Masquil. Canción de amores."
         }
@@ -5237,7 +5340,7 @@
         },
         {
           "verse": 7,
-          "tth": "Has amado la justicia y odiado la maldad; por eso, te ha ungido Elohim, tu Elohim, <em>con</em> aceite de gozo <em>más</em> que <em>a</em> tus compañeros.",
+          "tth": "Has amado la justicia y odiado la maldad; por eso, te ha ungido Elohim, tu Elohim,<em>con</em> aceite de gozo <em>más</em> que <em>a</em> tus compañeros.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5314,7 +5417,7 @@
             }
           ],
           "hebrew_terms": [],
-          "subtitle": "Para el vencedor. De los hijos de Koraj.Al Alamot¹⁶⁰. Cántico."
+          "subtitle": "Para el vencedor. De los hijos de Koraj. Al Alamot¹⁶⁰. Cántico."
         }
       ]
     },
@@ -5335,7 +5438,7 @@
         },
         {
           "verse": 3,
-          "tth": "<em>cuando</em> rujan y hagan espuma sus aguas, <em>cuando</em> tiemblen los montes en su orgullo. <em>Selah</em>¹⁶¹<em>. </em>",
+          "tth": "<em>cuando</em> rujan y hagan espuma sus aguas, <em>cuando</em> tiemblen los montes en su orgullo. <em>Selah</em>¹⁶¹<em>.</em>",
           "footnotes": [
             {
               "marker": "¹⁶¹",
@@ -5366,7 +5469,7 @@
         },
         {
           "verse": 7,
-          "tth": "יהוה Tzebaot <em>está</em> con nosotros; nuestro alto refugio, Elohim de Yaakov. <em>Selah. </em>",
+          "tth": "יהוה Tzebaot <em>está</em> con nosotros; nuestro alto refugio, Elohim de Yaakov. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5434,7 +5537,7 @@
         },
         {
           "verse": 4,
-          "tth": "Escogerá para nosotros nuestra heredad, la majestad de Yaakov, <em>a</em> quien Él ama. <em>Selah</em>¹⁶⁴<em>. </em>",
+          "tth": "Escogerá para nosotros nuestra heredad, la majestad de Yaakov, <em>a</em> quien Él ama. <em>Selah</em>¹⁶⁴<em>.</em>",
           "footnotes": [
             {
               "marker": "¹⁶⁴",
@@ -5452,7 +5555,7 @@
             {
               "marker": "¹⁶⁵",
               "number": "165",
-              "word": "ruáh",
+              "word": "t'ruáh",
               "explanation": "Expresión de alegría, pronunciado tanto con la voz como con un shofar."
             },
             {
@@ -5545,7 +5648,7 @@
         },
         {
           "verse": 8,
-          "tth": "Como <em>lo</em> hemos oído, así <em>lo</em> hemos visto en la ciudad de יהוה Tzebaot, en la ciudad de nuestro Elohim. Elohim la afirmará hasta siempre. <em>Selah</em>¹⁶⁸<em>. </em>",
+          "tth": "Como <em>lo</em> hemos oído, así <em>lo</em> hemos visto en la ciudad de יהוה Tzebaot, en la ciudad de nuestro Elohim. Elohim la afirmará hasta siempre. <em>Selah</em>¹⁶⁸<em>.</em>",
           "footnotes": [
             {
               "marker": "¹⁶⁸",
@@ -5609,7 +5712,14 @@
         {
           "verse": 14,
           "tth": "Porque Este es Elohim, nuestro Elohim siempre y eternamente; Él nos guiará sobre la muerte¹⁷².",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁷²",
+              "number": "172",
+              "word": "muerte",
+              "explanation": "La versión gr. dice: hasta siempre."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Para el vencedor. De los hijos de Koraj. Cántico."
         }
@@ -5644,7 +5754,7 @@
         },
         {
           "verse": 5,
-          "tth": "¿Por qué he de temer en días de mal, <em>cuando</em> la iniquidad de mi talón me rodeará?",
+          "tth": "¿Por qué he de temer en días de mal,<em>cuando</em> la iniquidad de mi talón me rodeará?",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5720,7 +5830,7 @@
         },
         {
           "verse": 13,
-          "tth": "Este es el camino de ellos, su locura, y <em>los que son</em> después de ellos en sus bocas se complacerán. <em>Selah</em>¹⁷⁷<em>. </em>",
+          "tth": "Este es el camino de ellos, su locura, y <em>los que son</em> después de ellos en sus bocas se complacerán. <em>Selah</em>¹⁷⁷<em>.</em>",
           "footnotes": [
             {
               "marker": "¹⁷⁷",
@@ -5739,7 +5849,7 @@
         },
         {
           "verse": 15,
-          "tth": "Sin embargo, Elohim redimirá mi ser de la mano del Sheol, porque Él me recibirá. <em>Selah. </em>",
+          "tth": "Sin embargo, Elohim redimirá mi ser de la mano del Sheol, porque Él me recibirá. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -5825,7 +5935,7 @@
         },
         {
           "verse": 6,
-          "tth": "Y darán a conocer los cielos su justicia, porque Elohim es el Juez. <em>Selah</em>¹⁸⁰<em>. </em>",
+          "tth": "Y darán a conocer los cielos su justicia, porque Elohim es el Juez. <em>Selah</em>¹⁸⁰<em>.</em>",
           "footnotes": [
             {
               "marker": "¹⁸⁰",
@@ -6063,7 +6173,7 @@
         },
         {
           "verse": 17,
-          "tth": "Los sacrificios de Elohim son el ánimo quebrantado; <em>al</em> corazón quebrantado y aplastado, Elohim, no despreciarás.",
+          "tth": "Los sacrificios de Elohim son el ánimo quebrantado;<em>al</em> corazón quebrantado y aplastado, Elohim, no despreciarás.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -6099,7 +6209,7 @@
               "marker": "¹⁸⁵",
               "number": "185",
               "word": "día",
-              "explanation": "Léase ‘día' como un título mesiánico."
+              "explanation": "Léase 'día' como un título mesiánico."
             }
           ],
           "hebrew_terms": []
@@ -6112,7 +6222,7 @@
         },
         {
           "verse": 3,
-          "tth": "Has amado el mal <em>más</em> que el bien, la mentira <em>más</em> que hablar justicia. <em>Selah</em>¹⁸⁶<em>. </em>",
+          "tth": "Has amado el mal <em>más</em> que el bien, la mentira <em>más</em> que hablar justicia. <em>Selah</em>¹⁸⁶<em>.</em>",
           "footnotes": [
             {
               "marker": "¹⁸⁶",
@@ -6131,7 +6241,7 @@
         },
         {
           "verse": 5,
-          "tth": "Además, El te derribará para siempre; te arrebatará y te arrancará de la tienda, y te desarraigará de la tierra de los vivos. <em>Selah. </em>",
+          "tth": "Además, El te derribará para siempre; te arrebatará y te arrancará de la tienda, y te desarraigará de la tierra de los vivos. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -6172,7 +6282,7 @@
             }
           ],
           "hebrew_terms": [],
-          "subtitle": "Para el vencedor. Sobre Majalat¹⁸⁸.Masquil de David."
+          "subtitle": "Para el vencedor. Sobre Majalat¹⁸⁸. Masquil de David."
         }
       ]
     },
@@ -6249,7 +6359,7 @@
         },
         {
           "verse": 3,
-          "tth": "Porque extraños se levantaron contra mí, y despiadados han buscado mi vida; no han puesto <em>a</em> Elohim delante de sí. <em>Selah</em>¹⁹¹<em>. </em>",
+          "tth": "Porque extraños se levantaron contra mí, y despiadados han buscado mi vida; no han puesto <em>a</em> Elohim delante de sí. <em>Selah</em>¹⁹¹<em>.</em>",
           "footnotes": [
             {
               "marker": "¹⁹¹",
@@ -6281,7 +6391,14 @@
         {
           "verse": 7,
           "tth": "Porque de toda estrechez me ha rescatado, y sobre¹⁹² mis enemigos miró mi ojo.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁹²",
+              "number": "192",
+              "word": "sobre",
+              "explanation": "Lit.: en."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Para el vencedor; con instrumentos de cuerda. Masquil de David."
         }
@@ -6355,7 +6472,7 @@
         },
         {
           "verse": 7,
-          "tth": "He aquí, vagaría lejos; moraría en el desierto. <em>Selah</em>¹⁹⁷<em>. </em>",
+          "tth": "He aquí, vagaría lejos; moraría en el desierto. <em>Selah</em>¹⁹⁷<em>.</em>",
           "footnotes": [
             {
               "marker": "¹⁹⁷",
@@ -6399,7 +6516,7 @@
         },
         {
           "verse": 12,
-          "tth": "Porque no es un enemigo el que me insulta, <em>sino</em> lo soportaría; ni es uno que me odia el que sobre mí se ha engrandecido, <em>sino</em> me ocultaría de él;",
+          "tth": "Porque no es un enemigo el que me insulta, <em>sino</em> lo soportaría; ni es uno que me odia el que sobre mí se ha engrandecido,<em>sino</em> me ocultaría de él;",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -6418,7 +6535,7 @@
         },
         {
           "verse": 14,
-          "tth": "que hacíamos juntos una dulce conversación íntima, <em>que</em> en la casa de Elohim andábamos con la multitud.",
+          "tth": "que hacíamos juntos una dulce conversación íntima,<em>que</em> en la casa de Elohim andábamos con la multitud.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -6462,7 +6579,7 @@
         },
         {
           "verse": 19,
-          "tth": "Escuchará El²⁰², y los afligirá, y el que permanece <em>desde</em> la antigüedad, <em>Selah, </em> porque no hay cambios en ellos ni temen a Elohim.",
+          "tth": "Escuchará El²⁰², y los afligirá, y el que permanece <em>desde</em> la antigüedad, <em>Selah,</em> porque no hay cambios en ellos ni temen a Elohim.",
           "footnotes": [
             {
               "marker": "²⁰²",
@@ -6556,7 +6673,14 @@
         {
           "verse": 6,
           "tth": "Hacen emboscada²⁰⁶, se esconden, vigilan mis talones, cuando esperan mi vida.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁰⁶",
+              "number": "206",
+              "word": "emboscada",
+              "explanation": "Así en la versión gr., en el T.M.: Se reúnen."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -6598,7 +6722,14 @@
         {
           "verse": 13,
           "tth": "Porque has rescatado mi ser de la muerte, ¿no <em>rescataste</em> mis pies del tropiezo?, para andar delante de mi Elohim en la luz de la vida.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁰⁷",
+              "number": "207",
+              "word": "Mijtam",
+              "explanation": "Posiblemente: carta, escrito. De derivación dudosa, tal vez del término de igual significado: mijtav."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Para el vencedor; no destruyas. De David, un Mijtam²⁰⁷, cuando huía de delante de Shaúl, en la cueva."
         }
@@ -6618,6 +6749,12 @@
           "tth": "Clamaré al Elohim Elyón²⁰⁸, al El²⁰⁹ que completará sobre mí.",
           "footnotes": [
             {
+              "marker": "²⁰⁸",
+              "number": "208",
+              "word": "Elyón",
+              "explanation": "El Elevado."
+            },
+            {
               "marker": "²⁰⁹",
               "number": "209",
               "word": "El",
@@ -6628,8 +6765,15 @@
         },
         {
           "verse": 3,
-          "tth": "Él enviará desde los cielos y me salvará; Él reprocha <em>al</em> que jadea por mí. <em>Selah</em>²¹⁰<em>. </em> Enviará Elohim su bondad y su verdad.",
-          "footnotes": [],
+          "tth": "Él enviará desde los cielos y me salvará; Él reprocha <em>al</em> que jadea por mí. <em>Selah</em>²¹⁰<em>.</em> Enviará Elohim su bondad y su verdad.",
+          "footnotes": [
+            {
+              "marker": "²¹⁰",
+              "number": "210",
+              "word": "",
+              "explanation": "Eternamente. O, firme. Así también en vers. 6."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -6646,7 +6790,7 @@
         },
         {
           "verse": 6,
-          "tth": "Una red han preparado para mis pasos; se ha curvado mi ser; cavaron una fosa delante de mí, ¡<em>ellos mismos</em> cayeron dentro de ella! <em>Selah. </em>",
+          "tth": "Una red han preparado para mis pasos; se ha curvado mi ser; cavaron una fosa delante de mí, ¡<em>ellos mismos</em> cayeron dentro de ella! <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -6720,7 +6864,14 @@
         {
           "verse": 5,
           "tth": "que no oye la voz de los que encantan <em>²¹²</em>, <em>ni siquiera al más</em> sabio hechicero de hechizos.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²¹²",
+              "number": "212",
+              "word": "",
+              "explanation": "O, susurran."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -6756,7 +6907,14 @@
         {
           "verse": 11,
           "tth": "Y dirá el hombre: Ciertamente <em>hay</em> fruto para el justificado, ciertamente hay un Elohim que juzga en la tierra.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²¹³",
+              "number": "213",
+              "word": "Mijtam",
+              "explanation": "Posiblemente: carta, escrito. De derivación dudosa, tal vez del término de igual significado: mijtav."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Para el vencedor; no destruyas. De David, un Mijtam²¹³, cuando envió Shaúl y vigilaron la casa para matarlo."
         }
@@ -6791,7 +6949,7 @@
         },
         {
           "verse": 5,
-          "tth": "Y Tú, יהוה, Elohim Tzebaot, Elohim de Israel, despierta para visitar todas las naciones; no tengas piedad de ningún traidor de vacuidad. <em>Selah</em>²¹⁴<em>. </em>",
+          "tth": "Y Tú, יהוה, Elohim Tzebaot, Elohim de Israel, despierta para visitar todas las naciones; no tengas piedad de ningún traidor de vacuidad. <em>Selah</em>²¹⁴<em>.</em>",
           "footnotes": [
             {
               "marker": "²¹⁴",
@@ -6810,7 +6968,7 @@
         },
         {
           "verse": 7,
-          "tth": "He aquí, borbotean en su boca; espadas <em>hay</em> en sus labios, porque <em>dicen: </em> ¿Quién oye?",
+          "tth": "He aquí, borbotean en su boca; espadas <em>hay</em> en sus labios, porque <em>dicen:</em> ¿Quién oye?",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -6823,7 +6981,14 @@
         {
           "verse": 9,
           "tth": "Mi fuerza, a ti cantaré²¹⁵, porque Elohim es mi alto refugio,",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²¹⁵",
+              "number": "215",
+              "word": "cantaré",
+              "explanation": "El T.M. dice: a ti guardaré. Probablemente, un error de texto. Véase vers. 17."
+            }
+          ],
           "hebrew_terms": []
         },
         {
@@ -6859,7 +7024,7 @@
         },
         {
           "verse": 13,
-          "tth": "Acába <em>los</em> en tu ardor, acába <em>los</em>, y no serán <em>más</em>; y sabrán que Elohim gobierna en Yaakov, hasta los confines de la tierra. <em>Selah. </em>",
+          "tth": "Acába <em>los</em> en tu ardor, acába <em>los</em>, y no serán <em>más</em>; y sabrán que Elohim gobierna en Yaakov, hasta los confines de la tierra. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -6913,7 +7078,7 @@
         },
         {
           "verse": 4,
-          "tth": "Has dado a los que te temen una señal, para alzarlo delante del aguijón. <em>Selah. </em>",
+          "tth": "Has dado a los que te temen una señal, para alzarlo delante del aguijón. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -6937,7 +7102,7 @@
         },
         {
           "verse": 8,
-          "tth": "Moab es la olla <em>en que</em> me lavo; sobre Edom arrojaré mi zapato; por Mí grita triunfantemente Peléshet (Otra lectura posible es: <em>sobre Peléshet gritaré triunfantemente; </em> véase Salmo 108: 9).",
+          "tth": "Moab es la olla <em>en que</em> me lavo; sobre Edom arrojaré mi zapato; por Mí grita triunfantemente Peléshet (Otra lectura posible es: <em>sobre Peléshet gritaré triunfantemente;</em> véase Salmo 108: 9).",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -6991,7 +7156,7 @@
         },
         {
           "verse": 4,
-          "tth": "Moraré en tu tienda <em>para</em> siempre; me refugiaré en el escondite de tus alas. <em>Selah. </em>",
+          "tth": "Moraré en tu tienda <em>para</em> siempre; me refugiaré en el escondite de tus alas. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7009,7 +7174,7 @@
         },
         {
           "verse": 7,
-          "tth": "Se sentará siempre delante de Elohim; bondad y verdad asígna <em>le</em>, <em>y</em> lo guardarán.",
+          "tth": "Se sentará siempre delante de Elohim; bondad y verdad asígna <em>le</em>,<em>y</em> lo guardarán.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7018,7 +7183,7 @@
           "tth": "Así cantaré <em>a</em> tu Nombre para siempre, para cumplir mis votos día <em>a</em> día.",
           "footnotes": [],
           "hebrew_terms": [],
-          "subtitle": "Para el vencedor, de Iedutún.Cántico de David."
+          "subtitle": "Para el vencedor, de Iedutún. Cántico de David."
         }
       ]
     },
@@ -7045,7 +7210,7 @@
         },
         {
           "verse": 4,
-          "tth": "Ciertamente consultaron para derribarlo de su (La versión gr., dice: <em>mi</em>) elevación; se deleitarán <em>en</em> la falsedad; con la boca bendicen, pero en su interior maldicen. <em>Selah. </em>",
+          "tth": "Ciertamente consultaron para derribarlo de su (La versión gr., dice:<em>mi</em>) elevación; se deleitarán <em>en</em> la falsedad; con la boca bendicen, pero en su interior maldicen. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7069,7 +7234,7 @@
         },
         {
           "verse": 8,
-          "tth": "¡Confíen en Él en todo tiempo, pueblo! ¡Derramen delante de Él su corazón! Elohim es refugio para nosotros. <em>Selah. </em>",
+          "tth": "¡Confíen en Él en todo tiempo, pueblo! ¡Derramen delante de Él su corazón! Elohim es refugio para nosotros. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7081,7 +7246,7 @@
         },
         {
           "verse": 10,
-          "tth": "No confíen en la extorsión, y en el robo no se envanezcan; cuando la riqueza dé fruto, no pogan el corazón <em>en ella. </em>",
+          "tth": "No confíen en la extorsión, y en el robo no se envanezcan; cuando la riqueza dé fruto, no pogan el corazón <em>en ella.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7344,7 +7509,7 @@
         },
         {
           "verse": 4,
-          "tth": "<em>Los de</em> toda la tierra se postrarán a ti, y te cantarán, cantarán <em>a</em> tu Nombre. <em>Selah. </em>",
+          "tth": "<em>Los de</em> toda la tierra se postrarán a ti, y te cantarán, cantarán <em>a</em> tu Nombre. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7362,7 +7527,7 @@
         },
         {
           "verse": 7,
-          "tth": "Él gobierna en su poder <em>para</em> siempre; sus ojos vigilan a la naciones; no se exalten los rebeldes. <em>Selah. </em>",
+          "tth": "Él gobierna en su poder <em>para</em> siempre; sus ojos vigilan a la naciones; no se exalten los rebeldes. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7410,7 +7575,7 @@
         },
         {
           "verse": 15,
-          "tth": "Ofrendas ascendidas de engordados haré subir a ti, con incienso de carneros; haré <em>ofrenda de</em> ganado con machos cabríos. <em>Selah. </em>",
+          "tth": "Ofrendas ascendidas de engordados haré subir a ti, con incienso de carneros; haré <em>ofrenda de</em> ganado con machos cabríos. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7452,7 +7617,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Elohim se inclinará con favor a nosotros, y nos bendecirá, hará brillar su rostro con nosotros. <em>Selah; </em>",
+          "tth": "Elohim se inclinará con favor a nosotros, y nos bendecirá, hará brillar su rostro con nosotros. <em>Selah;</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7470,7 +7635,7 @@
         },
         {
           "verse": 4,
-          "tth": "Se alegrarán y gritarán de alegría los pueblos, porque juzgarás los pueblos <em>en</em> rectitud, y las naciones en la tierra guiarás. <em>Selah. </em>",
+          "tth": "Se alegrarán y gritarán de alegría los pueblos, porque juzgarás los pueblos <em>en</em> rectitud, y las naciones en la tierra guiarás. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7536,7 +7701,7 @@
         },
         {
           "verse": 7,
-          "tth": "Elohim, cuando saliste delante de tu pueblo, cuando marchaste por el desierto, <em>Selah, </em>",
+          "tth": "Elohim, cuando saliste delante de tu pueblo, cuando marchaste por el desierto, <em>Selah,</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7608,7 +7773,7 @@
         },
         {
           "verse": 19,
-          "tth": "Bendito Adonai, <em>que</em> día <em>a</em> día nos soporta, el Elohim de nuestra salvación. <em>Selah. </em>",
+          "tth": "Bendito Adonai, <em>que</em> día <em>a</em> día nos soporta, el Elohim de nuestra salvación. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -7656,7 +7821,7 @@
         },
         {
           "verse": 27,
-          "tth": "Allí <em>está</em> Biniamín, el pequeño, su gobernador, los príncipes de Iehudáh <em>con</em> su congregación (O, <em>los príncipes de Iehudáh, sus gobernantes; </em> o, <em>los príncipes de Iehudáh los apedrean</em>), los príncipes de Zebulún, los príncipes de Naftalí.",
+          "tth": "Allí <em>está</em> Biniamín, el pequeño, su gobernador, los príncipes de Iehudáh <em>con</em> su congregación (O, <em>los príncipes de Iehudáh, sus gobernantes;</em> o, <em>los príncipes de Iehudáh los apedrean</em>), los príncipes de Zebulún, los príncipes de Naftalí.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8111,7 +8276,7 @@
         },
         {
           "verse": 24,
-          "tth": "También mi lengua todo el día pronunciará tu justicia, porque han sido avergonzados, porque han sido abochornados, los que buscan mi mal. <em>De Shelomóh. </em>",
+          "tth": "También mi lengua todo el día pronunciará tu justicia, porque han sido avergonzados, porque han sido abochornados, los que buscan mi mal. <em>De Shelomóh.</em>",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -8579,7 +8744,7 @@
         },
         {
           "verse": 3,
-          "tth": "Se derriten la tierra y todos sus habitantes, <em>mas</em> Yo he establecido sus columnas. <em>Selah. </em>",
+          "tth": "Se derriten la tierra y todos sus habitantes, <em>mas</em> Yo he establecido sus columnas. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8645,7 +8810,7 @@
         },
         {
           "verse": 3,
-          "tth": "Allí quebró las llamas del arco, el escudo, la espada y la guerra. <em>Selah. </em>",
+          "tth": "Allí quebró las llamas del arco, el escudo, la espada y la guerra. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8681,7 +8846,7 @@
         },
         {
           "verse": 9,
-          "tth": "al levantarse Elohim para el juicio, para salvar a todos los afligidos de la tierra. <em>Selah. </em>",
+          "tth": "al levantarse Elohim para el juicio, para salvar a todos los afligidos de la tierra. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8702,7 +8867,7 @@
           "tth": "Él cortará el aliento de los príncipes; temible es para los reyes de la tierra.",
           "footnotes": [],
           "hebrew_terms": [],
-          "subtitle": "Para el vencedor, de Iedutún.Cántico de Asaf."
+          "subtitle": "Para el vencedor, de Iedutún. Cántico de Asaf."
         }
       ]
     },
@@ -8723,7 +8888,7 @@
         },
         {
           "verse": 3,
-          "tth": "Me acordaba de Elohim, y gemía, reflexionaba, y se cubría mi ánimo. <em>Selah. </em>",
+          "tth": "Me acordaba de Elohim, y gemía, reflexionaba, y se cubría mi ánimo. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8759,7 +8924,7 @@
         },
         {
           "verse": 9,
-          "tth": "¿Ha olvidado tener piedad El, o ha cerrado en ira sus compasiones? <em>Selah. </em>",
+          "tth": "¿Ha olvidado tener piedad El, o ha cerrado en ira sus compasiones? <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -8795,7 +8960,7 @@
         },
         {
           "verse": 15,
-          "tth": "Has redimido con el brazo <em>a</em> tu pueblo, los hijos de Yaakov y Iosef. <em>Selah. </em>",
+          "tth": "Has redimido con el brazo <em>a</em> tu pueblo, los hijos de Yaakov y Iosef. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -9079,6 +9244,12 @@
           "verse": 41,
           "tth": "Y volvieron y pusieron a prueba <em>a</em> El²¹⁸, y afligieron²¹⁹ <em>al</em> Kadosh²²⁰ de Israel.",
           "footnotes": [
+            {
+              "marker": "²¹⁸",
+              "number": "218",
+              "word": "El",
+              "explanation": "Poderoso."
+            },
             {
               "marker": "²¹⁹",
               "number": "219",
@@ -9542,7 +9713,7 @@
         },
         {
           "verse": 7,
-          "tth": "En la estrechez llamaste, y te saqué; te respondí en el escondite del trueno, te probé en las aguas de Meribah. <em>Selah. </em>",
+          "tth": "En la estrechez llamaste, y te saqué; te respondí en el escondite del trueno, te probé en las aguas de Meribah. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -9614,7 +9785,7 @@
         },
         {
           "verse": 2,
-          "tth": "¿Hasta cuándo juzgarán <em>con</em> injusticia y el rostro de los malvados levantarán? <em>Selah. </em>",
+          "tth": "¿Hasta cuándo juzgarán <em>con</em> injusticia y el rostro de los malvados levantarán? <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -9703,7 +9874,7 @@
         },
         {
           "verse": 8,
-          "tth": "también Ashur se ha unido con ellos; fueron <em>como</em> brazo para los hijos de Lot. <em>Selah. </em>",
+          "tth": "también Ashur se ha unido con ellos; fueron <em>como</em> brazo para los hijos de Lot. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -9793,7 +9964,7 @@
         },
         {
           "verse": 4,
-          "tth": "¡Felices los habitantes de tu casa!, continuamente te alabarán. <em>Selah. </em>",
+          "tth": "¡Felices los habitantes de tu casa!, continuamente te alabarán. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -9817,7 +9988,7 @@
         },
         {
           "verse": 8,
-          "tth": "¡יהוה, Elohim Tzebaot, escucha mi oración; da oído, Elohim de Yaakov! <em>Selah. </em>",
+          "tth": "¡יהוה, Elohim Tzebaot, escucha mi oración; da oído, Elohim de Yaakov! <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -9859,7 +10030,7 @@
         },
         {
           "verse": 2,
-          "tth": "Cargaste la iniquidad de tu pueblo, cubriste todo su pecado. <em>Selah. </em>",
+          "tth": "Cargaste la iniquidad de tu pueblo, cubriste todo su pecado. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -10055,7 +10226,7 @@
         },
         {
           "verse": 3,
-          "tth": "Cosas honrosas se hablan en ti, ciudad del Elohim. <em>Selah. </em>",
+          "tth": "Cosas honrosas se hablan en ti, ciudad del Elohim. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -10073,7 +10244,7 @@
         },
         {
           "verse": 6,
-          "tth": "יהוה contará al escribir <em>a los</em> pueblos: Este nació allí. <em>Selah. </em>",
+          "tth": "יהוה contará al escribir <em>a los</em> pueblos: Este nació allí. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -10126,7 +10297,7 @@
         },
         {
           "verse": 7,
-          "tth": "Sobre mí has apoyado tu ardor, <em>con</em> tus olas rompientes <em>me</em> afligiste. <em>Selah. </em>",
+          "tth": "Sobre mí has apoyado tu ardor, <em>con</em> tus olas rompientes <em>me</em> afligiste. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -10222,7 +10393,7 @@
         },
         {
           "verse": 4,
-          "tth": "Hasta siempre estableceré tu simiente, y edificaré por generación y generación tu trono. <em>Selah. </em>",
+          "tth": "Hasta siempre estableceré tu simiente, y edificaré por generación y generación tu trono. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -10420,7 +10591,7 @@
         },
         {
           "verse": 37,
-          "tth": "Como la luna será afirmado siempre, y <em>como</em> testigo firme en las nubes. <em>Selah. </em>",
+          "tth": "Como la luna será afirmado siempre, y <em>como</em> testigo firme en las nubes. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -10468,7 +10639,7 @@
         },
         {
           "verse": 45,
-          "tth": "Has acortado los días de su juventud; cubriste sobre él <em>con</em> vergüenza. <em>Selah. </em>",
+          "tth": "Has acortado los días de su juventud; cubriste sobre él <em>con</em> vergüenza. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -10486,7 +10657,7 @@
         },
         {
           "verse": 48,
-          "tth": "¿Quién <em>siendo</em> varón vivirá y no verá muerte? ¿Hará escapar su vida de la mano del Sheol? <em>Selah. </em>",
+          "tth": "¿Quién <em>siendo</em> varón vivirá y no verá muerte? ¿Hará escapar su vida de la mano del Sheol?<em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -11223,7 +11394,7 @@
         },
         {
           "verse": 12,
-          "tth": "Alégrense, justos, en יהוה, y alaben a la memoria de su santidad. <em>Cántico. </em>",
+          "tth": "Alégrense, justos, en יהוה, y alaben a la memoria de su santidad. <em>Cántico.</em>",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -11605,7 +11776,7 @@
         },
         {
           "verse": 28,
-          "tth": "Los hijos de tus siervos habitarán, y su simiente delante de ti será afirmada. <em>De David. </em>",
+          "tth": "Los hijos de tus siervos habitarán, y su simiente delante de ti será afirmada. <em>De David.</em>",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -11945,7 +12116,7 @@
         },
         {
           "verse": 33,
-          "tth": "Cantaré a יהוה en mi vida, entonaré a mi Elohim mientras yo <em>exista. </em>",
+          "tth": "Cantaré a יהוה en mi vida, entonaré a mi Elohim mientras yo <em>exista.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -13686,7 +13857,7 @@
         },
         {
           "verse": 13,
-          "tth": "Empujándo <em>me, </em> me empujaste para caer, pero יהוה me ayudó.",
+          "tth": "Empujándo <em>me,</em> me empujaste para caer, pero יהוה me ayudó.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -13716,7 +13887,7 @@
         },
         {
           "verse": 18,
-          "tth": "Corrigiéndo <em>me, </em> me disciplinó Yah, y a la muerte no me dio.",
+          "tth": "Corrigiéndo <em>me,</em> me disciplinó Yah, y a la muerte no me dio.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -13782,7 +13953,7 @@
         },
         {
           "verse": 29,
-          "tth": "Confiesen a יהוה, porque es bueno, porque para siempre es su bondad. <em>Alef. </em>",
+          "tth": "Confiesen a יהוה, porque es bueno, porque para siempre es su bondad. <em>Alef.</em>",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -13835,7 +14006,7 @@
         },
         {
           "verse": 8,
-          "tth": "Tus estatutos guardaré, no me abandones demasiado. <em>Bet. </em>",
+          "tth": "Tus estatutos guardaré, no me abandones demasiado. <em>Bet.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -13883,7 +14054,7 @@
         },
         {
           "verse": 16,
-          "tth": "En tus estatutos me deleitaré, no olvidaré tu palabra. <em>Guímel. </em>",
+          "tth": "En tus estatutos me deleitaré, no olvidaré tu palabra. <em>Guímel.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -13931,7 +14102,7 @@
         },
         {
           "verse": 24,
-          "tth": "También tus testimonios son mi deleite, los hombres de mi consejo. <em>Dálet. </em>",
+          "tth": "También tus testimonios son mi deleite, los hombres de mi consejo. <em>Dálet.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -13979,7 +14150,7 @@
         },
         {
           "verse": 32,
-          "tth": "El camino de tus mandamientos correré, porque ensancharás mi corazón. <em>He. </em>",
+          "tth": "El camino de tus mandamientos correré, porque ensancharás mi corazón. <em>He.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -14027,7 +14198,7 @@
         },
         {
           "verse": 40,
-          "tth": "He aquí, he deseado tus preceptos, con tu justicia vivifícame. <em>Vav. </em>",
+          "tth": "He aquí, he deseado tus preceptos, con tu justicia vivifícame. <em>Vav.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -14075,7 +14246,7 @@
         },
         {
           "verse": 48,
-          "tth": "Y alzaré mis palmas hacia tus mandamientos, los cuales he amado, y reflexionaré en tus estatutos. <em>Záin. </em>",
+          "tth": "Y alzaré mis palmas hacia tus mandamientos, los cuales he amado, y reflexionaré en tus estatutos. <em>Záin.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -14123,7 +14294,7 @@
         },
         {
           "verse": 56,
-          "tth": "Esto fue para mí (O, Esto tuve), porque tus preceptos he vigilado. <em>Jet. </em>",
+          "tth": "Esto fue para mí (O, Esto tuve), porque tus preceptos he vigilado. <em>Jet.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -14171,7 +14342,7 @@
         },
         {
           "verse": 64,
-          "tth": "Tu bondad, יהוה, llenó la tierra, tus estatutos enséñame. <em>Tet. </em>",
+          "tth": "Tu bondad, יהוה, llenó la tierra, tus estatutos enséñame. <em>Tet.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -14219,7 +14390,7 @@
         },
         {
           "verse": 72,
-          "tth": "Buena es para mí la Torah de tu boca, <em>más</em> que miles de oro y plata. <em>Yud. </em>",
+          "tth": "Buena es para mí la Torah de tu boca, <em>más</em> que miles de oro y plata. <em>Yud.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -14267,7 +14438,7 @@
         },
         {
           "verse": 80,
-          "tth": "Sea mi corazón completo en tus estatutos, a fin de que no me avergüence. <em>Caf. </em>",
+          "tth": "Sea mi corazón completo en tus estatutos, a fin de que no me avergüence. <em>Caf.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -14315,7 +14486,7 @@
         },
         {
           "verse": 88,
-          "tth": "Conforme a tu bondad vivifícame, y guardaré el testimonio de tu boca. <em>Lámed. </em>",
+          "tth": "Conforme a tu bondad vivifícame, y guardaré el testimonio de tu boca. <em>Lámed.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -14363,7 +14534,7 @@
         },
         {
           "verse": 96,
-          "tth": "A toda perfección le he visto final; tu mandamiento es muy amplio. <em>Mem. </em>",
+          "tth": "A toda perfección le he visto final; tu mandamiento es muy amplio. <em>Mem.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -14411,7 +14582,7 @@
         },
         {
           "verse": 104,
-          "tth": "A partir de tus preceptos entenderé; por eso, he odiado toda senda de mentira. <em>Nun. </em>",
+          "tth": "A partir de tus preceptos entenderé; por eso, he odiado toda senda de mentira. <em>Nun.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -14459,7 +14630,7 @@
         },
         {
           "verse": 112,
-          "tth": "Incliné mi corazón para hacer tus estatutos para siempre, <em>hasta</em> el fin. <em>Sámej. </em>",
+          "tth": "Incliné mi corazón para hacer tus estatutos para siempre, <em>hasta</em> el fin. <em>Sámej.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -14507,7 +14678,7 @@
         },
         {
           "verse": 120,
-          "tth": "Se estremeció mi carne por temor a ti, y de tus juicios tengo temor. <em>‘Áin, </em>",
+          "tth": "Se estremeció mi carne por temor a ti, y de tus juicios tengo temor. <em>'Áin,</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -14555,7 +14726,7 @@
         },
         {
           "verse": 128,
-          "tth": "Por eso, todos tus preceptos, todo he hecho rectamente; toda senda de mentira he aborrecido. <em>Peh. </em>",
+          "tth": "Por eso, todos tus preceptos, todo he hecho rectamente; toda senda de mentira he aborrecido. <em>Peh.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -14603,7 +14774,7 @@
         },
         {
           "verse": 136,
-          "tth": "Canales de aguas descienden de mis ojos, por no guardar ellos tu Torah. <em>Tzadi. </em>",
+          "tth": "Canales de aguas descienden de mis ojos, por no guardar ellos tu Torah. <em>Tzadi.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -14651,7 +14822,7 @@
         },
         {
           "verse": 144,
-          "tth": "Justicia son tus testimonios para siempre, hazme entender y viviré. <em>Kuf. </em>",
+          "tth": "Justicia son tus testimonios para siempre, hazme entender y viviré. <em>Kuf.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -14699,7 +14870,7 @@
         },
         {
           "verse": 152,
-          "tth": "<em>Desde</em> antes he sabido de tus testimonios, que para siempre los has fundado. <em>Resh. </em>",
+          "tth": "<em>Desde</em> antes he sabido de tus testimonios, que para siempre los has fundado. <em>Resh.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -14747,7 +14918,7 @@
         },
         {
           "verse": 160,
-          "tth": "La cabeza de tu palabra es verdad, y para siempre es todo juicio de tu justicia. <em>Shin. </em>",
+          "tth": "La cabeza de tu palabra es verdad, y para siempre es todo juicio de tu justicia. <em>Shin.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -14795,7 +14966,7 @@
         },
         {
           "verse": 168,
-          "tth": "Guardé tus preceptos y tus testimonios, porque todos mis caminos están delante de ti. <em>Tav. </em>",
+          "tth": "Guardé tus preceptos y tus testimonios, porque todos mis caminos están delante de ti. <em>Tav.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -15884,7 +16055,7 @@
         },
         {
           "verse": 9,
-          "tth": "¡Feliz el que agarre y estrelle a tus niños contra la peña! <em>De David. </em>",
+          "tth": "¡Feliz el que agarre y estrelle a tus niños contra la peña! <em>De David.</em>",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -16111,7 +16282,7 @@
         },
         {
           "verse": 3,
-          "tth": "Afilan su lengua como serpiente; veneno de víbora <em>hay</em> bajo sus labios. <em>Selah. </em>",
+          "tth": "Afilan su lengua como serpiente; veneno de víbora <em>hay</em> bajo sus labios. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -16123,7 +16294,7 @@
         },
         {
           "verse": 5,
-          "tth": "Han ocultado los altivos una trampa para mí; y <em>con</em> cuerdas han extendido una red junto a (Lit.: a la mano de) mi camino; señuelos pusieron para mí. <em>Selah. </em>",
+          "tth": "Han ocultado los altivos una trampa para mí; y <em>con</em> cuerdas han extendido una red junto a (Lit.: a la mano de) mi camino; señuelos pusieron para mí. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -16141,7 +16312,7 @@
         },
         {
           "verse": 8,
-          "tth": "No des, יהוה, los deseos del malvado; su plan perverso no saques a la luz, <em>sino</em> se exaltarían. <em>Selah. </em>",
+          "tth": "No des, יהוה, los deseos del malvado; su plan perverso no saques a la luz, <em>sino</em> se exaltarían. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -16249,7 +16420,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Con <em>mi voz a יהוה clamaré, </em> Con mi voz a יהוה suplicaré favor.",
+          "tth": "Con <em>mi voz a יהוה clamaré,</em> Con mi voz a יהוה suplicaré favor.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -16327,7 +16498,7 @@
         },
         {
           "verse": 6,
-          "tth": "Extendí mis manos a ti; mi ser como tierra cansada es para ti. <em>Selah. </em>",
+          "tth": "Extendí mis manos a ti; mi ser como tierra cansada es para ti. <em>Selah.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -16363,7 +16534,7 @@
         },
         {
           "verse": 12,
-          "tth": "Y en tu bondad, silencia <em>a</em> mis enemigos, y haz perecer <em>a</em> todos los opresores de mi ser, porque yo soy tu siervo. <em>De David. </em>",
+          "tth": "Y en tu bondad, silencia <em>a</em> mis enemigos, y haz perecer <em>a</em> todos los opresores de mi ser, porque yo soy tu siervo. <em>De David.</em>",
           "footnotes": [],
           "hebrew_terms": []
         }
@@ -16607,7 +16778,7 @@
         },
         {
           "verse": 2,
-          "tth": "Alabaré <em>a</em> יהוה en mi vida, entonaré a mi Elohim mientras yo <em>exista. </em>",
+          "tth": "Alabaré <em>a</em> יהוה en mi vida, entonaré a mi Elohim mientras yo <em>exista.</em>",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -16970,7 +17141,14 @@
         {
           "verse": 6,
           "tth": "Toda neshamáh²²³ alabará <em>a</em> Yah. ¡Alaben a Yah (heb.: <em>HaleluYah</em>)!",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²²³",
+              "number": "223",
+              "word": "neshamáh",
+              "explanation": "O sea, todo el que haya recibido Rúaj Ha'Kódesh en Yeshúa el Mesías."
+            }
+          ],
           "hebrew_terms": []
         }
       ]

--- a/data/tth_2/json/tzefaniah.json
+++ b/data/tth_2/json/tzefaniah.json
@@ -251,7 +251,7 @@
         },
         {
           "verse": 8,
-          "tth": "He oído el insulto de Moab y las injurias de los hijos de Amón, <em>con</em> los cuales insultaron a mi pueblo y se engrandecieron sobre su frontera.",
+          "tth": "He oído el insulto de Moab y las injurias de los hijos de Amón,<em>con</em> los cuales insultaron a mi pueblo y se engrandecieron sobre su frontera.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -430,7 +430,7 @@
             {
               "marker": "¹⁹",
               "number": "19",
-              "word": "ruáh",
+              "word": "t'ruáh",
               "explanation": "Expresión de alegría, pronunciado tanto con la voz como con un shofar."
             }
           ],
@@ -483,7 +483,14 @@
         {
           "verse": 20,
           "tth": "En aquel tiempo <em>los</em> haré venir a ustedes; y en aquel tiempo los reuniré, porque les daré nombre y alabanza²² en todos los pueblos de la tierra, cuando Yo haga volver a sus cautivos a ojos de ustedes –dijo יהוה.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²²",
+              "number": "22",
+              "word": "alabanza",
+              "explanation": "Otra lectura posible es: los daré para nombre y para alabanza."
+            }
+          ],
           "hebrew_terms": []
         }
       ]

--- a/data/tth_2/json/vaikra.json
+++ b/data/tth_2/json/vaikra.json
@@ -425,7 +425,14 @@
         {
           "verse": 17,
           "tth": "Estatuto olam¹⁶ <em>será</em> por sus generaciones, en todos sus asentamientos; toda grasa y toda sangre no comerán”.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹⁶",
+              "number": "16",
+              "word": "olam",
+              "explanation": "Tiempo oculto, sólo conocido por Elohim."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Ofrendas por el pecado"
         }
@@ -2764,7 +2771,14 @@
         {
           "verse": 8,
           "tth": "Pero si no encuentra su mano suficiencia <em>para</em> un cordero, tomará ella dos tórtolas o dos hijos de paloma, uno para ofrenda ascendida y uno para ofrenda por el pecado; y hará reconciliación por ella el sacerdote, y ella será pura¹²⁹”.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "¹²⁹",
+              "number": "129",
+              "word": "pura",
+              "explanation": "O, apta. Heb.: Taheráh."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Instrucciones sobre la tzaraat"
         }
@@ -4952,7 +4966,20 @@
         {
           "verse": 37,
           "tth": "Y guardarán todos mis decretos²¹² y todos mis procesos legales²¹³, y los harán. Yo soy יהוה”.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²¹²",
+              "number": "212",
+              "word": "decretos",
+              "explanation": "Heb.: Jukim."
+            },
+            {
+              "marker": "²¹³",
+              "number": "213",
+              "word": "legales",
+              "explanation": "Heb.: Mishpatim."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Penas por actos de inmoralidad"
         }
@@ -6197,7 +6224,14 @@
         {
           "verse": 9,
           "tth": "Y será para Aharón y para sus hijos, y lo comerán en un lugar kadosh²⁷²; porque santidad de santidades es esto para él de las ofrendas de fuego de יהוה, un decreto olam.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁷²",
+              "number": "272",
+              "word": "kadosh",
+              "explanation": "Santo, apartado, distinguido."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Castigo del blasfemo"
         },
@@ -6832,7 +6866,14 @@
         {
           "verse": 13,
           "tth": "Yo soy יהוה su Elohim, que los saqué de la tierra de Mitzráim, de ser para ellos esclavos; y rompí las coyundas de su yugo y los hice caminar erguidos²⁹².",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "²⁹²",
+              "number": "292",
+              "word": "erguidos",
+              "explanation": "O, rectos."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Los resultados de la desobediencia"
         },

--- a/data/tth_2/json/zejariah.json
+++ b/data/tth_2/json/zejariah.json
@@ -34,19 +34,19 @@
         },
         {
           "verse": 3,
-          "tth": "Y les dirás: “Así ha dicho יהוה Tzebaot: ‘Vuelvan a Mí' –declaración de יהוה Tzebaot– ‘y Yo volveré a ustedes' –ha dicho יהוה Tzebaot.",
+          "tth": "Y les dirás: “Así ha dicho יהוה Tzebaot: 'Vuelvan a Mí' –declaración de יהוה Tzebaot– 'y Yo volveré a ustedes' –ha dicho יהוה Tzebaot.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 4,
-          "tth": "‘No sean como sus padres, a quienes proclamaron los profetas primeros, diciendo: “Así ha dicho יהוה Tzebaot: ‘Vuelvan ahora de sus malos caminos y de sus malas acciones' ”. Pero no escucharon ni me prestaron atención' –declaración de יהוה.",
+          "tth": "'No sean como sus padres, a quienes proclamaron los profetas primeros, diciendo: “Así ha dicho יהוה Tzebaot: 'Vuelvan ahora de sus malos caminos y de sus malas acciones' ”. Pero no escucharon ni me prestaron atención' –declaración de יהוה.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 5,
-          "tth": "‘Sus padres, ¿dónde <em>están</em> ellos? Y los profetas, ¿vivirán para siempre?",
+          "tth": "'Sus padres, ¿dónde <em>están</em> ellos? Y los profetas, ¿vivirán para siempre?",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -101,7 +101,7 @@
         },
         {
           "verse": 14,
-          "tth": "Y me dijo el ángel que hablaba conmigo: Proclama, diciendo: “Así ha dicho יהוה Tzebaot: ‘He celado a Yerushaláim y a Tzión <em>con</em> gran celo,",
+          "tth": "Y me dijo el ángel que hablaba conmigo: Proclama, diciendo: “Así ha dicho יהוה Tzebaot: 'He celado a Yerushaláim y a Tzión <em>con</em> gran celo,",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -113,13 +113,13 @@
         },
         {
           "verse": 16,
-          "tth": "Por eso, así ha dicho יהוה: ‘Regresé a Yerushaláim con compasión; mi casa será edificada en ella' –declaración de יהוה Tzebaot– ‘y cordel será extendido sobre Yerushaláim' ”.",
+          "tth": "Por eso, así ha dicho יהוה: 'Regresé a Yerushaláim con compasión; mi casa será edificada en ella' –declaración de יהוה Tzebaot– 'y cordel será extendido sobre Yerushaláim' ”.",
           "footnotes": [],
           "hebrew_terms": []
         },
         {
           "verse": 17,
-          "tth": "Proclama de nuevo, diciendo: “Así ha dicho יהוה Tzebaot: ‘De nuevo serán esparcidas mis ciudades de bien, y consolará יהוה de nuevo a Tzión, y escogerá de nuevo a Yerushaláim' ”.",
+          "tth": "Proclama de nuevo, diciendo: “Así ha dicho יהוה Tzebaot: 'De nuevo serán esparcidas mis ciudades de bien, y consolará יהוה de nuevo a Tzión, y escogerá de nuevo a Yerushaláim' ”.",
           "footnotes": [],
           "hebrew_terms": [],
           "subtitle": "Visión de los cuernos y de los artesanos"
@@ -259,7 +259,7 @@
             {
               "marker": "⁴",
               "number": "4",
-              "word": "satán",
+              "word": "Ha'satán",
               "explanation": "El adversario."
             }
           ],
@@ -390,7 +390,7 @@
         },
         {
           "verse": 7,
-          "tth": "“¿Quién eres tú, monte grande? Delante de Zerubabel <em>serás</em> por llanura; y él sacará la piedra principal⁹ <em>con</em> gritos de: ‘¡Favor, favor a ella! ' ”",
+          "tth": "“¿Quién eres tú, monte grande? Delante de Zerubabel <em>serás</em> por llanura; y él sacará la piedra principal⁹ <em>con</em> gritos de: '¡Favor, favor a ella! ' ”",
           "footnotes": [
             {
               "marker": "⁹",
@@ -637,7 +637,7 @@
         },
         {
           "verse": 12,
-          "tth": "Y le dirás, diciendo: “Así ha dicho יהוה Tzebaot, diciendo: ‘He aquí un hombre, Retoño¹⁷ es su nombre, y desde su lugar retoñará y edificará el Hejal¹⁸ de יהוה.",
+          "tth": "Y le dirás, diciendo: “Así ha dicho יהוה Tzebaot, diciendo: 'He aquí un hombre, Retoño¹⁷ es su nombre, y desde su lugar retoñará y edificará el Hejal¹⁸ de יהוה.",
           "footnotes": [
             {
               "marker": "¹⁷",
@@ -950,7 +950,7 @@
         },
         {
           "verse": 21,
-          "tth": "E irán los habitantes de una a otra, diciendo: ‘Andando, andaremos para rogar al rostro de יהוה y para buscar a יהוה Tzebaot. Iré yo también'.",
+          "tth": "E irán los habitantes de una a otra, diciendo: 'Andando, andaremos para rogar al rostro de יהוה y para buscar a יהוה Tzebaot. Iré yo también'.",
           "footnotes": [],
           "hebrew_terms": []
         },
@@ -962,7 +962,7 @@
         },
         {
           "verse": 23,
-          "tth": "Así ha dicho יהוה Tzebaot: “En aquellos días <em>será</em> que tomarán fuerte diez hombres de toda lengua de las naciones, y tomarán fuerte el borde²⁸ <em>del vestido</em> de un hombre iehudí²⁹, diciendo: ‘Iremos con ustedes, porque escuchamos <em>que</em> Elohim <em>está</em> con ustedes' ”.",
+          "tth": "Así ha dicho יהוה Tzebaot: “En aquellos días <em>será</em> que tomarán fuerte diez hombres de toda lengua de las naciones, y tomarán fuerte el borde²⁸ <em>del vestido</em> de un hombre iehudí²⁹, diciendo: 'Iremos con ustedes, porque escuchamos <em>que</em> Elohim <em>está</em> con ustedes' ”.",
           "footnotes": [
             {
               "marker": "²⁸",
@@ -1052,7 +1052,7 @@
             {
               "marker": "³²",
               "number": "32",
-              "word": "ruáh",
+              "word": "t'ruáh",
               "explanation": "Expresión de alegría, pronunciado tanto con la voz como con un shofar."
             },
             {
@@ -1136,7 +1136,14 @@
         {
           "verse": 17,
           "tth": "Porque, ¡cuánta su bondad y cuánta su belleza! El grano <em>a</em> los jóvenes y el mosto a las vírgenes hará florecer³⁸.",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "³⁸",
+              "number": "38",
+              "word": "florecer",
+              "explanation": "O, hará hablar."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "Elohim bendecirá a Iehudáh y Efráim"
         }
@@ -1147,7 +1154,7 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Pidan de יהוה lluvia en el tiempo de lluvia tardía, יהוה hace los relámpagos³⁹; y lluvia de aguacero <em>les</em> dará a ellos, a <em>cada</em> hombre, hierba en el campo.",
+          "tth": "Pidan de יהוה lluvia en el tiempo de lluvia tardía,יהוה hace los relámpagos³⁹; y lluvia de aguacero <em>les</em> dará a ellos, a <em>cada</em> hombre, hierba en el campo.",
           "footnotes": [
             {
               "marker": "³⁹",
@@ -1257,7 +1264,14 @@
         {
           "verse": 3,
           "tth": "Voz de aullido de los pastores, porque ha sido devastado su esplendor; voz de rugido de leoncillos, porque fue devastado el orgullo del Iardén⁴².",
-          "footnotes": [],
+          "footnotes": [
+            {
+              "marker": "⁴²",
+              "number": "42",
+              "word": "Iardén",
+              "explanation": "Jordán."
+            }
+          ],
           "hebrew_terms": [],
           "subtitle": "El rebaño desolado"
         },
@@ -1592,7 +1606,7 @@
         },
         {
           "verse": 9,
-          "tth": "Y haré entrar a la tercera en el fuego, y los refinaré conforme al refinar de la plata, y los probaré conforme al probar del oro. Él llamará en mi Nombre, y Yo le responderé; diré: “Mi pueblo es él”, y él dirá: “יהוה es mi Elohim”. <em>El reino de</em>__יהוה__",
+          "tth": "Y haré entrar a la tercera en el fuego, y los refinaré conforme al refinar de la plata, y los probaré conforme al probar del oro. Él llamará en mi Nombre, y Yo le responderé; diré: “Mi pueblo es él”, y él dirá: “יהוה es mi Elohim”. <em>El reino de</em> יהוה",
           "footnotes": [],
           "hebrew_terms": []
         }

--- a/mobile/src/components/VerseCard.tsx
+++ b/mobile/src/components/VerseCard.tsx
@@ -31,7 +31,10 @@ import {
   sanitizeEmTags,
   buildMarkerRegex,
   createFootnoteLookup,
-  toSuperscriptNumber,
+  type MarkerMatch,
+  collectMarkerMatches,
+  resolveFootnoteForMarker,
+  formatMarkerForDisplay,
 } from "@/src/utils/footnoteUtils";
 
 type RenderTranslationOptions = {
@@ -40,119 +43,6 @@ type RenderTranslationOptions = {
   footnoteLookup: Map<string, TranslationFootnote>;
   onFootnotePress?: (footnote: TranslationFootnote) => void;
   renderUnmappedSuperscripts?: boolean;
-};
-
-const superscriptPattern = /[⁰¹²³⁴⁵⁶⁷⁸⁹]+/g;
-const bracketFootnotePattern = /\[[a-z0-9]+\]/gi;
-
-type MarkerMatch = {
-  start: number;
-  end: number;
-  content: string;
-};
-
-const collectMarkerMatches = (
-  text: string,
-  markerRegex: RegExp | null,
-  renderUnmappedSuperscripts: boolean,
-): MarkerMatch[] => {
-  const matches: MarkerMatch[] = [];
-
-  if (markerRegex) {
-    const explicitMarkerRegex = new RegExp(
-      markerRegex.source,
-      markerRegex.flags.includes("g")
-        ? markerRegex.flags
-        : `${markerRegex.flags}g`,
-    );
-
-    for (const match of text.matchAll(explicitMarkerRegex)) {
-      if (match.index === undefined) continue;
-      matches.push({
-        start: match.index,
-        end: match.index + match[0].length,
-        content: match[0],
-      });
-    }
-  }
-
-  if (renderUnmappedSuperscripts) {
-    for (const match of text.matchAll(superscriptPattern)) {
-      if (match.index === undefined) continue;
-      matches.push({
-        start: match.index,
-        end: match.index + match[0].length,
-        content: match[0],
-      });
-    }
-
-    for (const match of text.matchAll(bracketFootnotePattern)) {
-      if (match.index === undefined) continue;
-      matches.push({
-        start: match.index,
-        end: match.index + match[0].length,
-        content: match[0],
-      });
-    }
-  }
-
-  if (matches.length === 0) {
-    return [];
-  }
-
-  const unique = new Map<string, MarkerMatch>();
-  for (const match of matches) {
-    unique.set(`${match.start}-${match.end}`, match);
-  }
-
-  const sortedMatches = Array.from(unique.values()).sort(
-    (a, b) => a.start - b.start || b.end - a.end,
-  );
-
-  const nonOverlappingMatches: MarkerMatch[] = [];
-  let currentEnd = -1;
-  for (const match of sortedMatches) {
-    if (match.start < currentEnd) {
-      continue;
-    }
-    nonOverlappingMatches.push(match);
-    currentEnd = match.end;
-  }
-
-  return nonOverlappingMatches;
-};
-
-const resolveFootnoteForMarker = (
-  footnoteLookup: Map<string, TranslationFootnote>,
-  marker: string,
-): TranslationFootnote | undefined => {
-  const directMatch = footnoteLookup.get(marker);
-  if (directMatch) {
-    return directMatch;
-  }
-
-  const bracketMatch = /^\[([a-z0-9]+)\]$/i.exec(marker);
-  if (!bracketMatch) {
-    return undefined;
-  }
-
-  const bracketValue = bracketMatch[1];
-  return (
-    footnoteLookup.get(bracketValue) ??
-    footnoteLookup.get(toSuperscriptNumber(bracketValue))
-  );
-};
-
-const formatMarkerForDisplay = (marker: string): string => {
-  const bracketMatch = /^\[([a-z0-9]+)\]$/i.exec(marker);
-  if (!bracketMatch) {
-    return marker;
-  }
-
-  const bracketValue = bracketMatch[1];
-  return /^\d+$/.test(bracketValue)
-    ? toSuperscriptNumber(bracketValue)
-    : bracketValue;
 };
 
 const renderTextSegment = (

--- a/mobile/src/components/VerseCard.tsx
+++ b/mobile/src/components/VerseCard.tsx
@@ -31,6 +31,7 @@ import {
   sanitizeEmTags,
   buildMarkerRegex,
   createFootnoteLookup,
+  toSuperscriptNumber,
 } from "@/src/utils/footnoteUtils";
 
 type RenderTranslationOptions = {
@@ -38,6 +39,120 @@ type RenderTranslationOptions = {
   footnoteMarkerStyle: StyleProp<TextStyle>;
   footnoteLookup: Map<string, TranslationFootnote>;
   onFootnotePress?: (footnote: TranslationFootnote) => void;
+  renderUnmappedSuperscripts?: boolean;
+};
+
+const superscriptPattern = /[⁰¹²³⁴⁵⁶⁷⁸⁹]+/g;
+const bracketFootnotePattern = /\[[a-z0-9]+\]/gi;
+
+type MarkerMatch = {
+  start: number;
+  end: number;
+  content: string;
+};
+
+const collectMarkerMatches = (
+  text: string,
+  markerRegex: RegExp | null,
+  renderUnmappedSuperscripts: boolean,
+): MarkerMatch[] => {
+  const matches: MarkerMatch[] = [];
+
+  if (markerRegex) {
+    const explicitMarkerRegex = new RegExp(
+      markerRegex.source,
+      markerRegex.flags.includes("g")
+        ? markerRegex.flags
+        : `${markerRegex.flags}g`,
+    );
+
+    for (const match of text.matchAll(explicitMarkerRegex)) {
+      if (match.index === undefined) continue;
+      matches.push({
+        start: match.index,
+        end: match.index + match[0].length,
+        content: match[0],
+      });
+    }
+  }
+
+  if (renderUnmappedSuperscripts) {
+    for (const match of text.matchAll(superscriptPattern)) {
+      if (match.index === undefined) continue;
+      matches.push({
+        start: match.index,
+        end: match.index + match[0].length,
+        content: match[0],
+      });
+    }
+
+    for (const match of text.matchAll(bracketFootnotePattern)) {
+      if (match.index === undefined) continue;
+      matches.push({
+        start: match.index,
+        end: match.index + match[0].length,
+        content: match[0],
+      });
+    }
+  }
+
+  if (matches.length === 0) {
+    return [];
+  }
+
+  const unique = new Map<string, MarkerMatch>();
+  for (const match of matches) {
+    unique.set(`${match.start}-${match.end}`, match);
+  }
+
+  const sortedMatches = Array.from(unique.values()).sort(
+    (a, b) => a.start - b.start || b.end - a.end,
+  );
+
+  const nonOverlappingMatches: MarkerMatch[] = [];
+  let currentEnd = -1;
+  for (const match of sortedMatches) {
+    if (match.start < currentEnd) {
+      continue;
+    }
+    nonOverlappingMatches.push(match);
+    currentEnd = match.end;
+  }
+
+  return nonOverlappingMatches;
+};
+
+const resolveFootnoteForMarker = (
+  footnoteLookup: Map<string, TranslationFootnote>,
+  marker: string,
+): TranslationFootnote | undefined => {
+  const directMatch = footnoteLookup.get(marker);
+  if (directMatch) {
+    return directMatch;
+  }
+
+  const bracketMatch = /^\[([a-z0-9]+)\]$/i.exec(marker);
+  if (!bracketMatch) {
+    return undefined;
+  }
+
+  const bracketValue = bracketMatch[1];
+  return (
+    footnoteLookup.get(bracketValue) ??
+    footnoteLookup.get(toSuperscriptNumber(bracketValue))
+  );
+};
+
+const formatMarkerForDisplay = (marker: string): string => {
+  const bracketMatch = /^\[([a-z0-9]+)\]$/i.exec(marker);
+  if (!bracketMatch) {
+    return marker;
+  }
+
+  const bracketValue = bracketMatch[1];
+  return /^\d+$/.test(bracketValue)
+    ? toSuperscriptNumber(bracketValue)
+    : bracketValue;
 };
 
 const renderTextSegment = (
@@ -48,13 +163,20 @@ const renderTextSegment = (
   footnoteMarkerStyle: StyleProp<TextStyle>,
   onFootnotePress?: (footnote: TranslationFootnote) => void,
   baseStyle?: StyleProp<TextStyle>,
+  renderUnmappedSuperscripts = false,
 ): ReactNode[] => {
   const sanitized = sanitizeEmTags(text);
   if (!sanitized) {
     return [];
   }
 
-  if (!markerRegex) {
+  const markerMatches = collectMarkerMatches(
+    sanitized,
+    markerRegex,
+    renderUnmappedSuperscripts,
+  );
+
+  if (markerMatches.length === 0) {
     return baseStyle
       ? [
           <Text key={`${keyPrefix}-text`} style={baseStyle}>
@@ -63,38 +185,56 @@ const renderTextSegment = (
         ]
       : [sanitized];
   }
-
-  const pieces = sanitized.split(markerRegex);
   const nodes: ReactNode[] = [];
 
-  for (let i = 0; i < pieces.length; i += 1) {
-    const piece = pieces[i];
-    if (!piece) {
-      continue;
+  let lastIndex = 0;
+
+  for (let i = 0; i < markerMatches.length; i += 1) {
+    const markerMatch = markerMatches[i];
+    const plainText = sanitized.slice(lastIndex, markerMatch.start);
+    if (plainText) {
+      if (baseStyle) {
+        nodes.push(
+          <Text key={`${keyPrefix}-text-${i}`} style={baseStyle}>
+            {plainText}
+          </Text>,
+        );
+      } else {
+        nodes.push(plainText);
+      }
     }
 
-    const footnote = footnoteLookup.get(piece);
-    if (footnote) {
-      nodes.push(
-        <Text
-          key={`${keyPrefix}-marker-${i}`}
-          onPress={onFootnotePress ? () => onFootnotePress(footnote) : undefined}
-          style={[baseStyle, footnoteMarkerStyle]}
-        >
-          {piece}
-        </Text>,
-      );
-      continue;
-    }
+    const marker = markerMatch.content;
+    const footnote = resolveFootnoteForMarker(footnoteLookup, marker);
+    const markerText = formatMarkerForDisplay(marker);
 
+    nodes.push(
+      <Text
+        key={`${keyPrefix}-marker-${i}`}
+        onPress={
+          footnote && onFootnotePress
+            ? () => onFootnotePress(footnote)
+            : undefined
+        }
+        style={[baseStyle, footnoteMarkerStyle]}
+      >
+        {markerText}
+      </Text>,
+    );
+
+    lastIndex = markerMatch.end;
+  }
+
+  const trailingText = sanitized.slice(lastIndex);
+  if (trailingText) {
     if (baseStyle) {
       nodes.push(
-        <Text key={`${keyPrefix}-text-${i}`} style={baseStyle}>
-          {piece}
+        <Text key={`${keyPrefix}-text-tail`} style={baseStyle}>
+          {trailingText}
         </Text>,
       );
     } else {
-      nodes.push(piece);
+      nodes.push(trailingText);
     }
   }
 
@@ -108,6 +248,7 @@ const renderTranslationWithItalics = (
     footnoteMarkerStyle,
     footnoteLookup,
     onFootnotePress,
+    renderUnmappedSuperscripts = false,
   }: RenderTranslationOptions,
 ) => {
   const segments: ReactNode[] = [];
@@ -132,6 +273,8 @@ const renderTranslationWithItalics = (
           footnoteLookup,
           footnoteMarkerStyle,
           onFootnotePress,
+          undefined,
+          renderUnmappedSuperscripts,
         ),
       );
     }
@@ -145,6 +288,7 @@ const renderTranslationWithItalics = (
         footnoteMarkerStyle,
         onFootnotePress,
         italicStyle,
+        renderUnmappedSuperscripts,
       ),
     );
 
@@ -162,6 +306,8 @@ const renderTranslationWithItalics = (
         footnoteLookup,
         footnoteMarkerStyle,
         onFootnotePress,
+        undefined,
+        renderUnmappedSuperscripts,
       ),
     );
   }
@@ -227,7 +373,9 @@ const createStyles = (
     translationFootnoteMarker: {
       color: colors.accentCopper,
       fontSize: typography.sizes.caption,
-      lineHeight: typography.sizes.caption * typography.lineHeights.body,
+      lineHeight: typography.sizes.caption + 2,
+      includeFontPadding: false,
+      transform: [{ translateY: -5 }],
     },
     footnoteModalOverlay: {
       flex: 1,
@@ -607,7 +755,7 @@ export const VerseCard = ({
 
       {hideTranslationText ? null : (
         <Text style={[styles.translation, translationStyleOverrides]}>
-          {translationOnly ? `${verse.verse} ` : ""}
+          {translationOnly ? `[${verse.verse}] ` : ""}
           {renderTranslationWithItalics(translationText, {
             italicStyle: styles.translationItalic,
             footnoteMarkerStyle: styles.translationFootnoteMarker,
@@ -615,6 +763,8 @@ export const VerseCard = ({
             onFootnotePress: canShowInteractiveFootnotes
               ? setActiveFootnote
               : undefined,
+            renderUnmappedSuperscripts:
+              effectiveTranslationLanguage === "es",
           })}
         </Text>
       )}

--- a/mobile/src/screens/VerseDetailContent.tsx
+++ b/mobile/src/screens/VerseDetailContent.tsx
@@ -70,10 +70,124 @@ import {
   buildMarkerRegex,
   createFootnoteLookup,
   DEFAULT_FOOTNOTE_MARKER_COLOR,
+  toSuperscriptNumber,
 } from "@/src/utils/footnoteUtils";
 import { stripCantillation, stripMeteg, stripNikud } from "@/src/utils/hebrew";
 
 const SWIPE_HINT_MAX_SHOWS = 5;
+
+const superscriptPattern = /[⁰¹²³⁴⁵⁶⁷⁸⁹]+/g;
+const bracketFootnotePattern = /\[[a-z0-9]+\]/gi;
+
+type MarkerMatch = {
+  start: number;
+  end: number;
+  content: string;
+};
+
+const collectMarkerMatches = (
+  text: string,
+  markerRegex: RegExp | null,
+  renderUnmappedSuperscripts: boolean,
+): MarkerMatch[] => {
+  const matches: MarkerMatch[] = [];
+
+  if (markerRegex) {
+    const explicitMarkerRegex = new RegExp(
+      markerRegex.source,
+      markerRegex.flags.includes("g")
+        ? markerRegex.flags
+        : `${markerRegex.flags}g`,
+    );
+
+    for (const match of text.matchAll(explicitMarkerRegex)) {
+      if (match.index === undefined) continue;
+      matches.push({
+        start: match.index,
+        end: match.index + match[0].length,
+        content: match[0],
+      });
+    }
+  }
+
+  if (renderUnmappedSuperscripts) {
+    for (const match of text.matchAll(superscriptPattern)) {
+      if (match.index === undefined) continue;
+      matches.push({
+        start: match.index,
+        end: match.index + match[0].length,
+        content: match[0],
+      });
+    }
+
+    for (const match of text.matchAll(bracketFootnotePattern)) {
+      if (match.index === undefined) continue;
+      matches.push({
+        start: match.index,
+        end: match.index + match[0].length,
+        content: match[0],
+      });
+    }
+  }
+
+  if (matches.length === 0) {
+    return [];
+  }
+
+  const unique = new Map<string, MarkerMatch>();
+  for (const match of matches) {
+    unique.set(`${match.start}-${match.end}`, match);
+  }
+
+  const sortedMatches = Array.from(unique.values()).sort(
+    (a, b) => a.start - b.start || b.end - a.end,
+  );
+
+  const nonOverlappingMatches: MarkerMatch[] = [];
+  let currentEnd = -1;
+  for (const match of sortedMatches) {
+    if (match.start < currentEnd) {
+      continue;
+    }
+    nonOverlappingMatches.push(match);
+    currentEnd = match.end;
+  }
+
+  return nonOverlappingMatches;
+};
+
+const resolveFootnoteForMarker = (
+  footnoteLookup: Map<string, TranslationFootnote>,
+  marker: string,
+): TranslationFootnote | undefined => {
+  const directMatch = footnoteLookup.get(marker);
+  if (directMatch) {
+    return directMatch;
+  }
+
+  const bracketMatch = /^\[([a-z0-9]+)\]$/i.exec(marker);
+  if (!bracketMatch) {
+    return undefined;
+  }
+
+  const bracketValue = bracketMatch[1];
+  return (
+    footnoteLookup.get(bracketValue) ??
+    footnoteLookup.get(toSuperscriptNumber(bracketValue))
+  );
+};
+
+const formatMarkerForDisplay = (marker: string): string => {
+  const bracketMatch = /^\[([a-z0-9]+)\]$/i.exec(marker);
+  if (!bracketMatch) {
+    return marker;
+  }
+
+  const bracketValue = bracketMatch[1];
+  return /^\d+$/.test(bracketValue)
+    ? toSuperscriptNumber(bracketValue)
+    : bracketValue;
+};
 
 const renderTranslationSegment = (
   text: string,
@@ -83,13 +197,20 @@ const renderTranslationSegment = (
   onFootnotePress?: (footnote: TranslationFootnote) => void,
   isItalic = false,
   markerColor = DEFAULT_FOOTNOTE_MARKER_COLOR,
+  renderUnmappedSuperscripts = false,
 ): ReactNode[] => {
   const sanitized = sanitizeEmTags(text);
   if (!sanitized) {
     return [];
   }
 
-  if (!markerRegex) {
+  const markerMatches = collectMarkerMatches(
+    sanitized,
+    markerRegex,
+    renderUnmappedSuperscripts,
+  );
+
+  if (markerMatches.length === 0) {
     return isItalic
       ? [
           <Text key={`${keyPrefix}-italic`} style={{ fontStyle: "italic" }}>
@@ -98,41 +219,62 @@ const renderTranslationSegment = (
         ]
       : [sanitized];
   }
-
-  const pieces = sanitized.split(markerRegex);
   const nodes: ReactNode[] = [];
 
-  for (let i = 0; i < pieces.length; i += 1) {
-    const piece = pieces[i];
-    if (!piece) {
-      continue;
+  let lastIndex = 0;
+
+  for (let i = 0; i < markerMatches.length; i += 1) {
+    const markerMatch = markerMatches[i];
+    const plainText = sanitized.slice(lastIndex, markerMatch.start);
+    if (plainText) {
+      if (isItalic) {
+        nodes.push(
+          <Text key={`${keyPrefix}-text-${i}`} style={{ fontStyle: "italic" }}>
+            {plainText}
+          </Text>,
+        );
+      } else {
+        nodes.push(plainText);
+      }
     }
 
-    const footnote = footnoteLookup.get(piece);
-    if (footnote) {
-      nodes.push(
-        <Text
-          key={`${keyPrefix}-marker-${i}`}
-          onPress={onFootnotePress ? () => onFootnotePress(footnote) : undefined}
-          style={{
-            color: markerColor,
-            fontSize: typography.sizes.caption,
-          }}
-        >
-          {piece}
-        </Text>,
-      );
-      continue;
-    }
+    const marker = markerMatch.content;
+    const footnote = resolveFootnoteForMarker(footnoteLookup, marker);
+    const markerText = formatMarkerForDisplay(marker);
 
+    nodes.push(
+      <Text
+        key={`${keyPrefix}-marker-${i}`}
+        onPress={
+          footnote && onFootnotePress
+            ? () => onFootnotePress(footnote)
+            : undefined
+        }
+        style={{
+          color: markerColor,
+          fontSize: typography.sizes.caption,
+          lineHeight: typography.sizes.caption + 2,
+          includeFontPadding: false,
+          transform: [{ translateY: -5 }],
+        }}
+      >
+        {markerText}
+      </Text>,
+    );
+
+    lastIndex = markerMatch.end;
+  }
+
+  const trailingText = sanitized.slice(lastIndex);
+  if (trailingText) {
     if (isItalic) {
       nodes.push(
-        <Text key={`${keyPrefix}-text-${i}`} style={{ fontStyle: "italic" }}>
-          {piece}
+        <Text key={`${keyPrefix}-text-tail`} style={{ fontStyle: "italic" }}>
+          {trailingText}
         </Text>,
       );
     } else {
-      nodes.push(piece);
+      nodes.push(trailingText);
     }
   }
 
@@ -144,6 +286,7 @@ const renderTranslationFlowText = (
   footnotes?: TranslationFootnote[],
   onFootnotePress?: (footnote: TranslationFootnote) => void,
   markerColor = DEFAULT_FOOTNOTE_MARKER_COLOR,
+  renderUnmappedSuperscripts = false,
 ): ReactNode[] => {
   const footnoteLookup = createFootnoteLookup(footnotes);
   const markerRegex = buildMarkerRegex(footnoteLookup);
@@ -169,6 +312,7 @@ const renderTranslationFlowText = (
           onFootnotePress,
           false,
           markerColor,
+          renderUnmappedSuperscripts,
         ),
       );
     }
@@ -182,6 +326,7 @@ const renderTranslationFlowText = (
         onFootnotePress,
         true,
         markerColor,
+        renderUnmappedSuperscripts,
       ),
     );
 
@@ -200,6 +345,7 @@ const renderTranslationFlowText = (
         onFootnotePress,
         false,
         markerColor,
+        renderUnmappedSuperscripts,
       ),
     );
   }
@@ -1336,6 +1482,7 @@ export const VerseDetailContent = () => {
                             language === "es" ? item.translation_footnotes : undefined,
                             language === "es" ? setActiveFlowFootnote : undefined,
                             colors.accentCopper,
+                            language === "es",
                           )}
                           {index < orderedVerses.length - 1 ? " " : ""}
                         </Text>

--- a/mobile/src/screens/VerseDetailContent.tsx
+++ b/mobile/src/screens/VerseDetailContent.tsx
@@ -1484,7 +1484,7 @@ export const VerseDetailContent = () => {
                             colors.accentCopper,
                             language === "es",
                           )}
-                          {index < orderedVerses.length - 1 ? " " : ""}
+                          {index < orderedVerses.length - 1 ? "\u200E " : ""}
                         </Text>
                       ))}
                     </Text>

--- a/mobile/src/screens/VerseDetailContent.tsx
+++ b/mobile/src/screens/VerseDetailContent.tsx
@@ -70,124 +70,14 @@ import {
   buildMarkerRegex,
   createFootnoteLookup,
   DEFAULT_FOOTNOTE_MARKER_COLOR,
-  toSuperscriptNumber,
+  type MarkerMatch,
+  collectMarkerMatches,
+  resolveFootnoteForMarker,
+  formatMarkerForDisplay,
 } from "@/src/utils/footnoteUtils";
 import { stripCantillation, stripMeteg, stripNikud } from "@/src/utils/hebrew";
 
 const SWIPE_HINT_MAX_SHOWS = 5;
-
-const superscriptPattern = /[⁰¹²³⁴⁵⁶⁷⁸⁹]+/g;
-const bracketFootnotePattern = /\[[a-z0-9]+\]/gi;
-
-type MarkerMatch = {
-  start: number;
-  end: number;
-  content: string;
-};
-
-const collectMarkerMatches = (
-  text: string,
-  markerRegex: RegExp | null,
-  renderUnmappedSuperscripts: boolean,
-): MarkerMatch[] => {
-  const matches: MarkerMatch[] = [];
-
-  if (markerRegex) {
-    const explicitMarkerRegex = new RegExp(
-      markerRegex.source,
-      markerRegex.flags.includes("g")
-        ? markerRegex.flags
-        : `${markerRegex.flags}g`,
-    );
-
-    for (const match of text.matchAll(explicitMarkerRegex)) {
-      if (match.index === undefined) continue;
-      matches.push({
-        start: match.index,
-        end: match.index + match[0].length,
-        content: match[0],
-      });
-    }
-  }
-
-  if (renderUnmappedSuperscripts) {
-    for (const match of text.matchAll(superscriptPattern)) {
-      if (match.index === undefined) continue;
-      matches.push({
-        start: match.index,
-        end: match.index + match[0].length,
-        content: match[0],
-      });
-    }
-
-    for (const match of text.matchAll(bracketFootnotePattern)) {
-      if (match.index === undefined) continue;
-      matches.push({
-        start: match.index,
-        end: match.index + match[0].length,
-        content: match[0],
-      });
-    }
-  }
-
-  if (matches.length === 0) {
-    return [];
-  }
-
-  const unique = new Map<string, MarkerMatch>();
-  for (const match of matches) {
-    unique.set(`${match.start}-${match.end}`, match);
-  }
-
-  const sortedMatches = Array.from(unique.values()).sort(
-    (a, b) => a.start - b.start || b.end - a.end,
-  );
-
-  const nonOverlappingMatches: MarkerMatch[] = [];
-  let currentEnd = -1;
-  for (const match of sortedMatches) {
-    if (match.start < currentEnd) {
-      continue;
-    }
-    nonOverlappingMatches.push(match);
-    currentEnd = match.end;
-  }
-
-  return nonOverlappingMatches;
-};
-
-const resolveFootnoteForMarker = (
-  footnoteLookup: Map<string, TranslationFootnote>,
-  marker: string,
-): TranslationFootnote | undefined => {
-  const directMatch = footnoteLookup.get(marker);
-  if (directMatch) {
-    return directMatch;
-  }
-
-  const bracketMatch = /^\[([a-z0-9]+)\]$/i.exec(marker);
-  if (!bracketMatch) {
-    return undefined;
-  }
-
-  const bracketValue = bracketMatch[1];
-  return (
-    footnoteLookup.get(bracketValue) ??
-    footnoteLookup.get(toSuperscriptNumber(bracketValue))
-  );
-};
-
-const formatMarkerForDisplay = (marker: string): string => {
-  const bracketMatch = /^\[([a-z0-9]+)\]$/i.exec(marker);
-  if (!bracketMatch) {
-    return marker;
-  }
-
-  const bracketValue = bracketMatch[1];
-  return /^\d+$/.test(bracketValue)
-    ? toSuperscriptNumber(bracketValue)
-    : bracketValue;
-};
 
 const renderTranslationSegment = (
   text: string,

--- a/mobile/src/services/scripture.ts
+++ b/mobile/src/services/scripture.ts
@@ -286,6 +286,14 @@ const resolveTthBookId = (bookId: string): string | undefined => {
 const isPsalmsBook = (bookId: string): boolean =>
   normalizeBookToken(bookId) === "psalms";
 
+const HEBREW_RUN_RE = /[\u0590-\u05FF]+/g;
+
+const isolateHebrewRuns = (value: string): string =>
+  value.replace(HEBREW_RUN_RE, (token) => `\u2067${token}\u2069`);
+
+const finalizeTranslationDisplayText = (value: string): string =>
+  value.trim().length > 0 ? isolateHebrewRuns(value) : value;
+
 const resolveTranslationText = (params: {
   bookId: string;
   language?: "en" | "es";
@@ -295,18 +303,22 @@ const resolveTranslationText = (params: {
   const { bookId, language, mappedTranslationKey, translationText } = params;
 
   if (!language) {
-    return translationText ?? "";
+    return finalizeTranslationDisplayText(translationText ?? "");
   }
 
   if (isPsalmsBook(bookId) && mappedTranslationKey === null) {
-    return getPsalmsSuperscriptionNotice(language);
+    return finalizeTranslationDisplayText(
+      getPsalmsSuperscriptionNotice(language),
+    );
   }
 
   if (translationText && translationText.trim().length > 0) {
-    return translationText;
+    return finalizeTranslationDisplayText(translationText);
   }
 
-  return getMissingSpanishTranslationNotice(language);
+  return finalizeTranslationDisplayText(
+    getMissingSpanishTranslationNotice(language),
+  );
 };
 
 type StaticChapterWord = {
@@ -447,15 +459,38 @@ const toSortedUniqueVerseNumbers = (values: number[]): number[] =>
     (a, b) => a - b,
   );
 
+const getTranslationLookupKey = (
+  bookId: string,
+  chapter: number,
+  verse: number,
+  language?: "en" | "es",
+): string | null => {
+  if (language !== "en") {
+    return `${chapter}-${verse}`;
+  }
+
+  return mapHebrewVerseToTranslationKey(bookId, chapter, verse);
+};
+
 const getRequiredTranslationChapters = (
   bookId: string,
   chapter: number,
+  language?: "en" | "es",
   expectedVerseNumbers?: number[],
 ): number[] => {
+  if (language !== "en") {
+    return [chapter];
+  }
+
   const mappedChapters = new Set<number>();
 
   for (const verseNumber of expectedVerseNumbers ?? []) {
-    const mappedKey = mapHebrewVerseToTranslationKey(bookId, chapter, verseNumber);
+    const mappedKey = getTranslationLookupKey(
+      bookId,
+      chapter,
+      verseNumber,
+      language,
+    );
     if (!mappedKey) {
       continue;
     }
@@ -541,6 +576,7 @@ const loadStaticTranslationsForChapter = async (
   const requiredTranslationChapters = getRequiredTranslationChapters(
     bookId,
     chapter,
+    language,
     expectedVerseNumbers,
   );
 
@@ -847,10 +883,11 @@ const mapStaticVersesToDisplay = (
         .filter(Boolean)
         .join(" ");
 
-    const translationKey = mapHebrewVerseToTranslationKey(
+    const translationKey = getTranslationLookupKey(
       bookId,
       verse.chapter,
       verse.verse,
+      language,
     );
     const translationEntry = translationKey
       ? translationMap.get(translationKey)
@@ -978,10 +1015,11 @@ const mapOfflineDataToDisplay = (
 
   return hebrewRows.map((hv) => {
     const verseKey = `${hv.chapter}-${hv.verse}`;
-    const mappedTranslationKey = mapHebrewVerseToTranslationKey(
+    const mappedTranslationKey = getTranslationLookupKey(
       bookId,
       hv.chapter,
       hv.verse,
+      language,
     );
     const translation = mappedTranslationKey
       ? translationMap.get(mappedTranslationKey)
@@ -1098,6 +1136,7 @@ const fetchChapterVersesOffline = async (
           getRequiredTranslationChapters(
             bookId,
             chapter,
+            translationLanguage,
             toSortedUniqueVerseNumbers(hebrewRows.map((row) => row.verse)),
           ).map((translationChapter) =>
             fetchTranslationVerses(bookId, translationChapter, translationLanguage),

--- a/mobile/src/services/scripture.ts
+++ b/mobile/src/services/scripture.ts
@@ -12,9 +12,10 @@ import { removeMaqafForDisplay } from "@/src/utils/hebrew";
 import {
   getMissingSpanishTranslationNotice,
   getPsalmsSuperscriptionNotice,
+  resolveTranslationLookupKey,
+  resolveTranslationTarget,
   TTH_BOOK_MAPPING,
 } from "@davar/shared/translationConfig";
-import { mapHebrewVerseToTranslationKey } from "@davar/shared/versification";
 
 // Chapter-level cache for TS2009 static JSON (matches web approach)
 const ts2009ChapterCache = new Map<string, Promise<Map<number, string> | null>>();
@@ -298,12 +299,23 @@ const resolveTranslationText = (params: {
   bookId: string;
   language?: "en" | "es";
   mappedTranslationKey: string | null;
+  translationTitle?: string;
   translationText?: string;
 }): string => {
-  const { bookId, language, mappedTranslationKey, translationText } = params;
+  const {
+    bookId,
+    language,
+    mappedTranslationKey,
+    translationTitle,
+    translationText,
+  } = params;
 
   if (!language) {
     return finalizeTranslationDisplayText(translationText ?? "");
+  }
+
+  if (translationTitle && translationTitle.trim().length > 0) {
+    return finalizeTranslationDisplayText(translationTitle);
   }
 
   if (isPsalmsBook(bookId) && mappedTranslationKey === null) {
@@ -348,6 +360,7 @@ type StaticTranslationVerse = {
 type StaticTranslationChapter = {
   chapter: number;
   verses?: StaticTranslationVerse[];
+  title?: string;
 };
 
 type StaticTranslationBook = {
@@ -410,6 +423,11 @@ type TranslationEntry = {
   footnotes?: TranslationFootnote[];
 };
 
+type LoadedStaticTranslations = {
+  verses: Map<string, TranslationEntry>;
+  titles: Map<number, string>;
+};
+
 const HEBREW_MARKS_RE = /[\u0591-\u05C7]/g;
 
 const normalizeSurfaceWord = (value?: string): string =>
@@ -465,11 +483,7 @@ const getTranslationLookupKey = (
   verse: number,
   language?: "en" | "es",
 ): string | null => {
-  if (language !== "en") {
-    return `${chapter}-${verse}`;
-  }
-
-  return mapHebrewVerseToTranslationKey(bookId, chapter, verse);
+  return resolveTranslationLookupKey(bookId, chapter, verse, language);
 };
 
 const getRequiredTranslationChapters = (
@@ -571,8 +585,9 @@ const loadStaticTranslationsForChapter = async (
   language?: "en" | "es",
   hebrewOnly?: boolean,
   expectedVerseNumbers?: number[],
-): Promise<Map<string, TranslationEntry>> => {
+): Promise<LoadedStaticTranslations> => {
   const translationMap = new Map<string, TranslationEntry>();
+  const translationTitleMap = new Map<number, string>();
   const requiredTranslationChapters = getRequiredTranslationChapters(
     bookId,
     chapter,
@@ -581,7 +596,10 @@ const loadStaticTranslationsForChapter = async (
   );
 
   if (!language || hebrewOnly) {
-    return translationMap;
+    return {
+      verses: translationMap,
+      titles: translationTitleMap,
+    };
   }
 
   if (language === "es") {
@@ -600,6 +618,10 @@ const loadStaticTranslationsForChapter = async (
 
           if (!chapterData?.verses) {
             continue;
+          }
+
+          if (typeof chapterData.title === "string" && chapterData.title.trim()) {
+            translationTitleMap.set(translationChapter, chapterData.title.trim());
           }
 
           for (const verse of chapterData.verses) {
@@ -629,6 +651,10 @@ const loadStaticTranslationsForChapter = async (
 
           if (!chapterData?.verses) {
             continue;
+          }
+
+          if (typeof chapterData.title === "string" && chapterData.title.trim()) {
+            translationTitleMap.set(translationChapter, chapterData.title.trim());
           }
 
           for (const verse of chapterData.verses) {
@@ -692,7 +718,10 @@ const loadStaticTranslationsForChapter = async (
     }
   }
 
-  return translationMap;
+  return {
+    verses: translationMap,
+    titles: translationTitleMap,
+  };
 };
 
 const loadStaticDssForChapter = async (
@@ -824,6 +853,7 @@ const mapStaticVersesToDisplay = (
   bookId: string,
   verses: StaticChapterVerse[],
   translationMap: Map<string, TranslationEntry>,
+  translationTitleMap: Map<number, string>,
   dssMap: Map<number, StaticDssDifference[]>,
   translitMap: Map<number, StaticTranslitWord[]>,
   dssTranslitMap: Map<string, StaticDssTranslitVariant>,
@@ -883,12 +913,15 @@ const mapStaticVersesToDisplay = (
         .filter(Boolean)
         .join(" ");
 
-    const translationKey = getTranslationLookupKey(
+    const translationTarget = resolveTranslationTarget(
       bookId,
       verse.chapter,
       verse.verse,
       language,
     );
+    const translationKey = translationTarget.reference
+      ? `${translationTarget.reference.chapter}-${translationTarget.reference.verse}`
+      : null;
     const translationEntry = translationKey
       ? translationMap.get(translationKey)
       : undefined;
@@ -896,6 +929,9 @@ const mapStaticVersesToDisplay = (
       bookId,
       language,
       mappedTranslationKey: translationKey,
+      translationTitle: translationTarget.usesPsalmTitle
+        ? translationTitleMap.get(verse.chapter)
+        : undefined,
       translationText: translationEntry?.text,
     });
 
@@ -964,7 +1000,7 @@ const fetchChapterVersesStatic = async (
     sourceVerses.map((verse) => verse.verse),
   );
 
-  const [translationMap, dssMap, translitMap, dssTranslitMap] = await Promise.all([
+  const [translations, dssMap, translitMap, dssTranslitMap] = await Promise.all([
     loadStaticTranslationsForChapter(
       bookId,
       chapter,
@@ -977,10 +1013,13 @@ const fetchChapterVersesStatic = async (
     loadStaticDssTranslitForChapter(bookId, chapter, options?.showDss),
   ]);
 
+  const { verses: translationMap, titles: translationTitleMap } = translations;
+
   return mapStaticVersesToDisplay(
     bookId,
     sourceVerses,
     translationMap,
+    translationTitleMap,
     dssMap,
     translitMap,
     dssTranslitMap,
@@ -1015,12 +1054,15 @@ const mapOfflineDataToDisplay = (
 
   return hebrewRows.map((hv) => {
     const verseKey = `${hv.chapter}-${hv.verse}`;
-    const mappedTranslationKey = getTranslationLookupKey(
+    const translationTarget = resolveTranslationTarget(
       bookId,
       hv.chapter,
       hv.verse,
       language,
     );
+    const mappedTranslationKey = translationTarget.reference
+      ? `${translationTarget.reference.chapter}-${translationTarget.reference.verse}`
+      : null;
     const translation = mappedTranslationKey
       ? translationMap.get(mappedTranslationKey)
       : undefined;
@@ -1028,6 +1070,7 @@ const mapOfflineDataToDisplay = (
       bookId,
       language,
       mappedTranslationKey,
+      translationTitle: undefined,
       translationText: translation?.text,
     });
     const dssVariants = dssMap.get(verseKey) ?? [];

--- a/mobile/src/store/useAppStore.ts
+++ b/mobile/src/store/useAppStore.ts
@@ -105,7 +105,6 @@ export const useAppStore = create<AppState>((set) => ({
       hebrewOnly: value ? false : state.hebrewOnly,
       showQumran: value ? false : state.showQumran,
       showCantillation: value ? false : state.showCantillation,
-      showNikud: value ? false : state.showNikud,
       showFullChapter: value ? true : false,
       seferMode: value ? true : false,
     })),

--- a/mobile/src/utils/footnoteUtils.ts
+++ b/mobile/src/utils/footnoteUtils.ts
@@ -66,3 +66,116 @@ export const buildMarkerRegex = (
       )
     : null;
 };
+
+export type MarkerMatch = {
+  start: number;
+  end: number;
+  content: string;
+};
+
+const superscriptPattern = /[⁰¹²³⁴⁵⁶⁷⁸⁹]+/g;
+const bracketFootnotePattern = /\[[a-z0-9]+\]/gi;
+
+export const collectMarkerMatches = (
+  text: string,
+  markerRegex: RegExp | null,
+  renderUnmappedSuperscripts: boolean,
+): MarkerMatch[] => {
+  const matches: MarkerMatch[] = [];
+
+  if (markerRegex) {
+    const explicitMarkerRegex = new RegExp(
+      markerRegex.source,
+      markerRegex.flags.includes("g")
+        ? markerRegex.flags
+        : `${markerRegex.flags}g`,
+    );
+
+    for (const match of text.matchAll(explicitMarkerRegex)) {
+      if (match.index === undefined) continue;
+      matches.push({
+        start: match.index,
+        end: match.index + match[0].length,
+        content: match[0],
+      });
+    }
+  }
+
+  if (renderUnmappedSuperscripts) {
+    for (const match of text.matchAll(superscriptPattern)) {
+      if (match.index === undefined) continue;
+      matches.push({
+        start: match.index,
+        end: match.index + match[0].length,
+        content: match[0],
+      });
+    }
+
+    for (const match of text.matchAll(bracketFootnotePattern)) {
+      if (match.index === undefined) continue;
+      matches.push({
+        start: match.index,
+        end: match.index + match[0].length,
+        content: match[0],
+      });
+    }
+  }
+
+  if (matches.length === 0) {
+    return [];
+  }
+
+  const unique = new Map<string, MarkerMatch>();
+  for (const match of matches) {
+    unique.set(`${match.start}-${match.end}`, match);
+  }
+
+  const sortedMatches = Array.from(unique.values()).sort(
+    (a, b) => a.start - b.start || b.end - a.end,
+  );
+
+  const nonOverlappingMatches: MarkerMatch[] = [];
+  let currentEnd = -1;
+  for (const match of sortedMatches) {
+    if (match.start < currentEnd) {
+      continue;
+    }
+    nonOverlappingMatches.push(match);
+    currentEnd = match.end;
+  }
+
+  return nonOverlappingMatches;
+};
+
+export const resolveFootnoteForMarker = (
+  footnoteLookup: Map<string, TranslationFootnote>,
+  marker: string,
+): TranslationFootnote | undefined => {
+  const directMatch = footnoteLookup.get(marker);
+  if (directMatch) {
+    return directMatch;
+  }
+
+  const bracketMatch = /^\[([a-z0-9]+)\]$/i.exec(marker);
+  if (!bracketMatch) {
+    return undefined;
+  }
+
+  const bracketValue = bracketMatch[1];
+  return (
+    footnoteLookup.get(bracketValue) ??
+    footnoteLookup.get(toSuperscriptNumber(bracketValue))
+  );
+};
+
+export const formatMarkerForDisplay = (marker: string): string => {
+  const bracketMatch = /^\[([a-z0-9]+)\]$/i.exec(marker);
+  if (!bracketMatch) {
+    return marker;
+  }
+
+  const bracketValue = bracketMatch[1];
+  return /^\d+$/.test(bracketValue)
+    ? toSuperscriptNumber(bracketValue)
+    : bracketValue;
+};

--- a/scripts/generate-static-data/index.ts
+++ b/scripts/generate-static-data/index.ts
@@ -11,6 +11,7 @@ import {
   OE_TO_ENGLISH,
   WEB_PUBLIC_DATA_ROOT,
 } from "./config";
+import { VERSIFICATION_DATA } from "../../shared/versificationData";
 
 type Ts2009BookPayload = {
   chapters?: unknown;
@@ -558,6 +559,63 @@ const readLocalTs2009BookPayload = async (
   }
 };
 
+/**
+ * For Psalms chapters that have superscription verses in the Hebrew text,
+ * the TS2009 Supabase data stores verses with Hebrew numbering (superscription
+ * as verse 1, first real verse as verse 2, etc.). The versification system
+ * expects English numbering (verse 1 = first real verse). This function
+ * detects and corrects Hebrew-numbered verse maps for Psalms chapters.
+ */
+const normalizePsalmsVerseMap = (
+  chapter: number,
+  verseMap: Record<string, string>,
+): Record<string, string> => {
+  const psaMap = VERSIFICATION_DATA["PSA"]?.simple_map;
+  if (!psaMap) return verseMap;
+
+  const chapterMap = (psaMap as Record<string, Record<string, string>>)[String(chapter)];
+  if (!chapterMap) return verseMap;
+
+  // Find the target Hebrew verse for English verse 1 (source key "1")
+  const targetForEnglishVerse1 = chapterMap["1"];
+  if (!targetForEnglishVerse1) return verseMap;
+
+  const [, targetVerseToken] = targetForEnglishVerse1.split(":");
+  const firstRealHebrewVerse = Number(targetVerseToken);
+  if (!Number.isFinite(firstRealHebrewVerse) || firstRealHebrewVerse <= 1) return verseMap;
+
+  // superscriptionCount = number of leading Hebrew verses that are superscriptions
+  const superscriptionCount = firstRealHebrewVerse - 1;
+
+  // Count expected English verses (source keys > 0)
+  const englishVerseCount = Object.keys(chapterMap).filter(
+    (k) => Number(k) > 0,
+  ).length;
+
+  const existingKeys = Object.keys(verseMap)
+    .map(Number)
+    .filter((n) => Number.isFinite(n))
+    .sort((a, b) => a - b);
+
+  // Only renumber if the data looks Hebrew-numbered:
+  // total verses = englishVerseCount + superscriptionCount
+  if (existingKeys.length !== englishVerseCount + superscriptionCount) {
+    return verseMap;
+  }
+
+  // Renumber: drop the first superscriptionCount verses, re-key from 1
+  const normalized: Record<string, string> = {};
+  const realVerseKeys = existingKeys.slice(superscriptionCount);
+  for (const [index, hebrewKey] of realVerseKeys.entries()) {
+    const englishVerse = index + 1;
+    const text = verseMap[String(hebrewKey)];
+    if (text !== undefined) {
+      normalized[String(englishVerse)] = text;
+    }
+  }
+  return normalized;
+};
+
 const generateTs2009Chapters = async (): Promise<{
   bundle: { books: Record<string, { chapters: number; verses: number }> };
   stats: Ts2009ExportStats;
@@ -660,10 +718,15 @@ const generateTs2009Chapters = async (): Promise<{
         continue;
       }
 
+      // For Psalms, normalize Hebrew-numbered verses to English numbering
+      const normalizedVerseMap = bookId === "psalms"
+        ? normalizePsalmsVerseMap(chapterNumber, verseMap)
+        : verseMap;
+
       const chapterPayload: Ts2009ChapterFile = {
         book: bookId,
         chapter: chapterNumber,
-        verses: verseMap,
+        verses: normalizedVerseMap,
       };
 
       await mkdir(join(ts2009OutDir, bookId), { recursive: true });
@@ -673,7 +736,7 @@ const generateTs2009Chapters = async (): Promise<{
         "utf-8",
       );
 
-      const verseCount = Object.keys(verseMap).length;
+      const verseCount = Object.keys(normalizedVerseMap).length;
       stats.chapters += 1;
       stats.verses += verseCount;
       bookVerseCount += verseCount;

--- a/scripts/tth_2/book_splitter.py
+++ b/scripts/tth_2/book_splitter.py
@@ -42,6 +42,11 @@ class TTH2BookSplitter:
         for book_key, info in BOOKS_INFO.items():
             self.book_patterns[book_key] = info.get('patterns', [])
 
+    @staticmethod
+    def count_chapter_markers(text: str) -> int:
+        """Count canonical chapter markers like '**1**' on standalone lines."""
+        return len(re.findall(r'^\*\*(\d+)\*\*\s*$', text, flags=re.MULTILINE))
+
     def find_book_boundaries(self, text: str, book_key: str) -> Tuple[int, int]:
         """
         Find the start and end line numbers for a specific book.
@@ -301,6 +306,16 @@ class TTH2BookSplitter:
                 # Extract book content
                 book_text = self.extract_book_section(
                     text, book_key, verbose=False)
+
+                expected_chapters = int(
+                    BOOKS_INFO.get(book_key, {}).get('expected_chapters', 0),
+                )
+                actual_chapters = self.count_chapter_markers(book_text)
+                if expected_chapters > 0 and actual_chapters < expected_chapters:
+                    raise ValueError(
+                        f"Extracted markdown for {book_key} appears truncated: "
+                        f"expected {expected_chapters} chapter markers, found {actual_chapters}."
+                    )
 
                 # Save to individual file
                 output_file = output_path / f"{book_key}.md"

--- a/scripts/tth_2/config.py
+++ b/scripts/tth_2/config.py
@@ -585,10 +585,11 @@ BOOKS_INFO = {
         'section_english': 'Gospel',
         'section_spanish': 'Evangelio',
         'patterns': [
-            r'Maasei\s+Hash\'lijim.*?מעשי\s+השליחים',
-            r'__MAASEI.*?מעשי\s+השליחים__',
-            r'HECHOS.*?מעשי\s+השליחים',
-            r'מעשי\s+השליחים',
+            r'^\s*(?:__|\*\*)\s*MAASEI\s+HASH[\'’]LIJIM\s*\(?HECHOS\)?\s*(?:__|\*\*)\s*$',
+            r'^\s*(?:__|\*\*)\s*MAASEI\s+HASH[\'’]LIJIM\s*(?:__|\*\*)\s*$',
+            r'^\s*(?:__|\*\*)\s*HECHOS\s*\(?MAASEI\s+HASH[\'’]LIJIM\)?\s*(?:__|\*\*)\s*$',
+            r'^\s*MAASEI\s+HASH[\'’]LIJIM\s*\(?HECHOS\)?\s*$',
+            r'^\s*HECHOS\s*\(?MAASEI\s+HASH[\'’]LIJIM\)?\s*$',
         ],
     },
     'romanos': {

--- a/scripts/tth_2/format_validator.py
+++ b/scripts/tth_2/format_validator.py
@@ -28,6 +28,20 @@ DISALLOWED_ESCAPES_RE = re.compile(r'\\([!\.\[\]])')
 MARKDOWN_ITALICS_RE = re.compile(r'\*[^*]+\*')
 EM_NESTING_RE = re.compile(r'<em>\s*<em>|</em>\s*</em>')
 DIVINE_NAME_WRAPPED_RE = re.compile(r'__[^_\n]*יהוה[^_\n]*__')
+SUPERSCRIPT_MARKER_RE = re.compile(r'[⁰¹²³⁴⁵⁶⁷⁸⁹]+')
+
+SUPERSCRIPT_DIGITS = {
+    '0': '⁰',
+    '1': '¹',
+    '2': '²',
+    '3': '³',
+    '4': '⁴',
+    '5': '⁵',
+    '6': '⁶',
+    '7': '⁷',
+    '8': '⁸',
+    '9': '⁹',
+}
 
 
 class TTHFormatValidator:
@@ -35,6 +49,18 @@ class TTHFormatValidator:
 
     def __init__(self, verbose: bool = False):
         self.verbose = verbose
+
+    @staticmethod
+    def _to_superscript_number(value: str) -> str:
+        """Convert plain digits into superscript marker representation."""
+        return ''.join(SUPERSCRIPT_DIGITS.get(digit, digit) for digit in value)
+
+    @staticmethod
+    def _extract_superscript_markers(text: str) -> List[str]:
+        """Collect unique superscript marker tokens from verse text."""
+        if not text:
+            return []
+        return sorted(set(match.group(0) for match in SUPERSCRIPT_MARKER_RE.finditer(text)))
 
     def _extract_monotonic_chapter_verse_counts(self, data: Dict[str, Any], source_name: str) -> Tuple[Dict[int, int], bool]:
         """
@@ -213,6 +239,7 @@ class TTHFormatValidator:
             'nested_em_tags': 0,
             'embedded_footnotes_sections': 0,
             'footnote_marker_mismatches': 0,
+            'superscript_without_footnote_entries': 0,
             'verse_sequence_issues': 0,
             'wrapped_divine_name_tokens': 0,
             'structure_reference_missing': 0,
@@ -258,6 +285,10 @@ class TTHFormatValidator:
                 if DIVINE_NAME_WRAPPED_RE.search(tth_text):
                     stats['wrapped_divine_name_tokens'] += 1
 
+                superscript_markers = self._extract_superscript_markers(
+                    tth_text)
+                available_footnote_markers = set()
+
                 for footnote in verse.get('footnotes', []):
                     stats['footnotes_checked'] += 1
                     explanation = footnote.get('explanation', '')
@@ -286,6 +317,30 @@ class TTHFormatValidator:
                         stats['footnote_marker_mismatches'] += 1
                         # Keep mismatch counts for diagnostics, but do not fail
                         # formatting validation on marker-reference integrity.
+
+                    marker_text = str(marker).strip()
+                    if marker_text:
+                        available_footnote_markers.add(marker_text)
+
+                    number_text = str(footnote.get('number', '')).strip()
+                    if number_text:
+                        available_footnote_markers.add(
+                            self._to_superscript_number(number_text),
+                        )
+
+                missing_superscript_refs = [
+                    marker
+                    for marker in superscript_markers
+                    if marker not in available_footnote_markers
+                ]
+                if missing_superscript_refs:
+                    stats['superscript_without_footnote_entries'] += len(
+                        missing_superscript_refs,
+                    )
+                    issues.append(
+                        f"Ch {chapter_num}:{verse_num} superscript markers without footnote entries: "
+                        + ", ".join(missing_superscript_refs),
+                    )
 
         self._validate_structure(book_key, data, issues, stats)
 
@@ -326,6 +381,8 @@ def print_book_report(book_key: str, is_valid: bool, issues: List[str], stats: D
         f"   - embedded footnotes text:  {stats['embedded_footnotes_sections']}")
     print(
         f"   - marker mismatches:        {stats['footnote_marker_mismatches']}")
+    print(
+        f"   - missing superscript refs: {stats['superscript_without_footnote_entries']}")
     print(f"   - verse sequence issues:    {stats['verse_sequence_issues']}")
     print(
         f"   - wrapped divine names:     {stats['wrapped_divine_name_tokens']}")

--- a/scripts/tth_2/json_postprocess.py
+++ b/scripts/tth_2/json_postprocess.py
@@ -159,6 +159,8 @@ class TTHJsonPostProcessor:
             inner = match.group(1)
             raw = inner.strip()
             token = raw
+            token = re.sub(r'</?em>', '', token, flags=re.IGNORECASE)
+            token = token.replace('*', '')
             token = re.sub(r"^[,.;:!?\"'“”‘’()\[\]{}]+", "", token)
             token = re.sub(r"[,.;:!?\"'“”‘’()\[\]{}]+$", "", token)
             token_no_num = re.sub(r'^[0-9⁰¹²³⁴⁵⁶⁷⁸⁹]+\s*', '', token)
@@ -168,7 +170,10 @@ class TTHJsonPostProcessor:
             if normalized in self.DIVINE_NAME_BASE_FORMS:
                 self.stats['divine_name_markdown_wrappers_removed'] += 1
                 cleaned_inner = re.sub(
-                    r'^[0-9⁰¹²³⁴⁵⁶⁷⁸⁹]+\s*', '', raw).strip()
+                    r'</?em>', '', raw, flags=re.IGNORECASE)
+                cleaned_inner = cleaned_inner.replace('*', '')
+                cleaned_inner = re.sub(
+                    r'^[0-9⁰¹²³⁴⁵⁶⁷⁸⁹]+\s*', '', cleaned_inner).strip()
                 if had_numeric_prefix:
                     return f" {cleaned_inner}"
                 return cleaned_inner

--- a/scripts/tth_2/md_to_json.py
+++ b/scripts/tth_2/md_to_json.py
@@ -199,6 +199,85 @@ class TTH2MdToJson:
         }
         return ''.join(superscript_map.get(digit, digit) for digit in num_str)
 
+    @staticmethod
+    def _footnote_identity(footnote: Dict[str, str]) -> str:
+        """Build a stable key used when merging footnote arrays."""
+        number = str(footnote.get('number', '')).strip()
+        marker = str(footnote.get('marker', '')).strip()
+        word = str(footnote.get('word', '')).strip().lower()
+        explanation = str(footnote.get('explanation', '')).strip().lower()
+
+        if number:
+            return f"number:{number}"
+        if marker:
+            return f"marker:{marker}"
+        if word:
+            return f"word:{word}"
+        return f"explanation:{explanation}"
+
+    def merge_verse_footnotes(
+        self,
+        existing: List[Dict[str, str]],
+        extracted: List[Dict[str, str]],
+    ) -> List[Dict[str, str]]:
+        """
+        Merge already-captured verse footnotes with newly extracted ones.
+
+        This prevents losing prior footnotes when continuation lines are
+        reparsed after markers were already converted to superscript text.
+        """
+        if not existing:
+            return extracted
+        if not extracted:
+            return existing
+
+        merged_by_key: Dict[str, Dict[str, str]] = {}
+        merge_order: List[str] = []
+
+        def add_footnote(footnote: Dict[str, str]) -> None:
+            normalized = {
+                'marker': str(footnote.get('marker', '')),
+                'number': str(footnote.get('number', '')),
+                'word': str(footnote.get('word', '')),
+                'explanation': str(footnote.get('explanation', '')),
+            }
+            key = self._footnote_identity(normalized)
+
+            if key in merged_by_key:
+                current = merged_by_key[key]
+                if not current['marker'] and normalized['marker']:
+                    current['marker'] = normalized['marker']
+                if not current['number'] and normalized['number']:
+                    current['number'] = normalized['number']
+                if not current['word'] and normalized['word']:
+                    current['word'] = normalized['word']
+                if not current['explanation'] and normalized['explanation']:
+                    current['explanation'] = normalized['explanation']
+                return
+
+            merged_by_key[key] = normalized
+            merge_order.append(key)
+
+        for footnote in existing:
+            add_footnote(footnote)
+        for footnote in extracted:
+            add_footnote(footnote)
+
+        merged = [merged_by_key[key] for key in merge_order]
+        return sorted(
+            merged,
+            key=lambda footnote: (
+                0,
+                int(footnote['number']),
+            )
+            if footnote.get('number', '').strip().isdigit()
+            else (
+                1,
+                footnote.get('marker', ''),
+                footnote.get('word', ''),
+            ),
+        )
+
     def extract_footnotes(self, text: str) -> Tuple[str, List[Dict[str, str]]]:
         """Extract footnotes from text and convert to superscript."""
         footnotes = []
@@ -573,7 +652,10 @@ class TTH2MdToJson:
                             merged, merged_footnotes = self.extract_footnotes(
                                 merged)
                             current_verses[-1]['tth'] = merged
-                            current_verses[-1]['footnotes'] = merged_footnotes
+                            current_verses[-1]['footnotes'] = self.merge_verse_footnotes(
+                                current_verses[-1].get('footnotes', []),
+                                merged_footnotes,
+                            )
                             current_verses[-1]['hebrew_terms'] = []
                             continue
 
@@ -624,7 +706,10 @@ class TTH2MdToJson:
                         merged, merged_footnotes = self.extract_footnotes(
                             merged)
                         current_verses[-1]['tth'] = merged
-                        current_verses[-1]['footnotes'] = merged_footnotes
+                        current_verses[-1]['footnotes'] = self.merge_verse_footnotes(
+                            current_verses[-1].get('footnotes', []),
+                            merged_footnotes,
+                        )
                         current_verses[-1]['hebrew_terms'] = []
                         i += 1
                         continue
@@ -669,19 +754,32 @@ class TTH2MdToJson:
 
                     if len(split_segments) <= 1:
                         # Regular multiline continuation, keep existing behavior.
+                        existing_footnotes = list(
+                            last_verse.get('footnotes', []))
                         last_verse['tth'] = self.clean_text_preserve_comments(
                             combined_text)
-                        last_verse['tth'], last_verse['footnotes'] = self.extract_footnotes(
+                        last_verse['tth'], extracted_footnotes = self.extract_footnotes(
                             last_verse['tth'])
+                        last_verse['footnotes'] = self.merge_verse_footnotes(
+                            existing_footnotes,
+                            extracted_footnotes,
+                        )
                         last_verse['hebrew_terms'] = []
                     else:
                         # Replace the current last verse with the re-split output.
-                        current_verses.pop()
+                        previous_last_verse = current_verses.pop()
                         for split_verse_num, split_verse_text in split_segments:
                             cleaned_text = self.clean_text_preserve_comments(
                                 split_verse_text)
-                            cleaned_text, footnotes = self.extract_footnotes(
+                            cleaned_text, extracted_footnotes = self.extract_footnotes(
                                 cleaned_text)
+
+                            footnotes = extracted_footnotes
+                            if split_verse_num == previous_last_verse.get('verse'):
+                                footnotes = self.merge_verse_footnotes(
+                                    previous_last_verse.get('footnotes', []),
+                                    extracted_footnotes,
+                                )
 
                             current_verses.append({
                                 'verse': split_verse_num,

--- a/shared/translationConfig.ts
+++ b/shared/translationConfig.ts
@@ -1,7 +1,17 @@
 // Translation configuration utilities for footnote handling and display rules
 
+import {
+  mapHebrewVerseToTranslationReference,
+  type VerseReference,
+} from "./versification";
+
 export type AppLanguage = "en" | "es" | "he";
 export type TranslationKey = "ts2009" | "tth" | "delitzsch";
+
+export type TranslationTarget = {
+  reference: VerseReference | null;
+  usesPsalmTitle: boolean;
+};
 
 type DssCommentaryInput = {
   comment_v2_en?: string | null;
@@ -72,6 +82,66 @@ export const getTranslationKey = (language: AppLanguage): TranslationKey => {
     default:
       return "ts2009"; // fallback
   }
+};
+
+const normalizeBookToken = (value: string): string =>
+  value.toLowerCase().replace(/[^a-z0-9]/g, "");
+
+const isPsalmsBook = (bookId: string): boolean =>
+  normalizeBookToken(bookId) === "psalms";
+
+export const resolveTranslationTarget = (
+  bookId: string,
+  chapter: number,
+  verse: number,
+  language?: Exclude<AppLanguage, "he">,
+): TranslationTarget => {
+  if (language === "en") {
+    return {
+      reference: mapHebrewVerseToTranslationReference(bookId, chapter, verse),
+      usesPsalmTitle: false,
+    };
+  }
+
+  if (language === "es" && isPsalmsBook(bookId)) {
+    const mappedReference = mapHebrewVerseToTranslationReference(
+      bookId,
+      chapter,
+      verse,
+    );
+
+    if (!mappedReference) {
+      return {
+        reference: null,
+        usesPsalmTitle: true,
+      };
+    }
+
+    return {
+      reference: mappedReference,
+      usesPsalmTitle: false,
+    };
+  }
+
+  return {
+    reference: { chapter, verse },
+    usesPsalmTitle: false,
+  };
+};
+
+export const resolveTranslationLookupKey = (
+  bookId: string,
+  chapter: number,
+  verse: number,
+  language?: Exclude<AppLanguage, "he">,
+): string | null => {
+  const target = resolveTranslationTarget(bookId, chapter, verse, language);
+
+  if (!target.reference) {
+    return null;
+  }
+
+  return `${target.reference.chapter}-${target.reference.verse}`;
 };
 
 export const shouldHideTranslationText = (

--- a/shared/translationConfig.ts
+++ b/shared/translationConfig.ts
@@ -133,7 +133,10 @@ const PSALMS_SUPERSCRIPTION_NOTICE: Record<AppLanguage, string> = {
 
 export const getMissingSpanishTranslationNotice = (
   language: AppLanguage,
-): string => MISSING_SPANISH_TRANSLATION_NOTICE[language] ?? MISSING_SPANISH_TRANSLATION_NOTICE.en;
+): string => {
+  if (language === "en") return "";
+  return MISSING_SPANISH_TRANSLATION_NOTICE[language] ?? MISSING_SPANISH_TRANSLATION_NOTICE.es;
+};
 
 export const getPsalmsSuperscriptionNotice = (
   language: AppLanguage,

--- a/shared/versification.ts
+++ b/shared/versification.ts
@@ -43,6 +43,10 @@ type ParsedVersificationEntry = {
   type: VersificationType;
   forward: Map<string, VerseReference>;
   reverse: Map<string, VerseReference>;
+  // Chapters that appear in the simple_map (i.e., have versification shifts).
+  // For superscription_shift books, verses in these chapters that have no
+  // reverse mapping are superscriptions and should return null.
+  mappedChapters: Set<number>;
 };
 
 const parsedVersificationByCode: Record<string, ParsedVersificationEntry> = {};
@@ -101,10 +105,17 @@ const parseVersificationEntry = (
     }
   }
 
+  const mappedChapters = new Set<number>();
+  for (const sourceChapterToken of Object.keys(entry.simple_map ?? {})) {
+    const ch = Number(sourceChapterToken);
+    if (Number.isFinite(ch)) mappedChapters.add(ch);
+  }
+
   return {
     type: entry.type,
     forward,
     reverse,
+    mappedChapters,
   };
 };
 
@@ -170,6 +181,12 @@ export const mapHebrewVerseToTranslationReference = (
     const mappedSource = versification.reverse.get(key);
 
     if (!mappedSource) {
+      // If this chapter is in the simple_map but has no reverse entry, the
+      // verse is a superscription line (e.g. Psalms with 2 superscription
+      // verses where only source key >= 1 appears in the map).
+      if (versification.mappedChapters.has(chapter)) {
+        return null;
+      }
       return { chapter, verse };
     }
 

--- a/web/src/app/components/FullChapterView.tsx
+++ b/web/src/app/components/FullChapterView.tsx
@@ -240,7 +240,7 @@ export function FullChapterView({
 											marginRight: "8px",
 										}}
 									>
-										{verse.verse}
+										[{verse.verse}]
 									</span>
 									<span
 										style={{
@@ -346,7 +346,7 @@ export function FullChapterView({
 													marginRight: "8px",
 												}}
 											>
-												{verse.verse}
+												[{verse.verse}]
 											</span>
 											{language === "es" && !(verse.translation ?? "").trim()
 												? spanishMissingTranslation

--- a/web/src/app/components/FullChapterView.tsx
+++ b/web/src/app/components/FullChapterView.tsx
@@ -226,7 +226,7 @@ export function FullChapterView({
 			{shouldShowSefer ? (
 				<div className="px-2">
 					{translationOnly ? (
-						<div className="leading-relaxed">
+						<div className="leading-relaxed" style={{ direction: "ltr" }}>
 							{verses.map((verse, idx) => (
 								<span key={verse.verse}>
 									<span
@@ -249,13 +249,14 @@ export function FullChapterView({
 											color: "var(--text-hebrew)",
 											opacity: 1,
 											fontWeight: 400,
+											direction: "ltr",
 										}}
 									>
 										{language === "es" && !(verse.translation ?? "").trim()
 											? spanishMissingTranslation
 											: renderVerseTranslation(verse)}
 									</span>
-									{idx < verses.length - 1 && " "}
+									{idx < verses.length - 1 && "\u200E "}
 								</span>
 							))}
 						</div>

--- a/web/src/app/components/VerseDisplay.tsx
+++ b/web/src/app/components/VerseDisplay.tsx
@@ -390,7 +390,7 @@ export function VerseDisplay({
 									opacity: 0.7,
 								}}
 							>
-								{verseNumber}
+								[{verseNumber}]
 							</div>
 						)}
 						{language === "es" && !translation.trim()

--- a/web/src/app/services/staticData.test.js
+++ b/web/src/app/services/staticData.test.js
@@ -1,4 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import {
+	resolveTranslationLookupKey,
+	resolveTranslationTarget,
+} from "../../../../shared/translationConfig";
 
 const readJson = async (relativePath) => {
 	const filePath = new URL(`../../../public/${relativePath}`, import.meta.url);
@@ -81,6 +85,43 @@ describe("static data integrity", () => {
 
 		expect(words.H7363).toBeUndefined();
 		expect(roots.H7363).toBeDefined();
+	});
+
+	test("Spanish Psalms superscriptions use chapter titles and keep later verses aligned", async () => {
+		const psalms = await readJson("data/bes/psalms.json");
+		const chapter = psalms.chapters.find((item) => item.chapter === 3);
+
+		expect(chapter).toBeDefined();
+		expect(typeof chapter.title).toBe("string");
+		expect(chapter.title.length > 0).toBe(true);
+
+		const verse1Target = resolveTranslationTarget("psalms", 3, 1, "es");
+		expect(verse1Target.usesPsalmTitle).toBe(true);
+		expect(verse1Target.reference).toBeNull();
+
+		const displayedVerse1 = verse1Target.usesPsalmTitle
+			? chapter.title
+			: chapter.verses.find(
+				(item) =>
+					item.verse === verse1Target.reference?.verse,
+			)?.bes;
+		expect(displayedVerse1).toBe(chapter.title);
+
+		const verse2Target = resolveTranslationTarget("psalms", 3, 2, "es");
+		expect(verse2Target.usesPsalmTitle).toBe(false);
+		expect(verse2Target.reference).toEqual({ chapter: 3, verse: 1 });
+
+		const displayedVerse2 = chapter.verses.find(
+			(item) => item.verse === verse2Target.reference?.verse,
+		)?.bes;
+		expect(displayedVerse2).toBe(chapter.verses.find((item) => item.verse === 1)?.bes);
+	});
+
+	test("English Psalm superscriptions stay mapped while Spanish Exodus stays direct", () => {
+		expect(resolveTranslationLookupKey("psalms", 3, 1, "en")).toBeNull();
+		expect(resolveTranslationLookupKey("psalms", 3, 2, "en")).toBe("3-1");
+		expect(resolveTranslationLookupKey("exodus", 7, 26, "es")).toBe("7-26");
+		expect(resolveTranslationLookupKey("exodus", 7, 26, "en")).toBe("8-1");
 	});
 });
 

--- a/web/src/app/services/staticData.ts
+++ b/web/src/app/services/staticData.ts
@@ -651,15 +651,38 @@ const toSortedUniqueVerseNumbers = (values: number[]): number[] =>
 		new Set(values.filter((value) => Number.isFinite(value) && value > 0)),
 	).sort((a, b) => a - b);
 
+const getTranslationLookupKey = (
+	bookId: string,
+	chapter: number,
+	verse: number,
+	language?: "es" | "en",
+): string | null => {
+	if (language !== "en") {
+		return `${chapter}-${verse}`;
+	}
+
+	return mapHebrewVerseToTranslationKey(bookId, chapter, verse);
+};
+
 const getRequiredTranslationChapters = (
 	bookId: string,
 	chapter: number,
+	language?: "es" | "en",
 	expectedVerseNumbers?: number[],
 ): number[] => {
+	if (language !== "en") {
+		return [chapter];
+	}
+
 	const mappedChapters = new Set<number>();
 
 	for (const verseNumber of expectedVerseNumbers ?? []) {
-		const mappedKey = mapHebrewVerseToTranslationKey(bookId, chapter, verseNumber);
+		const mappedKey = getTranslationLookupKey(
+			bookId,
+			chapter,
+			verseNumber,
+			language,
+		);
 		if (!mappedKey) {
 			continue;
 		}
@@ -681,6 +704,14 @@ const getRequiredTranslationChapters = (
 const isPsalmsBook = (bookId: string): boolean =>
 	normalizeBookToken(bookId) === "psalms";
 
+const HEBREW_RUN_RE = /[\u0590-\u05FF]+/g;
+
+const isolateHebrewRuns = (value: string): string =>
+	value.replace(HEBREW_RUN_RE, (token) => `\u2067${token}\u2069`);
+
+const finalizeTranslationDisplayText = (value: string): string =>
+	value.trim().length > 0 ? isolateHebrewRuns(value) : value;
+
 const resolveTranslationText = (params: {
 	bookId: string;
 	language?: "es" | "en";
@@ -690,18 +721,22 @@ const resolveTranslationText = (params: {
 	const { bookId, language, mappedTranslationKey, translationText } = params;
 
 	if (!language) {
-		return translationText ?? "";
+		return finalizeTranslationDisplayText(translationText ?? "");
 	}
 
 	if (isPsalmsBook(bookId) && mappedTranslationKey === null) {
-		return getPsalmsSuperscriptionNotice(language);
+		return finalizeTranslationDisplayText(
+			getPsalmsSuperscriptionNotice(language),
+		);
 	}
 
 	if (translationText && translationText.trim().length > 0) {
-		return translationText;
+		return finalizeTranslationDisplayText(translationText);
 	}
 
-	return getMissingSpanishTranslationNotice(language);
+	return finalizeTranslationDisplayText(
+		getMissingSpanishTranslationNotice(language),
+	);
 };
 
 const mapDssDifferences = (differences?: RawDssDifference[]): DssVariant[] => {
@@ -1175,6 +1210,7 @@ export const getChapterVerses = async (
 		: getRequiredTranslationChapters(
 				bookEntry.id,
 				chapter,
+				options?.language,
 				expectedVerseNumbers,
 			);
 
@@ -1237,10 +1273,11 @@ export const getChapterVerses = async (
 	}
 
 	return coreVerses.map((rawVerse) => {
-		const translationKey = mapHebrewVerseToTranslationKey(
+		const translationKey = getTranslationLookupKey(
 			bookEntry.id,
 			rawVerse.chapter,
 			rawVerse.verse,
+			options?.language,
 		);
 
 		return mapVerse(

--- a/web/src/app/services/staticData.ts
+++ b/web/src/app/services/staticData.ts
@@ -1,6 +1,8 @@
 import {
 	getMissingSpanishTranslationNotice,
 	getPsalmsSuperscriptionNotice,
+	resolveTranslationLookupKey,
+	resolveTranslationTarget,
 	TTH_BOOK_MAPPING,
 } from "../../../../shared/translationConfig";
 import { mapHebrewVerseToTranslationKey } from "../../../../shared/versification";
@@ -103,8 +105,14 @@ type RawTranslationBook = {
 	};
 	chapters?: Array<{
 		chapter: number;
+		title?: string;
 		verses: RawTranslationVerse[];
 	}>;
+};
+
+type LoadedTranslationChapter = {
+	verses: Record<string, RawTranslationVerse>;
+	titles: Record<number, string>;
 };
 
 type RawDssDifference = {
@@ -657,11 +665,7 @@ const getTranslationLookupKey = (
 	verse: number,
 	language?: "es" | "en",
 ): string | null => {
-	if (language !== "en") {
-		return `${chapter}-${verse}`;
-	}
-
-	return mapHebrewVerseToTranslationKey(bookId, chapter, verse);
+	return resolveTranslationLookupKey(bookId, chapter, verse, language);
 };
 
 const getRequiredTranslationChapters = (
@@ -716,12 +720,23 @@ const resolveTranslationText = (params: {
 	bookId: string;
 	language?: "es" | "en";
 	mappedTranslationKey: string | null;
+	translationTitle?: string | null;
 	translationText?: string | null;
 }): string => {
-	const { bookId, language, mappedTranslationKey, translationText } = params;
+	const {
+		bookId,
+		language,
+		mappedTranslationKey,
+		translationTitle,
+		translationText,
+	} = params;
 
 	if (!language) {
 		return finalizeTranslationDisplayText(translationText ?? "");
+	}
+
+	if (translationTitle && translationTitle.trim().length > 0) {
+		return finalizeTranslationDisplayText(translationTitle);
 	}
 
 	if (isPsalmsBook(bookId) && mappedTranslationKey === null) {
@@ -823,8 +838,9 @@ const sanitizeShirHashirimTth = (text?: string): string | undefined => {
 const loadTranslationChapter = async (
 	bookId: string,
 	requiredChapters: number[],
-): Promise<Record<string, RawTranslationVerse>> => {
+	): Promise<LoadedTranslationChapter> => {
 	const translationMap: Record<string, RawTranslationVerse> = {};
+	const translationTitles: Record<number, string> = {};
 
 	// Try TTH_2 first (official Spanish translation)
 	const tthBookId = resolveTthBookId(bookId);
@@ -843,6 +859,10 @@ const loadTranslationChapter = async (
 					continue;
 				}
 
+				if (typeof chapterData.title === "string" && chapterData.title.trim()) {
+					translationTitles[translationChapter] = chapterData.title.trim();
+				}
+
 				const verses =
 					tthBookId === "shir_hashirim"
 						? chapterData.verses.map((verse) => ({
@@ -857,7 +877,10 @@ const loadTranslationChapter = async (
 			}
 
 			if (Object.keys(translationMap).length > 0) {
-				return translationMap;
+				return {
+					verses: translationMap,
+					titles: translationTitles,
+				};
 			}
 		} catch {
 			// TTH_2 not available for this book, try BES fallback below
@@ -879,14 +902,24 @@ const loadTranslationChapter = async (
 				continue;
 			}
 
+			if (typeof chapterData.title === "string" && chapterData.title.trim()) {
+				translationTitles[translationChapter] = chapterData.title.trim();
+			}
+
 			for (const verse of chapterData.verses) {
 				translationMap[`${translationChapter}-${verse.verse}`] = verse;
 			}
 		}
 
-		return translationMap;
+		return {
+			verses: translationMap,
+			titles: translationTitles,
+		};
 	} catch {
-		return translationMap;
+		return {
+			verses: translationMap,
+			titles: translationTitles,
+		};
 	}
 };
 
@@ -1003,6 +1036,7 @@ const mapVerse = (
 	bookId: string,
 	rawVerse: RawVerse,
 	translationVerse?: RawTranslationVerse,
+	translationTitle?: string | null,
 	dssVerse?: RawDssVerse,
 	translitWords?: RawTranslitWord[],
 	dssTranslitByPosition?: Record<number, RawDssTranslitVariant>,
@@ -1073,6 +1107,7 @@ const mapVerse = (
 			bookId,
 			language,
 			mappedTranslationKey: mappedTranslationKey ?? null,
+			translationTitle,
 			translationText: baseTranslationText,
 		});
 
@@ -1217,7 +1252,7 @@ export const getChapterVerses = async (
 	const [translations, dssVerses, transliterations, dssTransliterations] =
 		await Promise.all([
 			options?.hebrewOnly
-				? Promise.resolve<Record<string, RawTranslationVerse>>({})
+				? Promise.resolve<LoadedTranslationChapter>({ verses: {}, titles: {} })
 				: loadTranslationChapter(bookEntry.id, requiredTranslationChapters),
 			options?.showDss
 				? loadDssChapter(bookEntry.id, chapter)
@@ -1273,17 +1308,23 @@ export const getChapterVerses = async (
 	}
 
 	return coreVerses.map((rawVerse) => {
-		const translationKey = getTranslationLookupKey(
+		const translationTarget = resolveTranslationTarget(
 			bookEntry.id,
 			rawVerse.chapter,
 			rawVerse.verse,
 			options?.language,
 		);
+		const translationKey = translationTarget.reference
+			? `${translationTarget.reference.chapter}-${translationTarget.reference.verse}`
+			: null;
 
 		return mapVerse(
 			bookEntry.id,
 			rawVerse,
-			translationKey ? translations[translationKey] : undefined,
+			translationKey ? translations.verses[translationKey] : undefined,
+			translationTarget.usesPsalmTitle
+				? translations.titles[rawVerse.chapter] ?? null
+				: null,
 			dssVerses[rawVerse.verse],
 			transliterations[rawVerse.verse],
 			dssTransliterations[rawVerse.verse],

--- a/web/src/app/utils/translationFormatter.tsx
+++ b/web/src/app/utils/translationFormatter.tsx
@@ -17,9 +17,9 @@ const superscriptDigitMap: Record<string, string> = {
 const superscriptPattern = /[⁰¹²³⁴⁵⁶⁷⁸⁹]+/g;
 const bracketFootnotePattern = /\[([a-z0-9]+)\]/gi;
 const footnoteMarkerClass =
-	"ml-0.5 align-super relative -top-[0.06em] inline-block text-[0.5em] leading-none font-semibold tracking-[0.01em] tabular-nums text-[#9f6a2f] dark:text-[#d2a06b]";
+	"ml-0.5 align-super relative -top-[0.22em] inline-block text-[0.4em] leading-none font-semibold tracking-[0.01em] tabular-nums text-[#9f6a2f] dark:text-[#d2a06b]";
 const fallbackMarkerClass =
-	"ml-0.5 align-super text-[0.52em] leading-none font-semibold text-[#9f6a2f] dark:text-[#d2a06b]";
+	"ml-0.5 align-super relative -top-[0.22em] inline-block text-[0.4em] leading-none font-semibold tabular-nums text-[#9f6a2f] dark:text-[#d2a06b]";
 const footnoteTooltipClass =
 	"pointer-events-none invisible absolute top-full left-1/2 z-30 mt-2 w-[min(320px,82vw)] -translate-x-1/2 rounded-xl border px-3 py-2 text-left opacity-0 shadow-xl backdrop-blur-[1px] transition-opacity group-hover:visible group-hover:opacity-100";
 


### PR DESCRIPTION
- Normalize TS2009 Psalms export in static data generation by detecting Hebrew-numbered superscription chapters and renumbering verses to English indexing.
- Use shared versification data during TS2009 chapter generation so exported per-chapter payloads and verse counts reflect normalized verse maps.
- Update translation fallback behavior to return an empty string for English when translation text is missing instead of showing a Spanish-specific notice.
- Improve superscription-shift mapping by tracking mapped chapters and returning null for unmapped superscription lines, including Psalms with multi-line superscriptions.
- Enabling nikud after disabling translation only in settings, fix wrong behavior that was disabling nikud