### PR TITLE
fix: align versification references and harden TTH2 Hoshea processing

### DIFF
--- a/data/tth_2/json/hoshea.json
+++ b/data/tth_2/json/hoshea.json
@@ -246,9 +246,10 @@
         },
         {
           "verse": 13,
-          "tth": "Y visitaré sobre ella los días de los baales, que ella quemó incienso para ellos y se adornó con su anillo de nariz y su joyería, y fue detrás de sus amantes y a Mí me olvidó –declaración de יהוה. Elohim se desposará con su pueblo",
+          "tth": "Y visitaré sobre ella los días de los baales, que ella quemó incienso para ellos y se adornó con su anillo de nariz y su joyería, y fue detrás de sus amantes y a Mí me olvidó –declaración de יהוה.",
           "footnotes": [],
-          "hebrew_terms": []
+          "hebrew_terms": [],
+          "subtitle": "Elohim se desposará con su pueblo"
         },
         {
           "verse": 14,
@@ -374,7 +375,7 @@
         },
         {
           "verse": 23,
-          "tth": "Y la sembraré para Mí en la tierra, y amaré a la no amada²⁴, y diré a lo que no era mi pueblo²⁵: “Pueblo mío eres tú²⁶”, y él dirá: “¡Elohim mío! ” Matrimonio simbólico de Hoshea",
+          "tth": "Y la sembraré para Mí en la tierra, y amaré a la no amada²⁴, y diré a lo que no era mi pueblo²⁵: “Pueblo mío eres tú²⁶”, y él dirá: “¡Elohim mío!”",
           "footnotes": [
             {
               "marker": "²⁴",
@@ -395,7 +396,8 @@
               "explanation": "Heb.: Amí atáh."
             }
           ],
-          "hebrew_terms": []
+          "hebrew_terms": [],
+          "subtitle": "Matrimonio simbólico de Hoshea"
         }
       ]
     },
@@ -616,9 +618,10 @@
         },
         {
           "verse": 19,
-          "tth": "La ha oprimido el viento en sus alas, y se avergonzarán de sus sacrificios. Castigo de la rebeldía de Israel",
+          "tth": "La ha oprimido el viento en sus alas, y se avergonzarán de sus sacrificios.",
           "footnotes": [],
-          "hebrew_terms": []
+          "hebrew_terms": [],
+          "subtitle": "Castigo de la rebeldía de Israel"
         }
       ]
     },
@@ -746,7 +749,7 @@
         },
         {
           "verse": 15,
-          "tth": "Iré y volveré a mi lugar hasta que vean su culpa y busquen mi rostro; en la estrechez de ellos madrugarán para buscarme⁴². Respuesta del pueblo",
+          "tth": "Iré y volveré a mi lugar hasta que vean su culpa y busquen mi rostro; en la estrechez de ellos madrugarán para buscarme⁴².",
           "footnotes": [
             {
               "marker": "⁴²",
@@ -755,7 +758,8 @@
               "explanation": "O, me buscarán ansiosamente."
             }
           ],
-          "hebrew_terms": []
+          "hebrew_terms": [],
+          "subtitle": "Respuesta del pueblo"
         }
       ]
     },
@@ -844,9 +848,10 @@
         },
         {
           "verse": 11,
-          "tth": "También, Iehudáh, ha puesto una cosecha para ti, cuando haga volver el cautiverio de mi pueblo. Iniquidad y rebeldía de Israel",
+          "tth": "También, Iehudáh, ha puesto una cosecha para ti, cuando haga volver el cautiverio de mi pueblo.",
           "footnotes": [],
-          "hebrew_terms": []
+          "hebrew_terms": [],
+          "subtitle": "Iniquidad y rebeldía de Israel"
         }
       ]
     },
@@ -980,7 +985,7 @@
         },
         {
           "verse": 16,
-          "tth": "Se volvieron⁵¹, mas no a lo alto, fueron como arco engañoso. Caerán por la espada sus príncipes debido a la ira de su lengua; esto será su escarnio en la tierra de Mitzráim. La idolatría de Israel",
+          "tth": "Se volvieron⁵¹, mas no a lo alto, fueron como arco engañoso. Caerán por la espada sus príncipes debido a la ira de su lengua; esto será su escarnio en la tierra de Mitzráim.",
           "footnotes": [
             {
               "marker": "⁵¹",
@@ -989,7 +994,8 @@
               "explanation": "O, volverán."
             }
           ],
-          "hebrew_terms": []
+          "hebrew_terms": [],
+          "subtitle": "La idolatría de Israel"
         }
       ]
     },
@@ -1097,9 +1103,10 @@
         },
         {
           "verse": 14,
-          "tth": "Y olvidó Israel a su Hacedor y edificó palacios, y Iehudáh multiplicó ciudades fortificadas; pero enviaré fuego en sus ciudades y consumirá sus palacios. Castigo de la infidelidad de Israel",
+          "tth": "Y olvidó Israel a su Hacedor y edificó palacios, y Iehudáh multiplicó ciudades fortificadas; pero enviaré fuego en sus ciudades y consumirá sus palacios.",
           "footnotes": [],
-          "hebrew_terms": []
+          "hebrew_terms": [],
+          "subtitle": "Castigo de la infidelidad de Israel"
         }
       ]
     },
@@ -1238,9 +1245,10 @@
         },
         {
           "verse": 17,
-          "tth": "Los despreciará mi Elohim, porque no lo han escuchado, y serán errantes en las naciones. La vid de Israel",
+          "tth": "Los despreciará mi Elohim, porque no lo han escuchado, y serán errantes en las naciones.",
           "footnotes": [],
-          "hebrew_terms": []
+          "hebrew_terms": [],
+          "subtitle": "La vid de Israel"
         }
       ]
     },
@@ -1550,7 +1558,7 @@
         },
         {
           "verse": 12,
-          "tth": "Me ha rodeado en mentiras Efráim, y en engaño la casa de Israel; y Iehudáh todavía gobierna⁸¹ con Elohim y con el Santo Fiel. Efráim es reprendido",
+          "tth": "Me ha rodeado en mentiras Efráim, y en engaño la casa de Israel; y Iehudáh todavía gobierna⁸¹ con Elohim y con el Santo Fiel.",
           "footnotes": [
             {
               "marker": "⁸¹",
@@ -1559,7 +1567,8 @@
               "explanation": "Otra lectura posible es: divaga."
             }
           ],
-          "hebrew_terms": []
+          "hebrew_terms": [],
+          "subtitle": "Efráim es reprendido"
         }
       ]
     },
@@ -1667,9 +1676,10 @@
         },
         {
           "verse": 14,
-          "tth": "Ha provocado a rechazo Efráim en amarguras; y sus sangres sobre él dejará, y su reproche le devolverá su Amo. Condenación de la idolatría de Efráim",
+          "tth": "Ha provocado a rechazo Efráim en amarguras; y sus sangres sobre él dejará, y su reproche le devolverá su Amo.",
           "footnotes": [],
-          "hebrew_terms": []
+          "hebrew_terms": [],
+          "subtitle": "Condenación de la idolatría de Efráim"
         }
       ]
     },
@@ -1815,9 +1825,10 @@
       "verses": [
         {
           "verse": 1,
-          "tth": "Será culpable Shomrón, porque se rebeló contra su Elohim. Por la espada caerán, sus niños serán hechos pedazos y sus embarazadas serán abiertas. Arrepentimiento de Israel",
+          "tth": "Será culpable Shomrón, porque se rebeló contra su Elohim. Por la espada caerán, sus niños serán hechos pedazos y sus embarazadas serán abiertas.",
           "footnotes": [],
-          "hebrew_terms": []
+          "hebrew_terms": [],
+          "subtitle": "Arrepentimiento de Israel"
         },
         {
           "verse": 2,

--- a/mobile/app/(tabs)/bookmarks.tsx
+++ b/mobile/app/(tabs)/bookmarks.tsx
@@ -71,7 +71,13 @@ export default function BookmarksScreen() {
                   })
                 }
               >
-                <VerseCard verse={item} />
+                <VerseCard
+                  verse={{
+                    ...item,
+                    sourceChapter: item.chapter,
+                    sourceVerse: item.verse,
+                  }}
+                />
               </Pressable>
             )}
             contentContainerStyle={styles.listContent}

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -38,7 +38,7 @@ LogBox.ignoreLogs([
 
 const getFocusedRouteName = (route: unknown) => {
   const state = (route as {
-    state?: { index?: number; routes?: Array<{ name?: string }> };
+    state?: { index?: number; routes?: { name?: string }[] };
   })?.state;
   const index = state?.index ?? 0;
   return state?.routes?.[index]?.name;

--- a/mobile/src/components/NavigationSheet.tsx
+++ b/mobile/src/components/NavigationSheet.tsx
@@ -34,6 +34,8 @@ type NavigationSheetProps = {
   currentBookId: string;
   currentChapter: number;
   currentVerse: number;
+  translationOnly?: boolean;
+  currentChapterVerseNumbers?: number[];
   onSelectVerse: (bookId: string, chapter: number, verse: number) => void;
   onClose?: () => void;
 };
@@ -234,6 +236,8 @@ const NavigationSheetComponent = (
     currentBookId,
     currentChapter,
     currentVerse,
+    translationOnly = false,
+    currentChapterVerseNumbers,
     onSelectVerse,
     onClose,
   }: NavigationSheetProps,
@@ -355,10 +359,34 @@ const NavigationSheetComponent = (
 
   // Get verses for selected chapter
   const verseNumbers = useMemo(() => {
+    if (
+      translationOnly &&
+      selectedBookId === currentBookId &&
+      selectedChapter === currentChapter &&
+      Array.isArray(currentChapterVerseNumbers) &&
+      currentChapterVerseNumbers.length > 0
+    ) {
+      return Array.from(
+        new Set(
+          currentChapterVerseNumbers.filter(
+            (value) => Number.isFinite(value) && value > 0,
+          ),
+        ),
+      ).sort((a, b) => a - b);
+    }
+
     const count = verseCounts[selectedBookId]?.[String(selectedChapter)];
     if (count) return Array.from({ length: count }, (_, i) => i + 1);
     return [];
-  }, [selectedBookId, selectedChapter, verseCounts]);
+  }, [
+    currentBookId,
+    currentChapter,
+    currentChapterVerseNumbers,
+    selectedBookId,
+    selectedChapter,
+    translationOnly,
+    verseCounts,
+  ]);
 
   // Pad numbers for grid
   const padNumbers = useCallback((numbers: number[]) => {

--- a/mobile/src/components/VerseCard.tsx
+++ b/mobile/src/components/VerseCard.tsx
@@ -31,7 +31,6 @@ import {
   sanitizeEmTags,
   buildMarkerRegex,
   createFootnoteLookup,
-  type MarkerMatch,
   collectMarkerMatches,
   resolveFootnoteForMarker,
   formatMarkerForDisplay,

--- a/mobile/src/components/ui/Skeleton.tsx
+++ b/mobile/src/components/ui/Skeleton.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { View, type ViewStyle } from "react-native";
+import { type ViewStyle } from "react-native";
 import Animated, {
   useSharedValue,
   useAnimatedStyle,

--- a/mobile/src/screens/VerseDetailContent.tsx
+++ b/mobile/src/screens/VerseDetailContent.tsx
@@ -70,7 +70,6 @@ import {
   buildMarkerRegex,
   createFootnoteLookup,
   DEFAULT_FOOTNOTE_MARKER_COLOR,
-  type MarkerMatch,
   collectMarkerMatches,
   resolveFootnoteForMarker,
   formatMarkerForDisplay,
@@ -752,6 +751,22 @@ export const VerseDetailContent = () => {
   const verse =
     chapterVerses.find((item) => item.verse === verseNumber) ??
     chapterVerses[0];
+  const previousTranslationOnlyRef = useRef(translationOnly);
+
+  useEffect(() => {
+    if (
+      previousTranslationOnlyRef.current &&
+      !translationOnly &&
+      verse
+    ) {
+      setEffectiveVerseId(
+        `${verse.bookId}-${verse.sourceChapter}-${verse.sourceVerse}`,
+      );
+    }
+
+    previousTranslationOnlyRef.current = translationOnly;
+  }, [setEffectiveVerseId, translationOnly, verse]);
+
   const bookMeta = useMemo(
     () =>
       booksMeta.find((book) => book.id === (verse?.bookId ?? bookId)) ?? null,
@@ -1241,6 +1256,7 @@ export const VerseDetailContent = () => {
           showDss: showQumran,
           hebrewOnly: hideTranslations,
           isConnected,
+          referenceMode: translationOnly ? "translation" : "source",
         });
         if (!isMounted) return;
         if (
@@ -1473,6 +1489,8 @@ export const VerseDetailContent = () => {
         currentBookId={verse?.bookId ?? bookId}
         currentChapter={verse?.chapter ?? chapter}
         currentVerse={verse?.verse ?? verseNumber}
+        translationOnly={translationOnly}
+        currentChapterVerseNumbers={orderedVerses.map((item) => item.verse)}
         onSelectVerse={handleNavigationSelect}
       />
       <Modal

--- a/mobile/src/services/scripture.ts
+++ b/mobile/src/services/scripture.ts
@@ -12,10 +12,12 @@ import { removeMaqafForDisplay } from "@/src/utils/hebrew";
 import {
   getMissingSpanishTranslationNotice,
   getPsalmsSuperscriptionNotice,
+  resolveTranslationSource,
   resolveTranslationLookupKey,
   resolveTranslationTarget,
   TTH_BOOK_MAPPING,
 } from "@davar/shared/translationConfig";
+import { getSourceChaptersForTranslationChapter } from "@davar/shared/versification";
 
 // Chapter-level cache for TS2009 static JSON (matches web approach)
 const ts2009ChapterCache = new Map<string, Promise<Map<number, string> | null>>();
@@ -253,12 +255,16 @@ export type DisplayVerse = {
   bookId: string;
   chapter: number;
   verse: number;
+  sourceChapter: number;
+  sourceVerse: number;
   hebrew: string;
   translation: string;
   words: DisplayWord[];
   qumranVariants?: { position: number; dssWord: string }[];
   translation_footnotes?: TranslationFootnote[];
 };
+
+type ReferenceMode = "source" | "translation";
 
 const formatBookName = (bookId: string) =>
   bookId.charAt(0).toUpperCase() + bookId.slice(1);
@@ -472,37 +478,31 @@ const isRenderableDssWord = (value?: string): value is string => {
   return countDssWordTokens(trimmed) === 1;
 };
 
-const toSortedUniqueVerseNumbers = (values: number[]): number[] =>
-  Array.from(new Set(values.filter((value) => Number.isFinite(value) && value > 0))).sort(
-    (a, b) => a - b,
-  );
-
 const getTranslationLookupKey = (
   bookId: string,
   chapter: number,
   verse: number,
   language?: "en" | "es",
 ): string | null => {
-  return resolveTranslationLookupKey(bookId, chapter, verse, language);
+  return resolveTranslationLookupKey(bookId, chapter, verse, { language });
 };
 
 const getRequiredTranslationChapters = (
   bookId: string,
-  chapter: number,
+  sourceVerses: { chapter: number; verse: number }[],
   language?: "en" | "es",
-  expectedVerseNumbers?: number[],
 ): number[] => {
-  if (language !== "en") {
-    return [chapter];
+  if (!language) {
+    return [];
   }
 
   const mappedChapters = new Set<number>();
 
-  for (const verseNumber of expectedVerseNumbers ?? []) {
+  for (const sourceVerse of sourceVerses) {
     const mappedKey = getTranslationLookupKey(
       bookId,
-      chapter,
-      verseNumber,
+      sourceVerse.chapter,
+      sourceVerse.verse,
       language,
     );
     if (!mappedKey) {
@@ -517,10 +517,35 @@ const getRequiredTranslationChapters = (
   }
 
   if (mappedChapters.size === 0) {
-    mappedChapters.add(chapter);
+    for (const sourceVerse of sourceVerses) {
+      mappedChapters.add(sourceVerse.chapter);
+    }
   }
 
   return [...mappedChapters].sort((a, b) => a - b);
+};
+
+const getSourceChaptersForRequest = (
+  bookId: string,
+  chapter: number,
+  language: "en" | "es" | undefined,
+  referenceMode: ReferenceMode,
+): number[] => {
+  if (!Number.isFinite(chapter) || chapter <= 0) {
+    return [];
+  }
+
+  if (!language || referenceMode !== "translation") {
+    return [chapter];
+  }
+
+  const source = resolveTranslationSource(bookId, { language });
+  if (!source) {
+    return [chapter];
+  }
+
+  const chapters = getSourceChaptersForTranslationChapter(bookId, chapter);
+  return chapters.length > 0 ? chapters : [chapter];
 };
 
 const toDssBookKey = (bookId: string): string => {
@@ -581,18 +606,16 @@ const parseTranslationFootnotes = (
 
 const loadStaticTranslationsForChapter = async (
   bookId: string,
-  chapter: number,
+  sourceVerses: StaticChapterVerse[],
   language?: "en" | "es",
   hebrewOnly?: boolean,
-  expectedVerseNumbers?: number[],
 ): Promise<LoadedStaticTranslations> => {
   const translationMap = new Map<string, TranslationEntry>();
   const translationTitleMap = new Map<number, string>();
   const requiredTranslationChapters = getRequiredTranslationChapters(
     bookId,
-    chapter,
+    sourceVerses.map((verse) => ({ chapter: verse.chapter, verse: verse.verse })),
     language,
-    expectedVerseNumbers,
   );
 
   if (!language || hebrewOnly) {
@@ -692,7 +715,10 @@ const loadStaticTranslationsForChapter = async (
         }
       }
     } catch (error) {
-      console.warn(`Failed to load TS2009 translations for ${bookId} ${chapter}:`, error);
+      console.warn(
+        `Failed to load TS2009 translations for ${bookId} chapters ${requiredTranslationChapters.join(",")}:`,
+        error,
+      );
       // Fall back to SQLite below
     }
   }
@@ -728,8 +754,8 @@ const loadStaticDssForChapter = async (
   bookId: string,
   chapter: number,
   showDss?: boolean,
-): Promise<Map<number, StaticDssDifference[]>> => {
-  const dssMap = new Map<number, StaticDssDifference[]>();
+): Promise<Map<string, StaticDssDifference[]>> => {
+  const dssMap = new Map<string, StaticDssDifference[]>();
 
   if (!showDss) {
     return dssMap;
@@ -753,7 +779,7 @@ const loadStaticDssForChapter = async (
       );
 
       if (differences.length > 0) {
-        dssMap.set(verseNumber, differences);
+        dssMap.set(`${chapter}:${verseNumber}`, differences);
       }
     }
   } catch {
@@ -766,23 +792,23 @@ const loadStaticDssForChapter = async (
 const loadStaticTranslitForChapter = async (
   bookId: string,
   chapter: number,
-): Promise<Map<number, StaticTranslitWord[]>> => {
+): Promise<Map<string, StaticTranslitWord[]>> => {
   try {
     const translitBook = await staticDataRequest<StaticTranslitBook>(
       `translit/${bookId}.json`,
     );
 
-    const translitMap = new Map<number, StaticTranslitWord[]>();
+    const translitMap = new Map<string, StaticTranslitWord[]>();
     for (const verseEntry of translitBook.verses ?? []) {
       if (verseEntry.chapter !== chapter) {
         continue;
       }
-      translitMap.set(verseEntry.verse, verseEntry.words ?? []);
+      translitMap.set(`${chapter}:${verseEntry.verse}`, verseEntry.words ?? []);
     }
 
     return translitMap;
   } catch {
-    return new Map<number, StaticTranslitWord[]>();
+    return new Map<string, StaticTranslitWord[]>();
   }
 };
 
@@ -813,7 +839,7 @@ const loadStaticDssTranslitForChapter = async (
         continue;
       }
 
-      dssTranslitMap.set(`${verse}:${position}`, variant);
+      dssTranslitMap.set(`${chapter}:${verse}:${position}`, variant);
     }
   } catch {
     // DSS transliteration data is optional; fall back to standard transliteration.
@@ -854,20 +880,23 @@ const mapStaticVersesToDisplay = (
   verses: StaticChapterVerse[],
   translationMap: Map<string, TranslationEntry>,
   translationTitleMap: Map<number, string>,
-  dssMap: Map<number, StaticDssDifference[]>,
-  translitMap: Map<number, StaticTranslitWord[]>,
+  dssMap: Map<string, StaticDssDifference[]>,
+  translitMap: Map<string, StaticTranslitWord[]>,
   dssTranslitMap: Map<string, StaticDssTranslitVariant>,
   language?: "en" | "es",
   showDss?: boolean,
+  referenceMode: ReferenceMode = "source",
+  requestedChapter?: number,
 ): DisplayVerse[] => {
-  return verses.map((verse) => {
-    const dssVariants = showDss ? (dssMap.get(verse.verse) ?? []) : [];
+  const mappedVerses = verses.map((verse) => {
+    const dssKey = `${verse.chapter}:${verse.verse}`;
+    const dssVariants = showDss ? (dssMap.get(dssKey) ?? []) : [];
     const dssVariantMap = new Map(
       dssVariants.map((variant) => [variant.position, variant]),
     );
 
     const sourceWords = Array.isArray(verse.words) ? verse.words : [];
-    const translitWords = translitMap.get(verse.verse) ?? [];
+    const translitWords = translitMap.get(dssKey) ?? [];
     const canMapTranslitByPosition = translitWords.length === sourceWords.length;
     const words: DisplayWord[] = sourceWords.map((word, index) => {
       const position = index + 1;
@@ -878,7 +907,7 @@ const mapStaticVersesToDisplay = (
       const translitWord = canMapTranslitByPosition
         ? translitWords[index]
         : findFallbackTranslitWord(word, translitWords);
-      const dssTranslit = dssTranslitMap.get(`${verse.verse}:${position}`);
+      const dssTranslit = dssTranslitMap.get(`${verse.chapter}:${verse.verse}:${position}`);
       const prefersDssTranslit = Boolean(showDss && hasRenderableQumranVariant);
       const dssTranslitEn = dssTranslit?.translit_en ?? dssVariant?.translit_en;
       const dssTranslitEs = dssTranslit?.translit_es ?? dssVariant?.translit_es;
@@ -917,8 +946,9 @@ const mapStaticVersesToDisplay = (
       bookId,
       verse.chapter,
       verse.verse,
-      language,
+      { language },
     );
+
     const translationKey = translationTarget.reference
       ? `${translationTarget.reference.chapter}-${translationTarget.reference.verse}`
       : null;
@@ -935,12 +965,23 @@ const mapStaticVersesToDisplay = (
       translationText: translationEntry?.text,
     });
 
+    const outputChapter =
+      referenceMode === "translation"
+        ? (translationTarget.reference?.chapter ?? 0)
+        : verse.chapter;
+    const outputVerse =
+      referenceMode === "translation"
+        ? (translationTarget.reference?.verse ?? 0)
+        : verse.verse;
+
     return {
-      id: `${bookId}-${verse.chapter}-${verse.verse}`,
+      id: `${bookId}-${outputChapter}-${outputVerse}`,
       book: formatBookName(bookId),
       bookId,
-      chapter: verse.chapter,
-      verse: verse.verse,
+      chapter: outputChapter,
+      verse: outputVerse,
+      sourceChapter: verse.chapter,
+      sourceVerse: verse.verse,
       hebrew: removeMaqafForDisplay(hebrewText),
       translation: translationText,
       words,
@@ -956,6 +997,40 @@ const mapStaticVersesToDisplay = (
       translation_footnotes: translationEntry?.footnotes,
     };
   });
+
+  if (referenceMode === "translation" && language && Number.isFinite(requestedChapter)) {
+    return mappedVerses
+      .filter((verse) => verse.chapter === requestedChapter)
+      .sort((a, b) => a.verse - b.verse || a.sourceChapter - b.sourceChapter || a.sourceVerse - b.sourceVerse);
+  }
+
+  return mappedVerses.sort((a, b) => a.sourceChapter - b.sourceChapter || a.sourceVerse - b.sourceVerse);
+};
+
+const loadStaticSourceChapterVerses = async (
+  bookId: string,
+  chapter: number,
+): Promise<StaticChapterVerse[]> => {
+  const chapterSources = [`oe/${bookId}/${chapter}.json`, `besorah/${bookId}/${chapter}.json`];
+  const sourceErrors: string[] = [];
+
+  for (const source of chapterSources) {
+    try {
+      const verses = await staticDataRequest<StaticChapterVerse[]>(source);
+      if (Array.isArray(verses) && verses.length > 0) {
+        return verses;
+      }
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      sourceErrors.push(`${source}: ${reason}`);
+    }
+  }
+
+  const details =
+    sourceErrors.length > 0 ? sourceErrors.join(" | ") : chapterSources.join(", ");
+  throw new Error(
+    `No static verse data found for ${bookId} chapter ${chapter}. Sources tried: ${details}`,
+  );
 };
 
 const fetchChapterVersesStatic = async (
@@ -965,52 +1040,68 @@ const fetchChapterVersesStatic = async (
     language?: "en" | "es";
     showDss?: boolean;
     hebrewOnly?: boolean;
+    referenceMode?: ReferenceMode;
   },
 ): Promise<DisplayVerse[]> => {
-  const chapterSources = [`oe/${bookId}/${chapter}.json`, `besorah/${bookId}/${chapter}.json`];
-
-  let sourceVerses: StaticChapterVerse[] | null = null;
-  const sourceErrors: string[] = [];
-
-  for (const source of chapterSources) {
-    try {
-      const verses = await staticDataRequest<StaticChapterVerse[]>(source);
-      if (Array.isArray(verses) && verses.length > 0) {
-        sourceVerses = verses;
-        break;
-      }
-    } catch (error) {
-      const reason = error instanceof Error ? error.message : String(error);
-      sourceErrors.push(`${source}: ${reason}`);
-      // Try next source
-    }
-  }
-
-  if (!sourceVerses || sourceVerses.length === 0) {
-    const details =
-      sourceErrors.length > 0
-        ? sourceErrors.join(" | ")
-        : chapterSources.join(", ");
-    throw new Error(
-      `No static verse data found for ${bookId} chapter ${chapter}. Sources tried: ${details}`,
-    );
-  }
-
-  const expectedVerseNumbers = toSortedUniqueVerseNumbers(
-    sourceVerses.map((verse) => verse.verse),
+  const referenceMode = options?.referenceMode ?? "source";
+  const sourceChapters = getSourceChaptersForRequest(
+    bookId,
+    chapter,
+    options?.language,
+    referenceMode,
   );
+
+  const sourceVerseChunks = await Promise.all(
+    sourceChapters.map((sourceChapter) =>
+      loadStaticSourceChapterVerses(bookId, sourceChapter),
+    ),
+  );
+  const sourceVerses = sourceVerseChunks.flat();
 
   const [translations, dssMap, translitMap, dssTranslitMap] = await Promise.all([
     loadStaticTranslationsForChapter(
       bookId,
-      chapter,
+      sourceVerses,
       options?.language,
       options?.hebrewOnly,
-      expectedVerseNumbers,
     ),
-    loadStaticDssForChapter(bookId, chapter, options?.showDss),
-    loadStaticTranslitForChapter(bookId, chapter),
-    loadStaticDssTranslitForChapter(bookId, chapter, options?.showDss),
+    Promise.all(
+      sourceChapters.map((sourceChapter) =>
+        loadStaticDssForChapter(bookId, sourceChapter, options?.showDss),
+      ),
+    ).then((maps) => {
+      const merged = new Map<string, StaticDssDifference[]>();
+      for (const map of maps) {
+        for (const [key, value] of map.entries()) {
+          merged.set(key, value);
+        }
+      }
+      return merged;
+    }),
+    Promise.all(
+      sourceChapters.map((sourceChapter) => loadStaticTranslitForChapter(bookId, sourceChapter)),
+    ).then((maps) => {
+      const merged = new Map<string, StaticTranslitWord[]>();
+      for (const map of maps) {
+        for (const [key, value] of map.entries()) {
+          merged.set(key, value);
+        }
+      }
+      return merged;
+    }),
+    Promise.all(
+      sourceChapters.map((sourceChapter) =>
+        loadStaticDssTranslitForChapter(bookId, sourceChapter, options?.showDss),
+      ),
+    ).then((maps) => {
+      const merged = new Map<string, StaticDssTranslitVariant>();
+      for (const map of maps) {
+        for (const [key, value] of map.entries()) {
+          merged.set(key, value);
+        }
+      }
+      return merged;
+    }),
   ]);
 
   const { verses: translationMap, titles: translationTitleMap } = translations;
@@ -1025,6 +1116,8 @@ const fetchChapterVersesStatic = async (
     dssTranslitMap,
     options?.language,
     options?.showDss,
+    referenceMode,
+    chapter,
   );
 };
 
@@ -1036,6 +1129,8 @@ const mapOfflineDataToDisplay = (
   translationRows: TranslationRow[],
   dssRows: DssVariantRow[],
   language?: "en" | "es",
+  referenceMode: ReferenceMode = "source",
+  requestedChapter?: number,
 ): DisplayVerse[] => {
   // Index translations by verse number
   const translationMap = new Map<string, TranslationRow>();
@@ -1052,13 +1147,13 @@ const mapOfflineDataToDisplay = (
     dssMap.set(key, existing);
   }
 
-  return hebrewRows.map((hv) => {
+  const mappedVerses = hebrewRows.map((hv) => {
     const verseKey = `${hv.chapter}-${hv.verse}`;
     const translationTarget = resolveTranslationTarget(
       bookId,
       hv.chapter,
       hv.verse,
-      language,
+      { language },
     );
     const mappedTranslationKey = translationTarget.reference
       ? `${translationTarget.reference.chapter}-${translationTarget.reference.verse}`
@@ -1142,12 +1237,23 @@ const mapOfflineDataToDisplay = (
       translationFootnotes = translation.footnotes as TranslationFootnote[];
     }
 
+    const outputChapter =
+      referenceMode === "translation"
+        ? (translationTarget.reference?.chapter ?? 0)
+        : hv.chapter;
+    const outputVerse =
+      referenceMode === "translation"
+        ? (translationTarget.reference?.verse ?? 0)
+        : hv.verse;
+
     return {
-      id: `${bookId}-${hv.chapter}-${hv.verse}`,
+      id: `${bookId}-${outputChapter}-${outputVerse}`,
       book: formatBookName(bookId),
       bookId,
-      chapter: hv.chapter,
-      verse: hv.verse,
+      chapter: outputChapter,
+      verse: outputVerse,
+      sourceChapter: hv.chapter,
+      sourceVerse: hv.verse,
       hebrew,
       translation: translationText,
       words,
@@ -1155,6 +1261,14 @@ const mapOfflineDataToDisplay = (
       translation_footnotes: translationFootnotes,
     };
   });
+
+  if (referenceMode === "translation" && language && Number.isFinite(requestedChapter)) {
+    return mappedVerses
+      .filter((verse) => verse.chapter === requestedChapter)
+      .sort((a, b) => a.verse - b.verse || a.sourceChapter - b.sourceChapter || a.sourceVerse - b.sourceVerse);
+  }
+
+  return mappedVerses.sort((a, b) => a.sourceChapter - b.sourceChapter || a.sourceVerse - b.sourceVerse);
 };
 
 // ── Offline fetch from SQLite ──────────────────────────────────────────────
@@ -1165,9 +1279,22 @@ const fetchChapterVersesOffline = async (
   options?: {
     language?: "en" | "es";
     showDss?: boolean;
+    referenceMode?: ReferenceMode;
   },
 ): Promise<DisplayVerse[]> => {
-  const hebrewRows = await fetchHebrewVerses(bookId, chapter);
+  const referenceMode = options?.referenceMode ?? "source";
+  const sourceChapters = getSourceChaptersForRequest(
+    bookId,
+    chapter,
+    options?.language,
+    referenceMode,
+  );
+
+  const hebrewRows = (
+    await Promise.all(
+      sourceChapters.map((sourceChapter) => fetchHebrewVerses(bookId, sourceChapter)),
+    )
+  ).flat();
   if (hebrewRows.length === 0) {
     throw new Error(`No offline Hebrew data for ${bookId} chapter ${chapter}`);
   }
@@ -1178,9 +1305,8 @@ const fetchChapterVersesOffline = async (
         await Promise.all(
           getRequiredTranslationChapters(
             bookId,
-            chapter,
+            hebrewRows.map((row) => ({ chapter: row.chapter, verse: row.verse })),
             translationLanguage,
-            toSortedUniqueVerseNumbers(hebrewRows.map((row) => row.verse)),
           ).map((translationChapter) =>
             fetchTranslationVerses(bookId, translationChapter, translationLanguage),
           ),
@@ -1189,7 +1315,11 @@ const fetchChapterVersesOffline = async (
     : [];
 
   const dssRows = options?.showDss
-    ? await fetchDssVariants(bookId, chapter)
+    ? (
+        await Promise.all(
+          sourceChapters.map((sourceChapter) => fetchDssVariants(bookId, sourceChapter)),
+        )
+      ).flat()
     : [];
 
   return mapOfflineDataToDisplay(
@@ -1198,6 +1328,8 @@ const fetchChapterVersesOffline = async (
     translationRows,
     dssRows,
     translationLanguage,
+    referenceMode,
+    chapter,
   );
 };
 
@@ -1209,6 +1341,7 @@ export const fetchChapterVerses = async (
     showDss?: boolean;
     hebrewOnly?: boolean;
     isConnected?: boolean;
+    referenceMode?: ReferenceMode;
   },
 ): Promise<DisplayVerse[]> => {
   // If explicitly offline, go straight to SQLite

--- a/mobile/src/types/api.ts
+++ b/mobile/src/types/api.ts
@@ -32,6 +32,8 @@ export type TranslationFootnote = {
 export type VerseResponse = {
   chapter: number;
   verse: number;
+  sourceChapter?: number;
+  sourceVerse?: number;
   hebrew: string;
   words: WordResponse[];
   translation?: string;

--- a/scripts/tth_2/md_to_json.py
+++ b/scripts/tth_2/md_to_json.py
@@ -399,6 +399,76 @@ class TTH2MdToJson:
 
         return False
 
+    def is_plain_section_header_line(self, lines: List[str], index: int, line: str) -> bool:
+        """
+        Detect unformatted standalone section headers between verse blocks.
+
+        Some source books contain section titles as plain text lines (without
+        italic markers), e.g. "Matrimonio simbólico de Hoshea". If left as-is,
+        these lines are appended to the previous verse body. We convert only
+        highly structured, isolated candidates and leave normal prose untouched.
+        """
+        stripped = line.strip()
+        if not stripped:
+            return False
+
+        # Ignore known non-header markers.
+        if stripped.startswith('#'):
+            return False
+        if stripped.startswith('*'):
+            return False
+        if re.match(r'^\*\*(\d+)\*\*(?:\s+.+)?$', stripped):
+            return False
+        if re.match(r'^\[\^\d+\]:', stripped):
+            return False
+
+        # Titles in this corpus appear isolated by blank lines.
+        prev_raw_blank = index > 0 and not lines[index - 1].strip()
+        next_raw_blank = index + \
+            1 < len(lines) and not lines[index + 1].strip()
+        if not (prev_raw_blank and next_raw_blank):
+            return False
+
+        # Context guard: must be between verse/chapter markers.
+        prev_nonempty = ''
+        for j in range(index - 1, -1, -1):
+            candidate = lines[j].strip()
+            if candidate:
+                prev_nonempty = candidate
+                break
+
+        next_nonempty = ''
+        for j in range(index + 1, len(lines)):
+            candidate = lines[j].strip()
+            if candidate:
+                next_nonempty = candidate
+                break
+
+        if not re.match(r'^\*\*\d+\*\*', prev_nonempty):
+            return False
+        if not re.match(r'^\*\*\d+\*\*(?:\s+.+)?$', next_nonempty):
+            return False
+
+        # Keep heuristic strict to avoid dropping legitimate wrapped verse prose.
+        if re.search(r'[,;:!?]', stripped):
+            return False
+        if re.search(r'\[\^\d+\]', stripped):
+            return False
+
+        words = re.findall(r"[A-Za-zÁÉÍÓÚÜÑáéíóúüñ'’-]+", stripped)
+        if len(words) < 2 or len(words) > 10:
+            return False
+
+        first_word = words[0]
+        if not first_word[0].isupper():
+            return False
+
+        # Narrative continuations often start with conjunctions/pronouns.
+        if first_word.lower() in {'y', 'pero', 'porque', 'pues', 'yo', 'él', 'ella', 'ellos', 'ellas', 'ustedes', 'nosotros'}:
+            return False
+
+        return True
+
     def is_book_header_boundary_line(self, line: str) -> bool:
         """
         Detect a new-book header marker leaked into a per-book markdown file.
@@ -742,6 +812,11 @@ class TTH2MdToJson:
                     if re.match(r'^\*\*\d+\*\*', line):
                         i += 1
                         continue
+
+                    # Plain standalone section headers (no markdown formatting)
+                    # should become subtitle material, not verse body text.
+                    if self.is_plain_section_header_line(lines, i, line):
+                        line = f"*{line}*"
 
                     # Add to the last verse, then re-split in case this
                     # continuation line embeds a new inline verse marker

--- a/scripts/tth_2/text_cleaner.py
+++ b/scripts/tth_2/text_cleaner.py
@@ -125,7 +125,7 @@ class TTHTextCleaner:
             next_char = match.group(2)
 
             # Don't add space if next char is already punctuation, quote, or special
-            if next_char in '.,;:!?"\')}]\\*_':
+            if next_char in '.,;:!?"\')}]\\*_”’»':
                 return punct + next_char
 
             # Don't add space before closing parenthesis or brackets
@@ -139,6 +139,25 @@ class TTHTextCleaner:
             return punct + ' ' + next_char
 
         return self.punctuation_space_pattern.sub(add_space, text)
+
+    def fix_inverted_punctuation_spacing(self, text: str) -> str:
+        """
+        Normalize spacing around Spanish inverted punctuation.
+
+        Examples:
+            "¡ Elohim mío!" -> "¡Elohim mío!"
+            "¿ Quién?" -> "¿Quién?"
+            "¡Elohim mío !" -> "¡Elohim mío!"
+        """
+        result = text
+
+        # Remove spacing after opening inverted punctuation.
+        result = re.sub(r'([¡¿])\s+', r'\1', result)
+
+        # Remove spacing before closing punctuation.
+        result = re.sub(r'\s+([!?])', r'\1', result)
+
+        return result
 
     # Words that should NEVER be split (Hebrew/Biblical names ending with connectors)
     PROTECTED_WORDS = {
@@ -288,10 +307,13 @@ class TTHTextCleaner:
         # 5. Finally fix punctuation spacing
         result = self.fix_punctuation_spacing(result)
 
-        # 6. Clean up any double spaces that might have been introduced
+        # 6. Normalize spacing around inverted/question punctuation
+        result = self.fix_inverted_punctuation_spacing(result)
+
+        # 7. Clean up any double spaces that might have been introduced
         result = re.sub(r'  +', ' ', result)
 
-        # 7. Clean up spaces before punctuation
+        # 8. Clean up spaces before punctuation
         result = re.sub(r'\s+([.,;:!?])', r'\1', result)
 
         return result.strip()

--- a/shared/translationConfig.ts
+++ b/shared/translationConfig.ts
@@ -7,10 +7,16 @@ import {
 
 export type AppLanguage = "en" | "es" | "he";
 export type TranslationKey = "ts2009" | "tth" | "delitzsch";
+export type TranslationSource = "ts2009" | "tth" | "bes";
 
 export type TranslationTarget = {
   reference: VerseReference | null;
   usesPsalmTitle: boolean;
+};
+
+export type TranslationResolverOptions = {
+  language?: Exclude<AppLanguage, "he">;
+  source?: TranslationSource;
 };
 
 type DssCommentaryInput = {
@@ -84,6 +90,38 @@ export const getTranslationKey = (language: AppLanguage): TranslationKey => {
   }
 };
 
+export const resolveTranslationSource = (
+  bookId: string,
+  options?: TranslationResolverOptions,
+): TranslationSource | undefined => {
+  if (options?.source) {
+    return options.source;
+  }
+
+  const language = options?.language;
+  if (!language) {
+    return undefined;
+  }
+
+  if (language === "en") {
+    return "ts2009";
+  }
+
+  if (language === "es") {
+    const normalizedBookId = normalizeBookToken(bookId);
+    const supportsTth = Object.keys(TTH_BOOK_MAPPING).some(
+      (bookKey) => normalizeBookToken(bookKey) === normalizedBookId,
+    );
+    return supportsTth ? "tth" : "bes";
+  }
+
+  return undefined;
+};
+
+const shouldApplyVersificationMapping = (source?: TranslationSource): boolean => {
+  return source === "ts2009" || source === "tth" || source === "bes";
+};
+
 const normalizeBookToken = (value: string): string =>
   value.toLowerCase().replace(/[^a-z0-9]/g, "");
 
@@ -94,16 +132,11 @@ export const resolveTranslationTarget = (
   bookId: string,
   chapter: number,
   verse: number,
-  language?: Exclude<AppLanguage, "he">,
+  options?: TranslationResolverOptions,
 ): TranslationTarget => {
-  if (language === "en") {
-    return {
-      reference: mapHebrewVerseToTranslationReference(bookId, chapter, verse),
-      usesPsalmTitle: false,
-    };
-  }
+  const source = resolveTranslationSource(bookId, options);
 
-  if (language === "es" && isPsalmsBook(bookId)) {
+  if (shouldApplyVersificationMapping(source)) {
     const mappedReference = mapHebrewVerseToTranslationReference(
       bookId,
       chapter,
@@ -113,7 +146,7 @@ export const resolveTranslationTarget = (
     if (!mappedReference) {
       return {
         reference: null,
-        usesPsalmTitle: true,
+        usesPsalmTitle: isPsalmsBook(bookId),
       };
     }
 
@@ -133,9 +166,9 @@ export const resolveTranslationLookupKey = (
   bookId: string,
   chapter: number,
   verse: number,
-  language?: Exclude<AppLanguage, "he">,
+  options?: TranslationResolverOptions,
 ): string | null => {
-  const target = resolveTranslationTarget(bookId, chapter, verse, language);
+  const target = resolveTranslationTarget(bookId, chapter, verse, options);
 
   if (!target.reference) {
     return null;

--- a/shared/versification.ts
+++ b/shared/versification.ts
@@ -43,6 +43,7 @@ type ParsedVersificationEntry = {
   type: VersificationType;
   forward: Map<string, VerseReference>;
   reverse: Map<string, VerseReference>;
+  sourceChaptersByTargetChapter: Map<number, Set<number>>;
   // Chapters that appear in the simple_map (i.e., have versification shifts).
   // For superscription_shift books, verses in these chapters that have no
   // reverse mapping are superscriptions and should return null.
@@ -73,6 +74,7 @@ const parseVersificationEntry = (
 ): ParsedVersificationEntry => {
   const forward = new Map<string, VerseReference>();
   const reverse = new Map<string, VerseReference>();
+  const sourceChaptersByTargetChapter = new Map<number, Set<number>>();
 
   for (const [sourceChapterToken, chapterMap] of Object.entries(entry.simple_map ?? {})) {
     const sourceChapter = Number(sourceChapterToken);
@@ -98,6 +100,11 @@ const parseVersificationEntry = (
 
       forward.set(makeRefKey(sourceRef.chapter, sourceRef.verse), targetRef);
 
+      const sourceChapters =
+        sourceChaptersByTargetChapter.get(targetRef.chapter) ?? new Set<number>();
+      sourceChapters.add(sourceRef.chapter);
+      sourceChaptersByTargetChapter.set(targetRef.chapter, sourceChapters);
+
       const reverseKey = makeRefKey(targetRef.chapter, targetRef.verse);
       if (!reverse.has(reverseKey)) {
         reverse.set(reverseKey, sourceRef);
@@ -115,6 +122,7 @@ const parseVersificationEntry = (
     type: entry.type,
     forward,
     reverse,
+    sourceChaptersByTargetChapter,
     mappedChapters,
   };
 };
@@ -211,4 +219,30 @@ export const mapHebrewVerseToTranslationKey = (
   }
 
   return `${mapped.chapter}-${mapped.verse}`;
+};
+
+export const getSourceChaptersForTranslationChapter = (
+  bookId: string,
+  translationChapter: number,
+): number[] => {
+  if (!Number.isFinite(translationChapter) || translationChapter <= 0) {
+    return [];
+  }
+
+  const versification = getParsedVersificationForBook(bookId);
+  if (!versification) {
+    return [translationChapter];
+  }
+
+  const chapters = new Set<number>();
+  chapters.add(translationChapter);
+
+  for (const sourceChapter of
+    versification.sourceChaptersByTargetChapter.get(translationChapter) ?? []) {
+    if (Number.isFinite(sourceChapter) && sourceChapter > 0) {
+      chapters.add(sourceChapter);
+    }
+  }
+
+  return [...chapters].sort((a, b) => a - b);
 };

--- a/web/scripts/dev-hot-data-server.ts
+++ b/web/scripts/dev-hot-data-server.ts
@@ -46,4 +46,6 @@ Bun.serve({
 	},
 });
 
-console.log(`[davar-web] hot-data-server listening on http://${hostname}:${port}`);
+console.log(
+	`[davar-web] hot-data-server listening on http://${hostname}:${port}`,
+);

--- a/web/scripts/dev-hot-gateway.ts
+++ b/web/scripts/dev-hot-gateway.ts
@@ -27,7 +27,10 @@ Bun.serve({
 			return new Response(file);
 		}
 
-		const upstream = new URL(url.pathname + url.search, `http://${htmlHost}:${htmlPort}`);
+		const upstream = new URL(
+			url.pathname + url.search,
+			`http://${htmlHost}:${htmlPort}`,
+		);
 		const proxiedRequest = new Request(upstream, req);
 		return fetch(proxiedRequest);
 	},

--- a/web/scripts/dev-hot.ts
+++ b/web/scripts/dev-hot.ts
@@ -44,20 +44,17 @@ if (ensure.exitCode !== 0) {
 	runtimeExit(ensure.exitCode ?? 1);
 }
 
-const htmlServer = Bun.spawn(
-	["bun", "--env-file=.env", "./index.html"],
-	{
-		cwd: webRoot,
-		env: {
-			...runtimeEnv,
-			PORT: String(useGateway ? htmlPort : appPort),
-			HOST: appHost,
-			PUBLIC_STATIC_URL: staticUrl,
-		},
-		stdout: "inherit",
-		stderr: "inherit",
+const htmlServer = Bun.spawn(["bun", "--env-file=.env", "./index.html"], {
+	cwd: webRoot,
+	env: {
+		...runtimeEnv,
+		PORT: String(useGateway ? htmlPort : appPort),
+		HOST: appHost,
+		PUBLIC_STATIC_URL: staticUrl,
 	},
-);
+	stdout: "inherit",
+	stderr: "inherit",
+});
 
 const gatewayServer = useGateway
 	? Bun.spawn(["bun", "./scripts/dev-hot-gateway.ts"], {

--- a/web/scripts/ensure-static-data.ts
+++ b/web/scripts/ensure-static-data.ts
@@ -27,11 +27,14 @@ if (!existsSync(metadataPath)) {
 	console.log("[davar-web] static-data=incomplete-ts2009 regenerating");
 }
 
-const generation = Bun.spawnSync(["bun", "../scripts/generate-static-data/index.ts"], {
-	cwd: webRoot,
-	stdout: "inherit",
-	stderr: "inherit",
-});
+const generation = Bun.spawnSync(
+	["bun", "../scripts/generate-static-data/index.ts"],
+	{
+		cwd: webRoot,
+		stdout: "inherit",
+		stderr: "inherit",
+	},
+);
 
 if (generation.exitCode !== 0) {
 	console.error("[davar-web] static-data=generate failed");

--- a/web/src/app/App.tsx
+++ b/web/src/app/App.tsx
@@ -349,6 +349,14 @@ export default function App() {
 	const handleTranslationOnlyChange = useCallback(
 		(nextTranslationOnly: boolean) => {
 			setTranslationOnly(nextTranslationOnly);
+			const activeVerse =
+				chapterVerses.find((item) => item.verse === currentVerse) ??
+				chapterVerses[0];
+
+			if (!nextTranslationOnly && activeVerse) {
+				setCurrentChapter(activeVerse.sourceChapter);
+				setCurrentVerse(activeVerse.sourceVerse);
+			}
 
 			if (nextTranslationOnly) {
 				if (!showFullChapter) {
@@ -366,6 +374,8 @@ export default function App() {
 			setSeferMode(false);
 		},
 		[
+			chapterVerses,
+			currentVerse,
 			showFullChapter,
 			seferMode,
 			setTranslationOnly,
@@ -718,6 +728,11 @@ export default function App() {
 		[chapterVerses, currentVerse],
 	);
 
+	const currentVerseIndex = useMemo(
+		() => chapterVerses.findIndex((item) => item.verse === currentVerse),
+		[chapterVerses, currentVerse],
+	);
+
 	const selectedWordVerseData = useMemo(() => {
 		const context = selectedWordContext ?? lastSelectedWordContext;
 		if (!context) return currentVerseData;
@@ -875,15 +890,19 @@ export default function App() {
 					? undefined
 					: language;
 			try {
-				const [chapterCountValue, verseCountValue, verses] = await Promise.all([
+				const [chapterCountValue, verses] = await Promise.all([
 					getChapterCount(currentBook.toLowerCase()),
-					getVerseCount(currentBook.toLowerCase(), currentChapter),
 					getChapterVerses(currentBook.toLowerCase(), currentChapter, {
 						language: translationLanguage,
 						showDss: showQumran,
 						hebrewOnly: false, // Always load translations; UI will control display
+						referenceMode: translationOnly ? "translation" : "source",
 					}),
 				]);
+
+				const verseCountValue = translationOnly
+					? verses.length
+					: await getVerseCount(currentBook.toLowerCase(), currentChapter);
 				if (!isMounted) return;
 				setChapterCount(chapterCountValue);
 				setVerseCount(verseCountValue);
@@ -1333,6 +1352,38 @@ export default function App() {
 	]);
 
 	const handlePreviousVerse = useCallback(async () => {
+		if (translationOnly) {
+			if (currentVerseIndex > 0) {
+				setCurrentVerse(chapterVerses[currentVerseIndex - 1].verse);
+				return true;
+			}
+
+			if (currentChapter > 1) {
+				try {
+					const previousChapter = currentChapter - 1;
+					const translationLanguage = language === "es" ? "es" : "en";
+					const previousChapterVerses = await getChapterVerses(
+						currentBook.toLowerCase(),
+						previousChapter,
+						{
+							language: translationLanguage,
+							showDss: showQumran,
+							hebrewOnly: false,
+							referenceMode: "translation",
+						},
+					);
+					const lastVerse = previousChapterVerses.at(-1)?.verse ?? 1;
+					setCurrentChapter(previousChapter);
+					setCurrentVerse(lastVerse);
+					return true;
+				} catch {
+					return false;
+				}
+			}
+
+			return false;
+		}
+
 		if (currentVerse > 1) {
 			setCurrentVerse(currentVerse - 1);
 			return true;
@@ -1353,9 +1404,33 @@ export default function App() {
 			}
 		}
 		return false;
-	}, [currentBook, currentChapter, currentVerse]);
+	}, [
+		chapterVerses,
+		currentBook,
+		currentChapter,
+		currentVerse,
+		currentVerseIndex,
+		language,
+		showQumran,
+		translationOnly,
+	]);
 
 	const handleNextVerse = useCallback(async () => {
+		if (translationOnly) {
+			if (currentVerseIndex >= 0 && currentVerseIndex < chapterVerses.length - 1) {
+				setCurrentVerse(chapterVerses[currentVerseIndex + 1].verse);
+				return true;
+			}
+
+			if (currentChapter < chapterCount) {
+				setCurrentChapter(currentChapter + 1);
+				setCurrentVerse(1);
+				return true;
+			}
+
+			return false;
+		}
+
 		if (currentVerse < verseCount) {
 			setCurrentVerse(currentVerse + 1);
 			return true;
@@ -1367,7 +1442,15 @@ export default function App() {
 			return true;
 		}
 		return false;
-	}, [chapterCount, currentChapter, currentVerse, verseCount]);
+	}, [
+		chapterCount,
+		chapterVerses,
+		currentChapter,
+		currentVerse,
+		currentVerseIndex,
+		translationOnly,
+		verseCount,
+	]);
 
 	const isScrollNavigationActive =
 		currentScreen === "verse" && !showFullChapter && !isMobile;
@@ -1584,7 +1667,7 @@ export default function App() {
 											hebrewText={currentVerseData.hebrew}
 											translation={currentVerseData.translation ?? ""}
 											verseRef={`${currentBook} ${currentChapter}:${currentVerse}`}
-											verseNumber={currentVerse}
+											verseNumber={currentVerseData.verse}
 											bookName={getDisplayBookName(currentBook)}
 											bookNameHebrew={getHebrewBookName(currentBook)}
 											book={currentBook}
@@ -1609,12 +1692,13 @@ export default function App() {
 												currentVerseData.translation_footnotes
 											}
 											previousVerseSnippet={
-												currentVerse > 1
+												currentVerseIndex > 0
 													? t("verse.previousSnippet")
 													: undefined
 											}
 											nextVerseSnippet={
-												currentVerse < chapterVerses.length
+												currentVerseIndex >= 0 &&
+												currentVerseIndex < chapterVerses.length - 1
 													? t("verse.nextSnippet")
 													: undefined
 											}
@@ -1625,10 +1709,11 @@ export default function App() {
 												void handleNextVerse();
 											}}
 											canNavigatePrevious={
-												currentVerse > 1 || currentChapter > 1
+												currentVerseIndex > 0 || currentChapter > 1
 											}
 											canNavigateNext={
-												currentVerse < chapterVerses.length ||
+												(currentVerseIndex >= 0 &&
+													currentVerseIndex < chapterVerses.length - 1) ||
 												currentChapter < chapterCount
 											}
 										/>

--- a/web/src/app/App.tsx
+++ b/web/src/app/App.tsx
@@ -269,26 +269,23 @@ export default function App() {
 		[language],
 	);
 
-	const resolveRenderableDssWord = useCallback(
-		(value?: string) => {
-			if (!value) return undefined;
-			const trimmed = value.trim();
-			if (!trimmed || trimmed.toLowerCase() === "note") {
-				return undefined;
-			}
+	const resolveRenderableDssWord = useCallback((value?: string) => {
+		if (!value) return undefined;
+		const trimmed = value.trim();
+		if (!trimmed || trimmed.toLowerCase() === "note") {
+			return undefined;
+		}
 
-			const tokenCount = trimmed
-				.replace(/[/:]/g, " ")
-				.split(/\s+/)
-				.filter(Boolean).length;
-			if (tokenCount !== 1) {
-				return undefined;
-			}
+		const tokenCount = trimmed
+			.replace(/[/:]/g, " ")
+			.split(/\s+/)
+			.filter(Boolean).length;
+		if (tokenCount !== 1) {
+			return undefined;
+		}
 
-			return trimmed;
-		},
-		[],
-	);
+		return trimmed;
+	}, []);
 
 	useEffect(() => {
 		if (!showFullChapter && seferMode) {
@@ -908,7 +905,19 @@ export default function App() {
 				setVerseCount(verseCountValue);
 				setChapterVerses(verses);
 				if (verses.length > 0) {
-					setCurrentVerse((prevVerse) => Math.min(prevVerse, verses.length));
+					const availableVerseNumbers = verses
+						.map((verse) => verse.verse)
+						.filter(
+							(verseNumber) => Number.isFinite(verseNumber) && verseNumber > 0,
+						);
+
+					if (availableVerseNumbers.length > 0) {
+						const availableVerseSet = new Set(availableVerseNumbers);
+						const fallbackVerse = availableVerseNumbers[0];
+						setCurrentVerse((prevVerse) =>
+							availableVerseSet.has(prevVerse) ? prevVerse : fallbackVerse,
+						);
+					}
 				}
 			} catch (error) {
 				if (!isMounted) return;
@@ -1417,15 +1426,35 @@ export default function App() {
 
 	const handleNextVerse = useCallback(async () => {
 		if (translationOnly) {
-			if (currentVerseIndex >= 0 && currentVerseIndex < chapterVerses.length - 1) {
+			if (
+				currentVerseIndex >= 0 &&
+				currentVerseIndex < chapterVerses.length - 1
+			) {
 				setCurrentVerse(chapterVerses[currentVerseIndex + 1].verse);
 				return true;
 			}
 
 			if (currentChapter < chapterCount) {
-				setCurrentChapter(currentChapter + 1);
-				setCurrentVerse(1);
-				return true;
+				try {
+					const nextChapter = currentChapter + 1;
+					const translationLanguage = language === "es" ? "es" : "en";
+					const nextChapterVerses = await getChapterVerses(
+						currentBook.toLowerCase(),
+						nextChapter,
+						{
+							language: translationLanguage,
+							showDss: showQumran,
+							hebrewOnly: false,
+							referenceMode: "translation",
+						},
+					);
+					const firstVerse = nextChapterVerses[0]?.verse ?? 1;
+					setCurrentChapter(nextChapter);
+					setCurrentVerse(firstVerse);
+					return true;
+				} catch {
+					return false;
+				}
 			}
 
 			return false;
@@ -1445,9 +1474,12 @@ export default function App() {
 	}, [
 		chapterCount,
 		chapterVerses,
+		currentBook,
 		currentChapter,
 		currentVerse,
 		currentVerseIndex,
+		language,
+		showQumran,
 		translationOnly,
 		verseCount,
 	]);
@@ -1748,27 +1780,27 @@ export default function App() {
 											(!isNavigatingWordPanel && !showWordSkeleton
 												? lastSelectedWord
 												: null);
-											const wordContextForCard =
-												selectedWord && selectedWordContext
-													? selectedWordContext
-													: !selectedWord && lastSelectedWordContext
-														? lastSelectedWordContext
-														: null;
+										const wordContextForCard =
+											selectedWord && selectedWordContext
+												? selectedWordContext
+												: !selectedWord && lastSelectedWordContext
+													? lastSelectedWordContext
+													: null;
 										const wordAnalysisForCard = selectedWord
 											? selectedWordAnalysis
 											: lastSelectedWordAnalysis;
 										const dssAnalysisForCard = selectedWord
 											? selectedDssAnalysis
 											: lastSelectedDssAnalysis;
-											const verseDataForWordCard = wordContextForCard
-												? chapterVerses.find(
-														(item) =>
-															item.chapter === wordContextForCard.chapter &&
-															item.verse === wordContextForCard.verse,
-													) ?? currentVerseData
-												: currentVerseData;
+										const verseDataForWordCard = wordContextForCard
+											? (chapterVerses.find(
+													(item) =>
+														item.chapter === wordContextForCard.chapter &&
+														item.verse === wordContextForCard.verse,
+												) ?? currentVerseData)
+											: currentVerseData;
 										const dssVariantForCard =
-												verseDataForWordCard?.dss?.find(
+											verseDataForWordCard?.dss?.find(
 												(variant) => variant.position === wordForCard?.position,
 											) ?? null;
 										const qumranWordForCard = resolveRenderableDssWord(
@@ -1837,7 +1869,7 @@ export default function App() {
 														word={wordForCard.text}
 														wordFromVerse={wordForCard.text}
 														strongNumber={wordAnalysisForCard?.strong_number}
-																		qumranWord={qumranWordForCard}
+														qumranWord={qumranWordForCard}
 														qumranStrong={dssVariantForCard?.dss_strong}
 														qumranTransliteration={qumranTransliteration}
 														qumranMeanings={dssMeanings}
@@ -1951,11 +1983,11 @@ export default function App() {
 						if (!selectedWord) return null;
 
 						const selectedWordVerseDataForSheet = selectedWordContext
-							? chapterVerses.find(
+							? (chapterVerses.find(
 									(item) =>
 										item.chapter === selectedWordContext.chapter &&
 										item.verse === selectedWordContext.verse,
-								) ?? currentVerseData
+								) ?? currentVerseData)
 							: currentVerseData;
 
 						const dssVariantForCard =
@@ -1979,12 +2011,12 @@ export default function App() {
 									? selectedWord.dss_translit_es
 									: undefined;
 						const qumranTransliteration = selectedDssAnalysis
-							? qumranTransliterationFromWord ??
+							? (qumranTransliterationFromWord ??
 								(language === "en"
 									? selectedDssAnalysis.translit_en
 									: language === "es"
 										? selectedDssAnalysis.translit_es
-										: undefined)
+										: undefined))
 							: qumranTransliterationFromWord;
 
 						const selectedWordMeanings =

--- a/web/src/app/components/FullChapterView.tsx
+++ b/web/src/app/components/FullChapterView.tsx
@@ -131,7 +131,10 @@ export function FullChapterView({
 
 			const variantEntry = showQumran ? dssMap.get(word.position) : undefined;
 			if (variantEntry) {
-				skipUntilIndex = Math.max(skipUntilIndex, wordIdx + variantEntry.span - 1);
+				skipUntilIndex = Math.max(
+					skipUntilIndex,
+					wordIdx + variantEntry.span - 1,
+				);
 			}
 			const rawText = variantEntry?.text ?? word.text;
 
@@ -170,11 +173,13 @@ export function FullChapterView({
 				isContextMatch &&
 				(typeof selectedWord?.position === "number"
 					? selectedWord.position === word.position
-					: Boolean(normalizedSelected) && normalizedSelected === normalizedWord);
+					: Boolean(normalizedSelected) &&
+						normalizedSelected === normalizedWord);
 
-			const prefixSegments = !variantEntry && word.prefixes?.length
-				? getPrefixSegments(displayText, word.prefixes)
-				: null;
+			const prefixSegments =
+				!variantEntry && word.prefixes?.length
+					? getPrefixSegments(displayText, word.prefixes)
+					: null;
 
 			return (
 				<span key={`${verse.chapter}-${verse.verse}-${word.position}`}>
@@ -353,10 +358,10 @@ export function FullChapterView({
 												? spanishMissingTranslation
 												: renderVerseTranslation(verse)}
 										</>
+									) : language === "es" && !(verse.translation ?? "").trim() ? (
+										spanishMissingTranslation
 									) : (
-										language === "es" && !(verse.translation ?? "").trim()
-											? spanishMissingTranslation
-											: renderVerseTranslation(verse)
+										renderVerseTranslation(verse)
 									)}
 								</div>
 							)}

--- a/web/src/app/components/VerseDisplay.tsx
+++ b/web/src/app/components/VerseDisplay.tsx
@@ -183,9 +183,7 @@ export function VerseDisplay({
 				? normalizeForMatch(selectedWord.text)
 				: null;
 		const selectedPosition =
-			selectedWord && isSelectionInCurrentVerse
-				? selectedWord.position
-				: null;
+			selectedWord && isSelectionInCurrentVerse ? selectedWord.position : null;
 
 		let skipUntilIndex = -1;
 
@@ -196,7 +194,10 @@ export function VerseDisplay({
 
 			const variantEntry = showQumran ? dssMap.get(word.position) : undefined;
 			if (variantEntry) {
-				skipUntilIndex = Math.max(skipUntilIndex, index + variantEntry.span - 1);
+				skipUntilIndex = Math.max(
+					skipUntilIndex,
+					index + variantEntry.span - 1,
+				);
 			}
 			const rawText = variantEntry?.text ?? word.text;
 
@@ -229,12 +230,14 @@ export function VerseDisplay({
 			const isSelected =
 				typeof selectedPosition === "number"
 					? selectedPosition === word.position
-					: Boolean(normalizedSelected) && normalizedSelected === normalizedWord;
+					: Boolean(normalizedSelected) &&
+						normalizedSelected === normalizedWord;
 
 			// Prefix segmentation is only valid for original Masoretic words.
-			const prefixSegments = !variantEntry && word.prefixes?.length
-				? getPrefixSegments(displayText, word.prefixes)
-				: null;
+			const prefixSegments =
+				!variantEntry && word.prefixes?.length
+					? getPrefixSegments(displayText, word.prefixes)
+					: null;
 
 			const shouldShowHintButton =
 				showOnboardingHint &&

--- a/web/src/app/components/WordCard.tsx
+++ b/web/src/app/components/WordCard.tsx
@@ -145,7 +145,9 @@ export function WordCard({
 			? removeMaqafForDisplay(
 					normalizeHebrewDisplay(
 						stripNikud(
-							stripMeteg(stripCantillation(headerWord.replace(/[\u05BE-]/g, " "))),
+							stripMeteg(
+								stripCantillation(headerWord.replace(/[\u05BE-]/g, " ")),
+							),
 						),
 					),
 				)
@@ -435,9 +437,7 @@ export function WordCard({
 			<div className="text-center space-y-2 pb-6">
 				<div
 					style={{
-						fontFamily: isQumranTab
-							? qumranFontFamily
-							: "'Cardo', serif",
+						fontFamily: isQumranTab ? qumranFontFamily : "'Cardo', serif",
 						fontSize: isQumranTab ? qumranWordFontSize : masoreticWordFontSize,
 						direction: "rtl",
 						lineHeight: isQumranTab && hasMultiWordDisplay ? 1.35 : 1.8,

--- a/web/src/app/services/staticData.test.js
+++ b/web/src/app/services/staticData.test.js
@@ -95,7 +95,9 @@ describe("static data integrity", () => {
 		expect(typeof chapter.title).toBe("string");
 		expect(chapter.title.length > 0).toBe(true);
 
-		const verse1Target = resolveTranslationTarget("psalms", 3, 1, "es");
+		const verse1Target = resolveTranslationTarget("psalms", 3, 1, {
+			language: "es",
+		});
 		expect(verse1Target.usesPsalmTitle).toBe(true);
 		expect(verse1Target.reference).toBeNull();
 
@@ -107,7 +109,9 @@ describe("static data integrity", () => {
 			)?.bes;
 		expect(displayedVerse1).toBe(chapter.title);
 
-		const verse2Target = resolveTranslationTarget("psalms", 3, 2, "es");
+		const verse2Target = resolveTranslationTarget("psalms", 3, 2, {
+			language: "es",
+		});
 		expect(verse2Target.usesPsalmTitle).toBe(false);
 		expect(verse2Target.reference).toEqual({ chapter: 3, verse: 1 });
 
@@ -117,11 +121,22 @@ describe("static data integrity", () => {
 		expect(displayedVerse2).toBe(chapter.verses.find((item) => item.verse === 1)?.bes);
 	});
 
-	test("English Psalm superscriptions stay mapped while Spanish Exodus stays direct", () => {
-		expect(resolveTranslationLookupKey("psalms", 3, 1, "en")).toBeNull();
-		expect(resolveTranslationLookupKey("psalms", 3, 2, "en")).toBe("3-1");
-		expect(resolveTranslationLookupKey("exodus", 7, 26, "es")).toBe("7-26");
-		expect(resolveTranslationLookupKey("exodus", 7, 26, "en")).toBe("8-1");
+	test("English and Spanish both honor versification shifts", () => {
+		expect(
+			resolveTranslationLookupKey("psalms", 3, 1, { language: "en" }),
+		).toBeNull();
+		expect(
+			resolveTranslationLookupKey("psalms", 3, 2, { language: "en" }),
+		).toBe("3-1");
+		expect(
+			resolveTranslationLookupKey("exodus", 7, 26, { language: "es" }),
+		).toBe("8-1");
+		expect(
+			resolveTranslationLookupKey("exodus", 7, 26, { language: "en" }),
+		).toBe("8-1");
+		expect(
+			resolveTranslationLookupKey("hosea", 2, 25, { language: "es" }),
+		).toBe("2-23");
 	});
 });
 

--- a/web/src/app/services/staticData.test.js
+++ b/web/src/app/services/staticData.test.js
@@ -104,9 +104,8 @@ describe("static data integrity", () => {
 		const displayedVerse1 = verse1Target.usesPsalmTitle
 			? chapter.title
 			: chapter.verses.find(
-				(item) =>
-					item.verse === verse1Target.reference?.verse,
-			)?.bes;
+					(item) => item.verse === verse1Target.reference?.verse,
+				)?.bes;
 		expect(displayedVerse1).toBe(chapter.title);
 
 		const verse2Target = resolveTranslationTarget("psalms", 3, 2, {
@@ -118,7 +117,9 @@ describe("static data integrity", () => {
 		const displayedVerse2 = chapter.verses.find(
 			(item) => item.verse === verse2Target.reference?.verse,
 		)?.bes;
-		expect(displayedVerse2).toBe(chapter.verses.find((item) => item.verse === 1)?.bes);
+		expect(displayedVerse2).toBe(
+			chapter.verses.find((item) => item.verse === 1)?.bes,
+		);
 	});
 
 	test("English and Spanish both honor versification shifts", () => {

--- a/web/src/app/services/staticData.ts
+++ b/web/src/app/services/staticData.ts
@@ -1,7 +1,7 @@
 import {
 	getMissingSpanishTranslationNotice,
 	getPsalmsSuperscriptionNotice,
- resolveTranslationSource,
+	resolveTranslationSource,
 	resolveTranslationLookupKey,
 	resolveTranslationTarget,
 	TTH_BOOK_MAPPING,
@@ -324,7 +324,10 @@ const loadTs2009ChapterFromBookFile = async (
 				`/data/ts2009/${fileStem}.json`,
 			);
 
-			const chapterVerses = extractTs2009ChapterVersesFromBook(staticBook, chapter);
+			const chapterVerses = extractTs2009ChapterVersesFromBook(
+				staticBook,
+				chapter,
+			);
 			if (!chapterVerses || chapterVerses.length === 0) {
 				continue;
 			}
@@ -384,8 +387,8 @@ const buildCandidatePaths = (path: string): string[] => {
 		return localPaths;
 	}
 
-	const prefixedPaths = localPaths.map((candidatePath) =>
-		`${staticUrlPrefix}${candidatePath}`,
+	const prefixedPaths = localPaths.map(
+		(candidatePath) => `${staticUrlPrefix}${candidatePath}`,
 	);
 
 	return [...new Set([...prefixedPaths, ...localPaths])];
@@ -862,7 +865,7 @@ const sanitizeShirHashirimTth = (text?: string): string | undefined => {
 const loadTranslationChapter = async (
 	bookId: string,
 	requiredChapters: number[],
-	): Promise<LoadedTranslationChapter> => {
+): Promise<LoadedTranslationChapter> => {
 	const translationMap: Record<string, RawTranslationVerse> = {};
 	const translationTitles: Record<number, string> = {};
 
@@ -1009,7 +1012,11 @@ const loadDssTranslitChapter = async (
 
 			const verse = Number(variant.verse);
 			const position = Number(variant.position);
-			if (!Number.isFinite(verse) || !Number.isFinite(position) || position <= 0) {
+			if (
+				!Number.isFinite(verse) ||
+				!Number.isFinite(position) ||
+				position <= 0
+			) {
 				continue;
 			}
 
@@ -1106,11 +1113,11 @@ const mapVerse = (
 			prefixes: word.prefixes ?? [],
 			has_dss_variant: dssVariantMap.has(index),
 			translit_en: prefersDssTranslit
-				? dssTranslitEn ?? word.translit_en ?? translitWord?.translit_en
-				: word.translit_en ?? translitWord?.translit_en,
+				? (dssTranslitEn ?? word.translit_en ?? translitWord?.translit_en)
+				: (word.translit_en ?? translitWord?.translit_en),
 			translit_es: prefersDssTranslit
-				? dssTranslitEs ?? word.translit_es ?? translitWord?.translit_es
-				: word.translit_es ?? translitWord?.translit_es,
+				? (dssTranslitEs ?? word.translit_es ?? translitWord?.translit_es)
+				: (word.translit_es ?? translitWord?.translit_es),
 			dss_translit_en: dssTranslitEn,
 			dss_translit_es: dssTranslitEs,
 		};
@@ -1131,7 +1138,7 @@ const mapVerse = (
 		const baseTranslationText =
 			language === "en"
 				? ts2009Translation
-				: translationVerse?.bes ?? translationVerse?.tth;
+				: (translationVerse?.bes ?? translationVerse?.tth);
 		const translationText = resolveTranslationText({
 			bookId,
 			language,
@@ -1143,9 +1150,7 @@ const mapVerse = (
 		if (options?.language === "en") {
 			response.translation = translationText;
 			response.translation_language = "en";
-		} else if (
-			options?.language === "es"
-		) {
+		} else if (options?.language === "es") {
 			response.translation = translationText;
 			response.translation_language = "es";
 			if (translationVerse?.bes || translationVerse?.tth) {
@@ -1273,7 +1278,9 @@ export const getChapterVerses = async (
 		referenceMode,
 	);
 	const coreVerseChunks = await Promise.all(
-		sourceChapters.map((sourceChapter) => loadCoreChapter(bookEntry, sourceChapter)),
+		sourceChapters.map((sourceChapter) =>
+			loadCoreChapter(bookEntry, sourceChapter),
+		),
 	);
 	const coreVerses = coreVerseChunks.flat();
 
@@ -1285,7 +1292,10 @@ export const getChapterVerses = async (
 		? []
 		: getRequiredTranslationChapters(
 				bookEntry.id,
-				coreVerses.map((verse) => ({ chapter: verse.chapter, verse: verse.verse })),
+				coreVerses.map((verse) => ({
+					chapter: verse.chapter,
+					verse: verse.verse,
+				})),
 				options?.language,
 			);
 
@@ -1299,7 +1309,7 @@ export const getChapterVerses = async (
 						sourceChapters.map((sourceChapter) =>
 							loadDssChapter(bookEntry.id, sourceChapter),
 						),
-				  ).then((records) => Object.assign({}, ...records))
+					).then((records) => Object.assign({}, ...records))
 				: Promise.resolve<Record<string, RawDssVerse>>({}),
 			Promise.all(
 				sourceChapters.map((sourceChapter) =>
@@ -1311,8 +1321,10 @@ export const getChapterVerses = async (
 						sourceChapters.map((sourceChapter) =>
 							loadDssTranslitChapter(bookEntry.id, sourceChapter),
 						),
-				  ).then((records) => Object.assign({}, ...records))
-				: Promise.resolve<Record<string, Record<number, RawDssTranslitVariant>>>({}),
+					).then((records) => Object.assign({}, ...records))
+				: Promise.resolve<
+						Record<string, Record<number, RawDssTranslitVariant>>
+					>({}),
 		]);
 
 	// If language is English, load TS2009 translations from Supabase (with caching)
@@ -1335,7 +1347,8 @@ export const getChapterVerses = async (
 
 		const ts2009Results = await Promise.all(
 			uniqueTranslationKeys.map(async (translationKey) => {
-				const [mappedChapterToken, mappedVerseToken] = translationKey.split("-");
+				const [mappedChapterToken, mappedVerseToken] =
+					translationKey.split("-");
 				const mappedChapter = Number(mappedChapterToken);
 				const mappedVerse = Number(mappedVerseToken);
 
@@ -1387,7 +1400,7 @@ export const getChapterVerses = async (
 			outputVerse,
 			translationKey ? translations.verses[translationKey] : undefined,
 			translationTarget.usesPsalmTitle
-				? translations.titles[rawVerse.chapter] ?? null
+				? (translations.titles[rawVerse.chapter] ?? null)
 				: null,
 			dssVerses[verseKey],
 			transliterations[verseKey],

--- a/web/src/app/services/staticData.ts
+++ b/web/src/app/services/staticData.ts
@@ -1,11 +1,12 @@
 import {
 	getMissingSpanishTranslationNotice,
 	getPsalmsSuperscriptionNotice,
+ resolveTranslationSource,
 	resolveTranslationLookupKey,
 	resolveTranslationTarget,
 	TTH_BOOK_MAPPING,
 } from "../../../../shared/translationConfig";
-import { mapHebrewVerseToTranslationKey } from "../../../../shared/versification";
+import { getSourceChaptersForTranslationChapter } from "../../../../shared/versification";
 import { fetchTs2009Translation } from "./supabaseClient";
 
 export interface WordResponse {
@@ -44,6 +45,8 @@ export interface TranslationFootnote {
 export interface VerseResponse {
 	chapter: number;
 	verse: number;
+	sourceChapter: number;
+	sourceVerse: number;
 	hebrew: string;
 	words: WordResponse[];
 	translation?: string;
@@ -51,6 +54,8 @@ export interface VerseResponse {
 	translation_footnotes?: TranslationFootnote[];
 	dss?: DssVariant[];
 }
+
+type ReferenceMode = "source" | "translation";
 
 export interface BookResponse {
 	id: string;
@@ -654,37 +659,31 @@ const extractBaseStrong = (value?: string): string | undefined => {
 	return parts.length > 0 ? parts[parts.length - 1] : undefined;
 };
 
-const toSortedUniqueVerseNumbers = (values: number[]): number[] =>
-	Array.from(
-		new Set(values.filter((value) => Number.isFinite(value) && value > 0)),
-	).sort((a, b) => a - b);
-
 const getTranslationLookupKey = (
 	bookId: string,
 	chapter: number,
 	verse: number,
 	language?: "es" | "en",
 ): string | null => {
-	return resolveTranslationLookupKey(bookId, chapter, verse, language);
+	return resolveTranslationLookupKey(bookId, chapter, verse, { language });
 };
 
 const getRequiredTranslationChapters = (
 	bookId: string,
-	chapter: number,
+	sourceVerses: Array<{ chapter: number; verse: number }>,
 	language?: "es" | "en",
-	expectedVerseNumbers?: number[],
 ): number[] => {
-	if (language !== "en") {
-		return [chapter];
+	if (!language) {
+		return [];
 	}
 
 	const mappedChapters = new Set<number>();
 
-	for (const verseNumber of expectedVerseNumbers ?? []) {
+	for (const sourceVerse of sourceVerses) {
 		const mappedKey = getTranslationLookupKey(
 			bookId,
-			chapter,
-			verseNumber,
+			sourceVerse.chapter,
+			sourceVerse.verse,
 			language,
 		);
 		if (!mappedKey) {
@@ -699,10 +698,35 @@ const getRequiredTranslationChapters = (
 	}
 
 	if (mappedChapters.size === 0) {
-		mappedChapters.add(chapter);
+		for (const sourceVerse of sourceVerses) {
+			mappedChapters.add(sourceVerse.chapter);
+		}
 	}
 
 	return [...mappedChapters].sort((a, b) => a - b);
+};
+
+const getSourceChaptersForRequest = (
+	bookId: string,
+	chapter: number,
+	language: "es" | "en" | undefined,
+	referenceMode: ReferenceMode,
+): number[] => {
+	if (!Number.isFinite(chapter) || chapter <= 0) {
+		return [];
+	}
+
+	if (!language || referenceMode !== "translation") {
+		return [chapter];
+	}
+
+	const source = resolveTranslationSource(bookId, { language });
+	if (!source) {
+		return [chapter];
+	}
+
+	const chapters = getSourceChaptersForTranslationChapter(bookId, chapter);
+	return chapters.length > 0 ? chapters : [chapter];
 };
 
 const isPsalmsBook = (bookId: string): boolean =>
@@ -926,7 +950,7 @@ const loadTranslationChapter = async (
 const loadDssChapter = async (
 	bookId: string,
 	chapter: number,
-): Promise<Record<number, RawDssVerse>> => {
+): Promise<Record<string, RawDssVerse>> => {
 	const dssBookKey = toDssBookKey(bookId);
 
 	try {
@@ -937,10 +961,10 @@ const loadDssChapter = async (
 
 		return Object.entries(chapterData.verses).reduce(
 			(acc, [verseKey, verseValue]) => {
-				acc[Number.parseInt(verseKey, 10)] = verseValue;
+				acc[`${chapter}:${Number.parseInt(verseKey, 10)}`] = verseValue;
 				return acc;
 			},
-			{} as Record<number, RawDssVerse>,
+			{} as Record<string, RawDssVerse>,
 		);
 	} catch {
 		return {};
@@ -950,16 +974,16 @@ const loadDssChapter = async (
 const loadTranslitChapter = async (
 	bookId: string,
 	chapter: number,
-): Promise<Record<number, RawTranslitWord[]>> => {
+): Promise<Record<string, RawTranslitWord[]>> => {
 	try {
 		const translitBook = await fetchJson<RawTranslitBook>(
 			`/data/translit/${bookId}.json`,
 		);
 
-		const verseMap: Record<number, RawTranslitWord[]> = {};
+		const verseMap: Record<string, RawTranslitWord[]> = {};
 		for (const verseEntry of translitBook.verses ?? []) {
 			if (verseEntry.chapter !== chapter) continue;
-			verseMap[verseEntry.verse] = verseEntry.words ?? [];
+			verseMap[`${chapter}:${verseEntry.verse}`] = verseEntry.words ?? [];
 		}
 
 		return verseMap;
@@ -971,14 +995,14 @@ const loadTranslitChapter = async (
 const loadDssTranslitChapter = async (
 	bookId: string,
 	chapter: number,
-): Promise<Record<number, Record<number, RawDssTranslitVariant>>> => {
+): Promise<Record<string, Record<number, RawDssTranslitVariant>>> => {
 	const dssBookKey = toDssBookKey(bookId);
 
 	try {
 		const translitBook = await fetchJson<RawDssTranslitBook>(
 			`/data/translit/dss/${dssBookKey}.json`,
 		);
-		const verseMap: Record<number, Record<number, RawDssTranslitVariant>> = {};
+		const verseMap: Record<string, Record<number, RawDssTranslitVariant>> = {};
 
 		for (const variant of translitBook.variants ?? []) {
 			if (variant.chapter !== chapter) continue;
@@ -989,12 +1013,13 @@ const loadDssTranslitChapter = async (
 				continue;
 			}
 
-			if (!verseMap[verse]) {
-				verseMap[verse] = {};
+			const key = `${chapter}:${verse}`;
+			if (!verseMap[key]) {
+				verseMap[key] = {};
 			}
 
 			// Align with WordResponse.position which is zero-based on web.
-			verseMap[verse][position - 1] = variant;
+			verseMap[key][position - 1] = variant;
 		}
 
 		return verseMap;
@@ -1035,6 +1060,8 @@ const findFallbackTranslitWord = (
 const mapVerse = (
 	bookId: string,
 	rawVerse: RawVerse,
+	outputChapter: number,
+	outputVerse: number,
 	translationVerse?: RawTranslationVerse,
 	translationTitle?: string | null,
 	dssVerse?: RawDssVerse,
@@ -1090,8 +1117,10 @@ const mapVerse = (
 	});
 
 	const response: VerseResponse = {
-		chapter: rawVerse.chapter,
-		verse: rawVerse.verse,
+		chapter: outputChapter,
+		verse: outputVerse,
+		sourceChapter: rawVerse.chapter,
+		sourceVerse: rawVerse.verse,
 		hebrew: rawVerse.hebrew,
 		words,
 	};
@@ -1229,24 +1258,35 @@ export const getChapterVerses = async (
 		language?: "es" | "en";
 		showDss?: boolean;
 		hebrewOnly?: boolean;
+		referenceMode?: ReferenceMode;
 	},
 ): Promise<VerseResponse[]> => {
 	const metadata = await loadMetadata();
 	const bookEntry = findBook(metadata.books, book);
 
 	if (!bookEntry) return [];
-
-	const coreVerses = await loadCoreChapter(bookEntry, chapter);
-	const expectedVerseNumbers = toSortedUniqueVerseNumbers(
-		coreVerses.map((verse) => verse.verse),
+	const referenceMode = options?.referenceMode ?? "source";
+	const sourceChapters = getSourceChaptersForRequest(
+		bookEntry.id,
+		chapter,
+		options?.language,
+		referenceMode,
 	);
+	const coreVerseChunks = await Promise.all(
+		sourceChapters.map((sourceChapter) => loadCoreChapter(bookEntry, sourceChapter)),
+	);
+	const coreVerses = coreVerseChunks.flat();
+
+	if (coreVerses.length === 0) {
+		return [];
+	}
+
 	const requiredTranslationChapters = options?.hebrewOnly
 		? []
 		: getRequiredTranslationChapters(
 				bookEntry.id,
-				chapter,
+				coreVerses.map((verse) => ({ chapter: verse.chapter, verse: verse.verse })),
 				options?.language,
-				expectedVerseNumbers,
 			);
 
 	const [translations, dssVerses, transliterations, dssTransliterations] =
@@ -1255,12 +1295,24 @@ export const getChapterVerses = async (
 				? Promise.resolve<LoadedTranslationChapter>({ verses: {}, titles: {} })
 				: loadTranslationChapter(bookEntry.id, requiredTranslationChapters),
 			options?.showDss
-				? loadDssChapter(bookEntry.id, chapter)
-				: Promise.resolve<Record<number, RawDssVerse>>({}),
-			loadTranslitChapter(bookEntry.id, chapter),
+				? Promise.all(
+						sourceChapters.map((sourceChapter) =>
+							loadDssChapter(bookEntry.id, sourceChapter),
+						),
+				  ).then((records) => Object.assign({}, ...records))
+				: Promise.resolve<Record<string, RawDssVerse>>({}),
+			Promise.all(
+				sourceChapters.map((sourceChapter) =>
+					loadTranslitChapter(bookEntry.id, sourceChapter),
+				),
+			).then((records) => Object.assign({}, ...records)),
 			options?.showDss
-				? loadDssTranslitChapter(bookEntry.id, chapter)
-				: Promise.resolve<Record<number, Record<number, RawDssTranslitVariant>>>({}),
+				? Promise.all(
+						sourceChapters.map((sourceChapter) =>
+							loadDssTranslitChapter(bookEntry.id, sourceChapter),
+						),
+				  ).then((records) => Object.assign({}, ...records))
+				: Promise.resolve<Record<string, Record<number, RawDssTranslitVariant>>>({}),
 		]);
 
 	// If language is English, load TS2009 translations from Supabase (with caching)
@@ -1270,10 +1322,11 @@ export const getChapterVerses = async (
 			...new Set(
 				coreVerses
 					.map((verse) =>
-						mapHebrewVerseToTranslationKey(
+						getTranslationLookupKey(
 							bookEntry.id,
 							verse.chapter,
 							verse.verse,
+							"en",
 						),
 					)
 					.filter((key): key is string => Boolean(key)),
@@ -1307,32 +1360,59 @@ export const getChapterVerses = async (
 		);
 	}
 
-	return coreVerses.map((rawVerse) => {
+	const mappedVerses = coreVerses.map((rawVerse) => {
 		const translationTarget = resolveTranslationTarget(
 			bookEntry.id,
 			rawVerse.chapter,
 			rawVerse.verse,
-			options?.language,
+			{ language: options?.language },
 		);
 		const translationKey = translationTarget.reference
 			? `${translationTarget.reference.chapter}-${translationTarget.reference.verse}`
 			: null;
+		const outputChapter =
+			referenceMode === "translation"
+				? (translationTarget.reference?.chapter ?? 0)
+				: rawVerse.chapter;
+		const outputVerse =
+			referenceMode === "translation"
+				? (translationTarget.reference?.verse ?? 0)
+				: rawVerse.verse;
+		const verseKey = `${rawVerse.chapter}:${rawVerse.verse}`;
 
 		return mapVerse(
 			bookEntry.id,
 			rawVerse,
+			outputChapter,
+			outputVerse,
 			translationKey ? translations.verses[translationKey] : undefined,
 			translationTarget.usesPsalmTitle
 				? translations.titles[rawVerse.chapter] ?? null
 				: null,
-			dssVerses[rawVerse.verse],
-			transliterations[rawVerse.verse],
-			dssTransliterations[rawVerse.verse],
+			dssVerses[verseKey],
+			transliterations[verseKey],
+			dssTransliterations[verseKey],
 			options,
 			translationKey ? ts2009Translations[translationKey] : undefined,
 			translationKey,
 		);
 	});
+
+	if (referenceMode === "translation" && options?.language) {
+		return mappedVerses
+			.filter((verse) => verse.chapter === chapter)
+			.sort(
+				(a, b) =>
+					a.verse - b.verse ||
+					a.sourceChapter - b.sourceChapter ||
+					a.sourceVerse - b.sourceVerse,
+			);
+	}
+
+	return mappedVerses.sort(
+		(a, b) =>
+			a.sourceChapter - b.sourceChapter || a.sourceVerse - b.sourceVerse,
+	);
 };
 
 export const getVerse = async (

--- a/web/src/app/utils/translationFormatter.tsx
+++ b/web/src/app/utils/translationFormatter.tsx
@@ -139,14 +139,17 @@ const renderTextSegment = (
 							key={`${keyPrefix}-sup-${matchIndex}`}
 							className="group relative inline-flex"
 						>
-							<sup className={`${footnoteMarkerClass}${italic ? " italic" : ""}`}>
+							<sup
+								className={`${footnoteMarkerClass}${italic ? " italic" : ""}`}
+							>
 								{normalized}
 							</sup>
 							<span
 								className={footnoteTooltipClass}
 								style={{
 									background: "var(--background, #f6f1e8)",
-									borderColor: "var(--neomorph-border, rgba(122, 95, 62, 0.35))",
+									borderColor:
+										"var(--neomorph-border, rgba(122, 95, 62, 0.35))",
 									color: "var(--text-primary, #2a2118)",
 									boxShadow:
 										"0 10px 24px rgba(29, 23, 17, 0.24), 0 2px 8px rgba(29, 23, 17, 0.16)",
@@ -185,14 +188,17 @@ const renderTextSegment = (
 							key={`${keyPrefix}-bracket-${matchIndex}`}
 							className="group relative inline-flex"
 						>
-							<sup className={`${footnoteMarkerClass}${italic ? " italic" : ""}`}>
+							<sup
+								className={`${footnoteMarkerClass}${italic ? " italic" : ""}`}
+							>
 								{marker}
 							</sup>
 							<span
 								className={footnoteTooltipClass}
 								style={{
 									background: "var(--background, #f6f1e8)",
-									borderColor: "var(--neomorph-border, rgba(122, 95, 62, 0.35))",
+									borderColor:
+										"var(--neomorph-border, rgba(122, 95, 62, 0.35))",
 									color: "var(--text-primary, #2a2118)",
 									boxShadow:
 										"0 10px 24px rgba(29, 23, 17, 0.24), 0 2px 8px rgba(29, 23, 17, 0.16)",

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -16,5 +16,11 @@
 		},
 		"skipLibCheck": true
 	},
-	"include": ["src", "scripts/**/*.ts", "server.ts", "build.ts", "../shared/**/*.ts"]
+	"include": [
+		"src",
+		"scripts/**/*.ts",
+		"server.ts",
+		"build.ts",
+		"../shared/**/*.ts"
+	]
 }


### PR DESCRIPTION
- Align web/mobile translation-only navigation with versification-aware references by carrying source chapter/verse metadata and switching between source/translation reference modes.
- Update mobile and web scripture/static data loaders to fetch and merge source chapters mapped to a translation chapter, including DSS/transliteration keying by chapter:verse.
- Extend shared translation resolvers (`resolveTranslationSource`, option-based lookup/target resolution) and versification utilities (`getSourceChaptersForTranslationChapter`) to keep English and Spanish mapping behavior consistent.
- Improve translation-only UX in navigation components (`NavigationSheet`, `VerseDetailContent`, web app verse navigation) so previous/next/chapter transitions use the correct displayed verse sequence.
- Harden TTH2 processing by detecting plain standalone section headers in markdown parsing and normalizing Spanish inverted punctuation/quote spacing in text cleaning.
- Regenerate Hoshea TTH2 JSON so leaked section headers are moved into `subtitle` fields and punctuation is normalized (including `"¡Elohim mío!"`), with related static-data mapping/test updates.