### PR TITLE
fix: announce Hutter after the next OTA

### DIFF
--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -8,10 +8,7 @@ import { OnOffButton } from "@/src/components/ui/OnOffButton";
 import { SettingsDropdown } from "@/src/components/ui/SettingsDropdown";
 import { getColors, radii, spacing, typography } from "@/src/theme";
 import { useAppStore, type AppState } from "@/src/store/useAppStore";
-import {
-  clearStorage,
-  saveHutterAnnouncementSeen,
-} from "@/src/services/storage";
+import { clearStorage } from "@/src/services/storage";
 import { useTranslation } from "@/src/i18n/useTranslation";
 
 const createStyles = (colors: ReturnType<typeof getColors>, isRTL: boolean) =>
@@ -161,9 +158,6 @@ export default function SettingsScreen() {
   const handleBesorahTextVersionChange = useCallback(
     (version: AppState["besorahTextVersion"]) => {
       setBesorahTextVersion(version);
-      if (version === "hutter") {
-        void saveHutterAnnouncementSeen();
-      }
     },
     [setBesorahTextVersion],
   );

--- a/mobile/src/services/storage.ts
+++ b/mobile/src/services/storage.ts
@@ -1,6 +1,9 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import type { ThemeMode } from "@/src/theme";
-import type { BesorahTextVersion } from "@davar/shared/translationConfig";
+import {
+  HUTTER_ANNOUNCEMENT_RELEASE,
+  type BesorahTextVersion,
+} from "@davar/shared/translationConfig";
 
 const STORAGE_KEYS = {
   themeMode: "davar.themeMode",
@@ -111,11 +114,14 @@ export const saveBesorahTextVersion = async (value: BesorahTextVersion) => {
 
 export const loadHutterAnnouncementSeen = async (): Promise<boolean> => {
   const value = await AsyncStorage.getItem(STORAGE_KEYS.hutterAnnouncementSeen);
-  return value === "true";
+  return value === HUTTER_ANNOUNCEMENT_RELEASE;
 };
 
 export const saveHutterAnnouncementSeen = async () => {
-  await AsyncStorage.setItem(STORAGE_KEYS.hutterAnnouncementSeen, "true");
+  await AsyncStorage.setItem(
+    STORAGE_KEYS.hutterAnnouncementSeen,
+    HUTTER_ANNOUNCEMENT_RELEASE,
+  );
 };
 
 const parseBoolean = (value: string | null, fallback: boolean) => {

--- a/shared/translationConfig.ts
+++ b/shared/translationConfig.ts
@@ -10,6 +10,9 @@ export type BesorahTextVersion = "delitzsch" | "hutter";
 export type TranslationKey = "ts2009" | "tth" | "delitzsch";
 export type TranslationSource = "ts2009" | "tth" | "bes";
 
+// Bump this value when an OTA/web release should announce Hutter again.
+export const HUTTER_ANNOUNCEMENT_RELEASE = "hutter-launch-2026-07-v2";
+
 export type TranslationTarget = {
   reference: VerseReference | null;
   usesPsalmTitle: boolean;

--- a/web/src/app/App.tsx
+++ b/web/src/app/App.tsx
@@ -39,7 +39,10 @@ import {
 	saveReadingState,
 	updateLastPositionForBook,
 } from "./utils/storageHelpers";
-import { getDssCommentaryForLanguage } from "./utils/translationConfig";
+import {
+	getDssCommentaryForLanguage,
+	HUTTER_ANNOUNCEMENT_RELEASE,
+} from "./utils/translationConfig";
 import { useVerseScrollNavigation } from "./utils/useVerseScrollNavigation";
 
 type Screen =
@@ -152,10 +155,11 @@ export default function App() {
 		"besorahTextVersion",
 		initialState.besorahTextVersion,
 	);
-	const [hutterAnnouncementSeen, setHutterAnnouncementSeen] = usePersistedState(
-		"hutterAnnouncementSeen",
-		initialState.hutterAnnouncementSeen,
-	);
+	const [hutterAnnouncementRelease, setHutterAnnouncementRelease] =
+		usePersistedState(
+			"hutterAnnouncementRelease",
+			initialState.hutterAnnouncementRelease,
+		);
 	const { t, isRTL } = useTranslation(language);
 	const [showHutterAnnouncement, setShowHutterAnnouncement] = useState(false);
 
@@ -818,15 +822,19 @@ export default function App() {
 	const besorahDisclaimerText = t("verse.besorahDisclaimer.short");
 
 	useEffect(() => {
-		if (currentScreen === "verse" && isBesorah && !hutterAnnouncementSeen) {
+		if (
+			currentScreen === "verse" &&
+			isBesorah &&
+			hutterAnnouncementRelease !== HUTTER_ANNOUNCEMENT_RELEASE
+		) {
 			setShowHutterAnnouncement(true);
 		}
-	}, [currentScreen, hutterAnnouncementSeen, isBesorah]);
+	}, [currentScreen, hutterAnnouncementRelease, isBesorah]);
 
 	const dismissHutterAnnouncement = useCallback(() => {
 		setShowHutterAnnouncement(false);
-		setHutterAnnouncementSeen(true);
-	}, [setHutterAnnouncementSeen]);
+		setHutterAnnouncementRelease(HUTTER_ANNOUNCEMENT_RELEASE);
+	}, [setHutterAnnouncementRelease]);
 
 	const activateHutter = useCallback(() => {
 		setBesorahTextVersion("hutter");
@@ -836,12 +844,8 @@ export default function App() {
 	const handleBesorahTextVersionChange = useCallback(
 		(version: "delitzsch" | "hutter") => {
 			setBesorahTextVersion(version);
-			if (version === "hutter") {
-				setShowHutterAnnouncement(false);
-				setHutterAnnouncementSeen(true);
-			}
 		},
-		[setBesorahTextVersion, setHutterAnnouncementSeen],
+		[setBesorahTextVersion],
 	);
 
 	useEffect(() => {

--- a/web/src/app/utils/storageHelpers.test.js
+++ b/web/src/app/utils/storageHelpers.test.js
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	createDefaultReadingState,
+	getStoredReadingState,
+} from "./storageHelpers";
+
+const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+
+const createLocalStorage = (initialValue) => {
+	const values = new Map(
+		initialValue ? [["davar.readingState", initialValue]] : [],
+	);
+
+	return {
+		getItem: (key) => values.get(key) ?? null,
+		setItem: (key, value) => values.set(key, value),
+	};
+};
+
+beforeEach(() => {
+	Object.defineProperty(globalThis, "window", {
+		configurable: true,
+		value: { localStorage: createLocalStorage() },
+	});
+});
+
+afterEach(() => {
+	if (originalWindow) {
+		Object.defineProperty(globalThis, "window", originalWindow);
+	} else {
+		delete globalThis.window;
+	}
+});
+
+describe("Hutter announcement persistence", () => {
+	test("new reading state has no announcement release receipt", () => {
+		expect(createDefaultReadingState().hutterAnnouncementRelease).toBe("");
+	});
+
+	test("legacy boolean receipt does not suppress the new OTA announcement", () => {
+		const legacyState = {
+			...createDefaultReadingState(),
+			hutterAnnouncementSeen: true,
+		};
+		delete legacyState.hutterAnnouncementRelease;
+
+		window.localStorage = createLocalStorage(JSON.stringify(legacyState));
+
+		expect(getStoredReadingState()?.hutterAnnouncementRelease).toBe("");
+	});
+});

--- a/web/src/app/utils/storageHelpers.ts
+++ b/web/src/app/utils/storageHelpers.ts
@@ -11,7 +11,7 @@ export interface ReadingStateV2 {
 	verse: number;
 	language: "en" | "es" | "he";
 	besorahTextVersion: BesorahTextVersion;
-	hutterAnnouncementSeen: boolean;
+	hutterAnnouncementRelease: string;
 	theme: "light" | "dark";
 	showQumran: boolean;
 	hebrewOnly: boolean;
@@ -68,7 +68,7 @@ function migrateV1toV2(v1Data: ReadingStateV1): ReadingStateV2 {
 		verse: v1Data.verse ?? 1,
 		language: v1Data.language ?? resolveDefaultLanguage(),
 		besorahTextVersion: "delitzsch",
-		hutterAnnouncementSeen: false,
+		hutterAnnouncementRelease: "",
 		theme: "light",
 		showQumran: false,
 		hebrewOnly: false,
@@ -174,7 +174,7 @@ export function createDefaultReadingState(): ReadingStateV2 {
 		verse: 1,
 		language: resolveDefaultLanguage(),
 		besorahTextVersion: "delitzsch",
-		hutterAnnouncementSeen: false,
+		hutterAnnouncementRelease: "",
 		theme: "light",
 		showQumran: false,
 		hebrewOnly: false,


### PR DESCRIPTION
## What changed

- replaced the permanent Hutter announcement boolean with a shared release token
- made existing web and mobile receipts stale for the next OTA/web deployment
- show the popup once on the first New Testament verse visit after receiving this update
- stopped the settings selector from marking the announcement as seen
- added a web migration regression test for users carrying the previous boolean receipt

## Why

The original receipt stored only `true`, so users who had already received or interacted with the previous update could permanently skip the announcement. A release token lets this OTA deliberately announce Hutter once without clearing unrelated preferences.

## Impact

After the next web deployment or Expo OTA update, every user will see the Hutter popup the first time they visit a Besorah verse. Closing it or activating Hutter records the current release so it does not appear again.

## Validation

- web build
- 16 focused web tests
- web lint
- mobile TypeScript check
- mobile Expo lint
