### PR TITLE
Update Ko-fi link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,4 @@
 # github sponsors
 github: edyhvh
 # ko-fi
-ko_fi: edyhvh
+ko_fi: edyehoshua


### PR DESCRIPTION
## What changed

- Updated the repository funding configuration to point Ko-fi donations to `edyehoshua`.
- Confirmed the web Ko-fi widget already uses the same account.

## Why

The funding configuration still referenced the previous Ko-fi account, so GitHub's funding link did not match the requested destination.

## Impact

The repository's Ko-fi funding link now resolves to https://ko-fi.com/edyehoshua.

## Validation

- `git diff --check`
- Repository-wide search for Ko-fi account references